### PR TITLE
Typed CDP Bindings - Part 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-typescript": "^8.2.1",
+    "@types/argparse": "^2.0.10",
+    "@types/debug": "^4.1.6",
     "@types/websocket": "^1.0.2",
     "@types/ws": "^7.4.4",
     "devtools-protocol": "^0.0.900357",

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -1,5 +1,7 @@
+import { Protocol } from 'devtools-protocol';
+
 export class Context {
-  _targetInfo: TargetInfo;
+  _targetInfo: Protocol.Target.TargetInfo;
   _contextId: string;
   _sessionId: string;
 
@@ -11,11 +13,11 @@ export class Context {
     this._sessionId = sessionId;
   }
 
-  _updateTargetInfo(targetInfo: TargetInfo) {
+  _updateTargetInfo(targetInfo: Protocol.Target.TargetInfo) {
     this._targetInfo = targetInfo;
   }
 
-  _onInfoChangedEvent(targetInfo: TargetInfo) {
+  _onInfoChangedEvent(targetInfo: Protocol.Target.TargetInfo) {
     this._updateTargetInfo(targetInfo);
   }
 

--- a/src/bidiMapper/domains/context/targetInfo.ts
+++ b/src/bidiMapper/domains/context/targetInfo.ts
@@ -1,6 +1,0 @@
-class TargetInfo {
-  targetId: string;
-  openerId: string | null;
-  url: string | null;
-  type: string;
-}

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -15,7 +15,7 @@
  */
 import { CommandProcessor } from './commandProcessor';
 
-import { CdpClient } from './utils/cdpClient';
+import { CdpClient, CdpTransport, connectCdp } from './utils/cdpClient';
 import { BidiServer } from './utils/bidiServer';
 import { ServerBinding } from './utils/iServer';
 
@@ -23,28 +23,24 @@ import { log } from './utils/log';
 const logSystem = log('system');
 
 declare global {
-  interface Window extends GlobalObj {}
-
-  interface GlobalObj {
+  interface Window {
     //`window.cdp` is exposed by `Target.exposeDevToolsProtocol` from the server side.
     // https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-exposeDevToolsProtocol
     cdp: {
-      send: (string) => void;
-      onmessage: (string) => void;
+      send: (message: string) => void;
+      onmessage: (message: string) => void;
     };
 
     // `window.sendBidiResponse` is exposed by `Runtime.addBinding` from the server side.
-    sendBidiResponse: (string) => void;
+    sendBidiResponse: (response: string) => void;
 
     // `window.onBidiMessage` is called via `Runtime.evaluate` from the server side.
-    onBidiMessage: (string) => void;
+    onBidiMessage: (message: string) => void;
 
     // `window.setSelfTargetId` is called via `Runtime.evaluate` from the server side.
-    setSelfTargetId: (string) => void;
+    setSelfTargetId: (targetId: string) => void;
   }
 }
-
-const globalObj = window as GlobalObj;
 
 // Initiate `setSelfTargetId` as soon as possible to prevent race condition.
 const _waitSelfTargetIdPromise = _waitSelfTargetId();
@@ -53,41 +49,51 @@ const _waitSelfTargetIdPromise = _waitSelfTargetId();
   window.document.documentElement.innerHTML = `<h1>Bidi mapper runs here!</h1><h2>Don't close.</h2>`;
   window.document.title = 'BiDi Mapper';
 
-  const cdpServer = _createCdpServer();
+  const cdpClient = _createCdpClient();
   const bidiServer = _createBidiServer();
 
   // Needed to filter out info related to BiDi target.
   const selfTargetId = await _waitSelfTargetIdPromise;
 
   // Needed to get events about new targets.
-  await _prepareCdp(cdpServer);
+  await _prepareCdp(cdpClient);
 
-  CommandProcessor.run(cdpServer, bidiServer, selfTargetId);
+  CommandProcessor.run(cdpClient, bidiServer, selfTargetId);
 
   logSystem('launched');
 
   bidiServer.sendMessage('launched');
 })();
 
-function _createCdpServer() {
-  const cdpBinding = new ServerBinding(
-    (message) => {
-      globalObj.cdp.send(message);
-    },
-    (handler) => {
-      globalObj.cdp.onmessage = handler;
+function _createCdpClient() {
+  // A CdpTransport implementation that uses the window.cdp bindings
+  // injected by Target.exposeDevToolsProtocol.
+  class WindowGlobalCdpTransport implements CdpTransport {
+    onmessage?: (message: string) => void;
+
+    constructor() {
+      window.cdp.onmessage = (message: string) => {
+        if (this.onmessage) {
+          this.onmessage.call(null, message);
+        }
+      };
     }
-  );
-  return new CdpClient(cdpBinding);
+
+    sendMessage(message: string): void {
+      window.cdp.send(message);
+    }
+  }
+
+  return connectCdp(new WindowGlobalCdpTransport());
 }
 
 function _createBidiServer() {
   const bidiBinding = new ServerBinding(
     (message) => {
-      globalObj.sendBidiResponse(message);
+      window.sendBidiResponse(message);
     },
     (handler) => {
-      globalObj.onBidiMessage = handler;
+      window.onBidiMessage = handler;
     }
   );
   return new BidiServer(bidiBinding);
@@ -96,27 +102,21 @@ function _createBidiServer() {
 // Needed to filter out info related to BiDi target.
 async function _waitSelfTargetId(): Promise<string> {
   return await new Promise((resolve) => {
-    globalObj.setSelfTargetId = function (targetId) {
+    window.setSelfTargetId = function (targetId) {
       logSystem('current target ID: ' + targetId);
       resolve(targetId);
     };
   });
 }
 
-async function _prepareCdp(cdpServer) {
+async function _prepareCdp(cdpClient: CdpClient) {
   // Needed to get events about new targets.
-  await cdpServer.sendMessage({
-    method: 'Target.setDiscoverTargets',
-    params: { discover: true },
-  });
+  await cdpClient.Target.setDiscoverTargets({ discover: true });
 
   // Needed to automatically attach to new targets.
-  await cdpServer.sendMessage({
-    method: 'Target.setAutoAttach',
-    params: {
-      autoAttach: true,
-      waitForDebuggerOnStart: false,
-      flatten: true,
-    },
+  await cdpClient.Target.setAutoAttach({
+    autoAttach: true,
+    waitForDebuggerOnStart: false,
+    flatten: true,
   });
 }

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -68,7 +68,7 @@ const _waitSelfTargetIdPromise = _waitSelfTargetId();
 function _createCdpClient() {
   // A CdpTransport implementation that uses the window.cdp bindings
   // injected by Target.exposeDevToolsProtocol.
-  class WindowGlobalCdpTransport implements CdpTransport {
+  class WindowCdpTransport implements CdpTransport {
     onmessage?: (message: string) => void;
 
     constructor() {
@@ -84,7 +84,7 @@ function _createCdpClient() {
     }
   }
 
-  return connectCdp(new WindowGlobalCdpTransport());
+  return connectCdp(new WindowCdpTransport());
 }
 
 function _createBidiServer() {

--- a/src/bidiMapper/tsconfig.json
+++ b/src/bidiMapper/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "moduleResolution": "node",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noImplicitAny": true
   }
 }

--- a/src/bidiMapper/utils/bidiServer.ts
+++ b/src/bidiMapper/utils/bidiServer.ts
@@ -54,7 +54,11 @@ export class BidiServer extends AbstractServer {
     this.notifySubscribersOnMessage(messageObj);
   }
 
-  private _respondWithError(plainCommandData, errorCode, errorMessage) {
+  private _respondWithError(
+    plainCommandData: any,
+    errorCode: string,
+    errorMessage: string
+  ) {
     const errorResponse = this._getErrorResponse(
       plainCommandData,
       errorCode,
@@ -63,7 +67,7 @@ export class BidiServer extends AbstractServer {
     this.sendMessage(errorResponse);
   }
 
-  private _getJsonType(value) {
+  private _getJsonType(value: any) {
     if (value === null) {
       return 'null';
     }
@@ -73,7 +77,11 @@ export class BidiServer extends AbstractServer {
     return typeof value;
   }
 
-  private _getErrorResponse(messageStr, errorCode, errorMessage) {
+  private _getErrorResponse(
+    messageStr: string,
+    errorCode: string,
+    errorMessage: string
+  ) {
     // TODO: this is bizarre per spec. We reparse the payload and
     // extract the ID, regardless of what kind of value it was.
     let messageId = undefined;

--- a/src/bidiMapper/utils/cdpClient.ts
+++ b/src/bidiMapper/utils/cdpClient.ts
@@ -17,10 +17,6 @@ import { ServerBinding, AbstractServer } from './iServer';
 import { log } from './log';
 const logCdp = log('cdp');
 
-// TODO: Remove. This is a quick test to verify we can import a node module.
-import { version } from 'devtools-protocol/json/browser_protocol.json';
-logCdp(`Using CDP version: ${version}`);
-
 export class CdpClient extends AbstractServer {
   private _commandCallbacks: Map<number, (messageObj: any) => void> = new Map();
 

--- a/src/bidiMapper/utils/cdpClient.ts
+++ b/src/bidiMapper/utils/cdpClient.ts
@@ -17,6 +17,10 @@ import { ServerBinding, AbstractServer } from './iServer';
 import { log } from './log';
 const logCdp = log('cdp');
 
+// TODO: Remove. This is a quick test to verify we can import a node module.
+import { version } from 'devtools-protocol/json/browser_protocol.json';
+logCdp(`Using CDP version: ${version}`);
+
 export class CdpClient extends AbstractServer {
   private _commandCallbacks: Map<number, (messageObj: any) => void> = new Map();
 

--- a/src/bidiMapper/utils/events.ts
+++ b/src/bidiMapper/utils/events.ts
@@ -1,0 +1,29 @@
+// A simple polyfill for Node's EventEmitter class that is usable in the browser.
+// Add new functionality to this class as needed.
+export class EventEmitter {
+  private _handlers: Map<string, Set<Function>>;
+
+  constructor() {
+    this._handlers = new Map();
+  }
+
+  public on(event: string, handler: Function): void {
+    if (!this._handlers.has(event)) {
+      this._handlers.set(event, new Set());
+    }
+    this._handlers.get(event).add(handler);
+  }
+
+  public emit(event: string, ...args: any[]): void {
+    const handlers = this._handlers.get(event);
+    if (handlers) {
+      for (const handler of handlers) {
+        try {
+          handler.apply(null, args);
+        } catch (e) {
+          continue;
+        }
+      }
+    }
+  }
+}

--- a/src/bidiMapper/utils/iServer.ts
+++ b/src/bidiMapper/utils/iServer.ts
@@ -39,7 +39,7 @@ export class ServerBinding {
     this._sendMessage = sendMessage;
   }
 
-  public set onmessage(messageHandler: (string) => void) {
+  public set onmessage(messageHandler: (message: string) => void) {
     this._messageHandlerSetter(messageHandler);
   }
 

--- a/src/browserLauncher.ts
+++ b/src/browserLauncher.ts
@@ -44,7 +44,7 @@ export class BrowserProcess {
 }
 
 export async function launchBrowser(
-  browserExecutablePath,
+  browserExecutablePath: string,
   headless: boolean
 ): Promise<BrowserProcess> {
   const tempDir = await _getTempDir();
@@ -94,7 +94,9 @@ async function _getTempDir(): Promise<string> {
   return await mkdtempAsync(profilePath);
 }
 
-async function _waitForWSEndpoint(browserProcess): Promise<string> {
+async function _waitForWSEndpoint(
+  browserProcess: childProcess.ChildProcessWithoutNullStreams
+): Promise<string> {
   // Potential errors during Chrome launch to make error message more sensible.
   const chromeLaunchErrors = [
     {
@@ -105,9 +107,7 @@ async function _waitForWSEndpoint(browserProcess): Promise<string> {
   ];
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({ input: browserProcess.stderr });
-    _addEventListener(rl, 'line', onLine);
-
-    function onLine(line) {
+    rl.on('line', (line) => {
       for (const error of chromeLaunchErrors) {
         const errorMatch = line.match(error.regex);
         if (errorMatch) {
@@ -120,11 +120,6 @@ async function _waitForWSEndpoint(browserProcess): Promise<string> {
       if (match) {
         resolve(match[1]);
       }
-    }
+    });
   });
-}
-
-function _addEventListener(emitter, eventName, handler) {
-  emitter.on(eventName, handler);
-  return { emitter, eventName, handler };
 }

--- a/src/mapperServer.ts
+++ b/src/mapperServer.ts
@@ -27,7 +27,7 @@ export class MapperServer implements IServer {
   private _handlers: ((messageObj: any) => void)[] = new Array();
   private _commandCallbacks: Map<number, (messageObj: any) => void> = new Map();
   private _ws: WebSocket;
-  private _mapperSessionId;
+  private _mapperSessionId: string;
   private _launchedPromiseResolve: () => void;
   private _launchedPromise: Promise<void> = new Promise((resolve) => {
     this._launchedPromiseResolve = resolve;
@@ -50,23 +50,22 @@ export class MapperServer implements IServer {
     return this._sendBidiMessage(messageObj);
   }
 
-  private _establishCdpSession: (cdpUrl: string) => Promise<void> =
-    async function (cdpUrl: string) {
-      return new Promise((resolve) => {
-        debugInternal('Establishing session with cdpUrl: ', cdpUrl);
+  private async _establishCdpSession(cdpUrl: string): Promise<void> {
+    return new Promise((resolve) => {
+      debugInternal('Establishing session with cdpUrl: ', cdpUrl);
 
-        this._ws = new WebSocket(cdpUrl);
+      this._ws = new WebSocket(cdpUrl);
 
-        this._ws.on('message', (dataStr: string) => {
-          this._onCdpMessage(dataStr);
-        });
-
-        this._ws.on('open', () => {
-          debugInternal('Session established.');
-          resolve();
-        });
+      this._ws.on('message', (dataStr: string) => {
+        this._onCdpMessage(dataStr);
       });
-    };
+
+      this._ws.on('open', () => {
+        debugInternal('Session established.');
+        resolve();
+      });
+    });
+  }
 
   private _sendBidiMessage(bidiMessageObj: any): Promise<void> {
     return this._sendCdpCommand({
@@ -106,7 +105,7 @@ export class MapperServer implements IServer {
       if (data.method === 'Runtime.consoleAPICalled') {
         debugLog.apply(
           null,
-          data.params.args.map((arg) => arg.value)
+          data.params.args.map((arg: any) => arg.value)
         );
         return;
       }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,7 +10,8 @@
     "module": "ESNext",
     "declaration": true,
     "declarationMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noImplicitAny": true
   },
   "files": ["index.ts"]
 }


### PR DESCRIPTION
This changes implements a strongly-typed CdpClient object that implements the interface provided in devtools-protocol module. CdpClient callers have been updated to use the new style.

Before:
```js
await cdpServer.sendMessage({
  method: 'Target.setAutoAttach',
  params: {
    autoAttach: true,
    waitForDebuggerOnStart: false,
    flatten: true,
  },
});
```

After:
```js
await cdpClient.Target.setAutoAttach({
  autoAttach: true,
  waitForDebuggerOnStart: false,
  flatten: true,
});
```

Events:
```js
this._cdpClient.Target.on('attachedToTarget', (params) => {
  this._contextProcessor.handleAttachedToTargetEvent(params);
});
```

Command and event parameters are fully typed. TypeScript interfaces for CDP types are also available from the `Protocol` namespace. e.g.: `Protocol.Target.TargetInfo`. Some functions that accept protocol types like TargetInfo as a parameter have been updated to use these.

The devtools-protocol module only provides types, and no implementation, so the implementation is up to us. The new code in cdpClient.ts reads the protocol .json files and uses this information at runtime to generate classes that implement the expected interface. When a generated method on a generate class is called, it will send a raw CDP message using a CdpTransport object and await a response.

Follow-up:
- There are still some manually-written CDP calls in mapperServer.ts that can be updated to use the new CdpClient. Needs a CdpTransport for websocket.
- Unit test coverage for CdpClient. Waiting for #12 