### PR TITLE
Update copyright notice

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,11 +1,12 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { CdpClient } from '../cdp';
 import { BrowsingContextProcessor } from './domains/context/browsingContextProcessor';
 import { Context } from './domains/context/context';

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { log } from '../../../utils/log';
 import { CdpClient } from '../../../cdp';
 import { Context } from './context';

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Protocol } from 'devtools-protocol';
 
 export class Context {

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { CommandProcessor } from './commandProcessor';
 
 import { CdpClient, CdpConnection } from '../cdp';

--- a/src/bidiMapper/rollup.config.js
+++ b/src/bidiMapper/rollup.config.js
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import typescript from '@rollup/plugin-typescript';
 import nodePolyfills from 'rollup-plugin-node-polyfills';
 import json from '@rollup/plugin-json';

--- a/src/bidiMapper/utils/bidiServer.ts
+++ b/src/bidiMapper/utils/bidiServer.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/bidiServerRunner.ts
+++ b/src/bidiServerRunner.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import websocket from 'websocket';
 import http from 'http';
 import { ITransport } from './utils/transport';

--- a/src/cdp/cdpClient.spec.ts
+++ b/src/cdp/cdpClient.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { CdpConnection } from './cdpConnection';
 import { StubTransport } from '../tests/stubTransport.spec';
 

--- a/src/cdp/cdpClient.ts
+++ b/src/cdp/cdpClient.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/cdp/cdpConnection.spec.ts
+++ b/src/cdp/cdpConnection.spec.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { StubTransport } from '../tests/stubTransport.spec';
 
 import * as chai from 'chai';

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ITransport } from '../utils/transport';
 import { CdpMessage } from './cdpMessage';
 import { CdpClient, createClient } from './cdpClient';

--- a/src/cdp/cdpMessage.ts
+++ b/src/cdp/cdpMessage.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export interface CdpError {
   code: number;
   message: string;

--- a/src/cdp/index.ts
+++ b/src/cdp/index.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { CdpClient } from './cdpClient';
 export { CdpConnection } from './cdpConnection';
 export { WebSocketTransport } from './websocketTransport';

--- a/src/cdp/websocketTransport.ts
+++ b/src/cdp/websocketTransport.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ITransport } from '../utils/transport';
 import WebSocket from 'ws';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import argparse from 'argparse';
 import puppeteer, { PuppeteerNode } from 'puppeteer';

--- a/src/mapperReader.ts
+++ b/src/mapperReader.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
 import fs from 'fs/promises';
 import path from 'path';

--- a/src/mapperServer.ts
+++ b/src/mapperServer.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import debug from 'debug';
 
 const debugInternal = debug('bidiMapper:internal');

--- a/src/tests/stubTransport.spec.ts
+++ b/src/tests/stubTransport.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { assert, spy, SinonSpy } from 'sinon';
 import { ITransport } from '../utils/transport';
 

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,5 +1,6 @@
 /**
- * Copyright 2021 Google Inc. All rights reserved.
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export function log(type: string): (...message: any[]) => void {
   return (...messages: any[]) => {
     // If run in browser, add debug message to the page.

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -1,4 +1,21 @@
 /**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Represents a low-level transport mechanism for raw text messages like
  * a WebSocket, pipe, or Window binding.
  */

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -1,10 +1,11 @@
-# Copyright 2021 Google LLC
+# Copyright 2021 Google LLC.
+# Copyright (c) Microsoft Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Updating the copyright notice based on the discussion at the last Chromium bidi sync. The new text reads:

```
/**
 * Copyright 2021 Google LLC.
 * Copyright (c) Microsoft Corporation.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
```