### PR TITLE
Typed CDP Bindings - Part 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,28 +8,29 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "bidi-server": "npm run build && npm run server --",
     "server": "node ./src/.build/index.js",
-    "build": "npm run prettier && npm run clean && tsc -b src/tsconfig.json",
+    "build": "npm run prettier && npm run clean && rollup --config src/bidiMapper/rollup.config.js && tsc -b src/tsconfig.json",
     "clean": "rimraf ./src/.build",
     "prettier": "npx prettier --write . "
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/websocket": "^1.0.2",
     "argparse": "^2.0.1",
     "debug": "^4.3.1",
-    "rollup": "^2.47.0",
     "ts-node": "^9.1.1",
     "tslib": "^2.2.0",
-    "typescript": "^4.2.4",
     "websocket": "^1.0.34",
     "ws": "^7.4.5"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-typescript": "^8.2.1",
+    "@types/websocket": "^1.0.2",
     "@types/ws": "^7.4.4",
     "devtools-protocol": "^0.0.900357",
     "prettier": "2.3.0",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "rollup": "^2.47.0",
+    "typescript": "^4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@types/rollup": "^0.54.0",
     "@types/websocket": "^1.0.2",
     "argparse": "^2.0.1",
     "debug": "^4.3.1",
@@ -29,6 +28,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/ws": "^7.4.4",
+    "devtools-protocol": "^0.0.900357",
     "prettier": "2.3.0",
     "rimraf": "^3.0.2"
   }

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -15,7 +15,7 @@
  */
 import { CommandProcessor } from './commandProcessor';
 
-import { CdpServer } from './utils/cdpServer';
+import { CdpClient } from './utils/cdpClient';
 import { BidiServer } from './utils/bidiServer';
 import { ServerBinding } from './utils/iServer';
 
@@ -78,7 +78,7 @@ function _createCdpServer() {
       globalObj.cdp.onmessage = handler;
     }
   );
-  return new CdpServer(cdpBinding);
+  return new CdpClient(cdpBinding);
 }
 
 function _createBidiServer() {

--- a/src/bidiMapper/rollup.config.js
+++ b/src/bidiMapper/rollup.config.js
@@ -1,0 +1,17 @@
+import typescript from '@rollup/plugin-typescript';
+import json from '@rollup/plugin-json';
+
+export default {
+  input: 'src/bidiMapper/mapper.ts',
+  output: {
+    file: 'src/.build/mapper.js',
+    sourcemap: true,
+    format: 'iife',
+  },
+  plugins: [
+    json(),
+    typescript({
+      tsconfig: 'src/bidiMapper/tsconfig.json',
+    }),
+  ],
+};

--- a/src/bidiMapper/tsconfig.json
+++ b/src/bidiMapper/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext"
+    "target": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true
   }
 }

--- a/src/bidiMapper/utils/cdpClient.ts
+++ b/src/bidiMapper/utils/cdpClient.ts
@@ -17,6 +17,10 @@ import { ServerBinding, AbstractServer } from './iServer';
 import { log } from './log';
 const logCdp = log('cdp');
 
+// TODO: Remove. This is a quick test to verify we can import a node module.
+import { version } from 'devtools-protocol/json/browser_protocol.json';
+logCdp(`Using CDP version: ${version}`);
+
 export class CdpClient extends AbstractServer {
   private _commandCallbacks: Map<number, (messageObj: any) => void> = new Map();
 

--- a/src/bidiMapper/utils/cdpClient.ts
+++ b/src/bidiMapper/utils/cdpClient.ts
@@ -17,7 +17,7 @@ import { ServerBinding, AbstractServer } from './iServer';
 import { log } from './log';
 const logCdp = log('cdp');
 
-export class CdpServer extends AbstractServer {
+export class CdpClient extends AbstractServer {
   private _commandCallbacks: Map<number, (messageObj: any) => void> = new Map();
 
   constructor(cdpBinding: ServerBinding) {

--- a/src/mapperReader.ts
+++ b/src/mapperReader.ts
@@ -15,21 +15,8 @@
  */
 `use strict`;
 
-import { rollup } from 'rollup';
-import typescript from '@rollup/plugin-typescript';
+import fs from 'fs/promises';
 
 export default async function read(): Promise<string> {
-  const bundle = await rollup({
-    input: 'src/bidiMapper/mapper.ts',
-    plugins: [
-      typescript({
-        tsconfig: 'src/bidiMapper/tsconfig.json',
-      }),
-    ],
-  });
-
-  const result = await bundle.generate({
-    format: 'iife',
-  });
-  return result.output[0].code;
+  return await fs.readFile(new URL('./mapper.js', import.meta.url), 'utf8');
 }


### PR DESCRIPTION
This change adds a dependency on https://www.npmjs.com/package/devtools-protocol which contains updated .json and .d.ts files for CDP.

To enable the mapper script to import this module, I've added a rollup config to be run during build. It is configured to allow node module imports.

As a quick test, I've imported the `version` property from `devtools-protocol` module to verify that this builds and is rolled up into the output file as expected.

A follow-up change will add a strongly-typed layer on top of CdpClient.