### PR TITLE
Share common tsconfig options

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": ["$tsc"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "npm: build",
+    }
+  ]
+}

--- a/src/bidiMapper/tsconfig.json
+++ b/src/bidiMapper/tsconfig.json
@@ -1,8 +1,6 @@
 {
+  "extends": "../configs/tsconfig.common.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "noImplicitAny": true
+    "outDir": "./.build"
   }
 }

--- a/src/configs/tsconfig.common.json
+++ b/src/configs/tsconfig.common.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "target": "ESNext",
+    "moduleResolution": "node",
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    "noImplicitAny": true
+  }
+}

--- a/src/configs/tsconfig.common.json
+++ b/src/configs/tsconfig.common.json
@@ -4,7 +4,6 @@
     "esModuleInterop": true,
     "target": "ESNext",
     "moduleResolution": "node",
-    "module": "ESNext",
     "resolveJsonModule": true,
     "noImplicitAny": true
   }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./configs/tsconfig.common.json",
   "compilerOptions": {
-    "outDir": "./.build"
+    "outDir": "./.build",
+    "module": "ESNext",
   },
   "files": ["index.ts"]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,17 +1,7 @@
 {
+  "extends": "./configs/tsconfig.common.json",
   "compilerOptions": {
-    "outDir": "./.build",
-    "sourceMap": true,
-    "esModuleInterop": true,
-    "allowJs": true,
-    "checkJs": true,
-    "target": "ESNext",
-    "moduleResolution": "node",
-    "module": "ESNext",
-    "declaration": true,
-    "declarationMap": true,
-    "resolveJsonModule": true,
-    "noImplicitAny": true
+    "outDir": "./.build"
   },
   "files": ["index.ts"]
 }


### PR DESCRIPTION
Adds a new tsconfig.common.json file which holds compiler options common to both the server and mapper code. The server and mapper tsconfig files "extend" this file. This helps ensure both components are built with the same options.

Also adding a default build task for vscode. This lets the user trigger a full build using ctrl+shift+B and vscode will show any typescript errors in the "errors" panel.