### PR TITLE
unit tests on `eval.es`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "argparse": "^2.0.1",
+    "chai-exclude": "^2.1.0",
     "debug": "^4.3.1",
     "puppeteer": "^10.2.0",
     "ts-node": "^9.1.1",

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -72,7 +72,7 @@ export class Context {
     // or,
     //   { exceptionDetails: { message: '<error message from user script>', stacktrace? } }
 
-    const expression = `(${EVALUATOR_SCRIPT}).apply(null, [${JSON.stringify(
+    const expression = `(${EVALUATOR_SCRIPT}).evaluate.apply(null, [${JSON.stringify(
       script
     )}, ${JSON.stringify(args)}])`;
     const { result, exceptionDetails } = await this._cdpClient.Runtime.evaluate(

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -2,7 +2,7 @@
  * Copyright 2021 Google LLC.
  * Copyright (c) Microsoft Corporation.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the 'License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -16,117 +16,136 @@
  */
 
 (() => {
-  class Serializer {
+  class SerializationMapper {
     _idToObject = new Map();
     _objectToId = new WeakMap();
+  }
 
-    constructor() {}
-
-    serialize(value) {
-      if (value === undefined) {
-        return { type: 'undefined' };
-      } else if (value === null) {
-        return { type: 'null' };
-      } else if (typeof value === 'string') {
-        return { type: 'string', value };
-      } else if (typeof value === 'number') {
-        let serialized;
-        if (Number.isNaN(value)) {
-          serialized = 'NaN';
-        } else if (Object.is(value, -0)) {
-          serialized = '-0';
-        } else if (value === -Infinity) {
-          serialized = '-Infinity';
-        } else if (value === +Infinity) {
-          serialized = '+Infinity';
-        } else {
-          serialized = value;
-        }
-        return { type: 'number', value: serialized };
-      } else if (typeof value === 'boolean') {
-        return { type: 'boolean', value };
-      } else if (value instanceof Object) {
-        // TODO: Recursive serialize.
-        let objectId = this._objectToId.get(value);
-        if (!objectId) {
-          objectId = uuid();
-          this._objectToId.set(value, objectId);
-          this._idToObject.set(objectId, new WeakRef(value));
-        }
-        return { type: 'object', objectId };
-      } else {
-        throw new Error('not yet implemented');
-      }
+  function getSerializationMapper() {
+    // No `window` can be in case of unit tests.
+    if (typeof window === 'undefined') {
+      global.window = {};
     }
 
-    deserialize(value) {
-      switch (value.type) {
-        case 'undefined': {
-          return undefined;
-        }
-        case 'null': {
-          return null;
-        }
-        case 'string': {
-          return value.value;
-        }
-        case 'number': {
-          if (value.value === 'NaN') {
-            return NaN;
-          } else if (value.value === '-0') {
-            return -0;
-          } else if (value.value === '+Infinity') {
-            return +Infinity;
-          } else if (value.value === '-Infinity') {
-            return -Infinity;
-          } else {
-            return value.value;
-          }
-        }
-        case 'boolean': {
-          return value.value;
-        }
-        case 'object': {
-          const weakRef = this._idToObject.get(value.objectId);
-          if (!weakRef) {
-            throw new Error('unknown object reference');
-          }
+    if (window.__webdriver_js_serializer === undefined) {
+      window.__webdriver_js_serializer = new SerializationMapper();
+    }
 
-          const obj = weakRef.deref();
-          if (!obj) {
-            throw new Error('stable object reference');
-          }
+    return window.__webdriver_js_serializer;
+  }
 
-          return obj;
-        }
-        default:
-          throw new Error('not yet implemented');
+  const serializationMapper = getSerializationMapper();
+
+  function serialize(value) {
+    if (value === undefined) {
+      return { type: 'undefined' };
+    } else if (value === null) {
+      return { type: 'null' };
+    } else if (typeof value === 'string') {
+      return { type: 'string', value };
+    } else if (typeof value === 'number') {
+      let serialized;
+      if (Number.isNaN(value)) {
+        serialized = 'NaN';
+      } else if (Object.is(value, -0)) {
+        serialized = '-0';
+      } else if (value === -Infinity) {
+        serialized = '-Infinity';
+      } else if (value === +Infinity) {
+        serialized = '+Infinity';
+      } else {
+        serialized = value;
       }
+      return { type: 'number', value: serialized };
+    } else if (typeof value === 'boolean') {
+      return { type: 'boolean', value };
+    } else if (value instanceof Object) {
+      // TODO: Recursive serialize.
+      let objectId = serializationMapper._objectToId.get(value);
+      if (!objectId) {
+        objectId = uuid();
+        serializationMapper._objectToId.set(value, objectId);
+        serializationMapper._idToObject.set(objectId, new WeakRef(value));
+      }
+      return { type: 'object', objectId };
+    } else {
+      throw new Error('not yet implemented');
+    }
+  }
+
+  function deserialize(value) {
+    switch (value.type) {
+      case 'undefined': {
+        return undefined;
+      }
+      case 'null': {
+        return null;
+      }
+      case 'string': {
+        return value.value;
+      }
+      case 'number': {
+        if (value.value === 'NaN') {
+          return NaN;
+        } else if (value.value === '-0') {
+          return -0;
+        } else if (value.value === '+Infinity') {
+          return +Infinity;
+        } else if (value.value === '-Infinity') {
+          return -Infinity;
+        } else {
+          return value.value;
+        }
+      }
+      case 'boolean': {
+        return value.value;
+      }
+      case 'object': {
+        const weakRef = serializationMapper._idToObject.get(value.objectId);
+        if (!weakRef) {
+          throw new Error('unknown object reference');
+        }
+
+        const obj = weakRef.deref();
+        if (!obj) {
+          throw new Error('stable object reference');
+        }
+
+        return obj;
+      }
+      default:
+        throw new Error('not yet implemented');
+
     }
   }
 
   function uuid() {
-    return crypto.randomUUID();
+    // TODO sadym: `crypto.randomUUID()` works only in secure context.
+    // Find out a way to use`crypto.randomUUID`
+    return (Math.random() + '').substr(2)
+      + '.' + (Math.random() + '').substr(2)
+      + '.' + (Math.random() + '').substr(2);
   }
 
-  return function evaluate(script, args) {
-    if (window.__webdriver_js_serializer === undefined) {
-      window.__webdriver_js_serializer = new Serializer();
-    }
-
-    const serializer = window.__webdriver_js_serializer;
+  function evaluate(script, args) {
     try {
-      const deserializedArgs = args.map((arg) => serializer.deserialize(arg));
+      const deserializedArgs = args.map((arg) => deserialize(arg));
       const func = new Function(`return (${script})`);
       const result = func.apply(null, deserializedArgs);
-      const serializedResult = serializer.serialize(result);
+      const serializedResult = serialize(result);
       return { result: serializedResult };
     } catch (e) {
       if (e instanceof Error) {
         return { exceptionDetails: { message: e.message, stacktrace: e.stack } };
       } else {
-        return { exceptionDetails: { value: serializer.serialize(e) } };
+        return { exceptionDetails: { value: serialize(e) } };
       }
     }
   };
+
+  return {
+    evaluate,
+    serialize,
+    deserialize
+  }
 })()

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -2,7 +2,7 @@
  * Copyright 2021 Google LLC.
  * Copyright (c) Microsoft Corporation.
  *
- * Licensed under the Apache License, Version 2.0 (the 'License");
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -21,20 +21,20 @@
     _objectToId = new WeakMap();
   }
 
-  function getSerializationMapper() {
+  function getObjectCache() {
     // No `window` can be in case of unit tests.
     if (typeof window === 'undefined') {
       global.window = {};
     }
 
     if (window.__webdriver_js_serializer === undefined) {
-      window.__webdriver_js_serializer = new SerializationMapper();
+      window.__webdriver_js_serializer = new ObjectCache();
     }
 
     return window.__webdriver_js_serializer;
   }
 
-  const serializationMapper = getSerializationMapper();
+  const objectCache = getObjectCache();
 
   function serialize(value, maxDepth = 1) {
     if (value === undefined) {
@@ -61,11 +61,11 @@
       return { type: 'boolean', value };
     } else if (value instanceof Object) {
       // TODO: Recursive serialize.
-      let objectId = serializationMapper._objectToId.get(value);
+      let objectId = objectCache._objectToId.get(value);
       if (!objectId) {
         objectId = uuid();
-        serializationMapper._objectToId.set(value, objectId);
-        serializationMapper._idToObject.set(objectId, new WeakRef(value));
+        objectCache._objectToId.set(value, objectId);
+        objectCache._idToObject.set(objectId, new WeakRef(value));
       }
 
       const result = { objectId };
@@ -131,7 +131,7 @@
       case 'array':
       case 'function':
       case 'object': {
-        const weakRef = serializationMapper._idToObject.get(value.objectId);
+        const weakRef = objectCache._idToObject.get(value.objectId);
         if (!weakRef) {
           throw new Error('unknown object reference');
         }
@@ -151,7 +151,7 @@
 
   function uuid() {
     // TODO sadym: `crypto.randomUUID()` works only in secure context.
-    // Find out a way to use`crypto.randomUUID`
+    // Find out a way to use`crypto.randomUUID`.
     return (Math.random() + '').substr(2)
       + '.' + (Math.random() + '').substr(2)
       + '.' + (Math.random() + '').substr(2);

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -16,7 +16,7 @@
  */
 
 (() => {
-  class SerializationMapper {
+  class ObjectCache {
     _idToObject = new Map();
     _objectToId = new WeakMap();
   }

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -22,16 +22,11 @@
   }
 
   function getObjectCache() {
-    // No `window` can be in case of unit tests.
-    if (typeof window === 'undefined') {
-      global.window = {};
+    if (globalThis.__webdriver_objectCache === undefined) {
+      globalThis.__webdriver_objectCache = new ObjectCache();
     }
 
-    if (window.__webdriver_js_serializer === undefined) {
-      window.__webdriver_js_serializer = new ObjectCache();
-    }
-
-    return window.__webdriver_js_serializer;
+    return globalThis.__webdriver_objectCache;
   }
 
   const objectCache = getObjectCache();

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -67,7 +67,16 @@
         serializationMapper._objectToId.set(value, objectId);
         serializationMapper._idToObject.set(objectId, new WeakRef(value));
       }
-      return { type: 'object', objectId };
+
+      const result = { objectId };
+
+      if (typeof value === 'function') {
+        result.type = 'function';
+        return result;
+      }
+
+      result.type = 'object';
+      return result;
     } else {
       throw new Error('not yet implemented');
     }
@@ -100,7 +109,9 @@
       case 'boolean': {
         return value.value;
       }
-      case 'object': {
+      case 'function':
+      case 'object':
+        {
         const weakRef = serializationMapper._idToObject.get(value.objectId);
         if (!weakRef) {
           throw new Error('unknown object reference');

--- a/src/bidiMapper/scripts/eval.spec.ts
+++ b/src/bidiMapper/scripts/eval.spec.ts
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import fs from 'fs/promises';
 import path from 'path';
 import * as chai from 'chai';
@@ -6,14 +23,18 @@ import chaiExclude from 'chai-exclude';
 chai.use(chaiExclude);
 
 describe('Evaluator', function () {
-    let EVALUATOR: any;
+    let EVALUATOR: {
+        evaluate: Function,
+        serialize: Function,
+        deserialize: Function
+    };
 
     // Get EVALUATOR.
     before(async function () {
-        const eval_text = await fs.readFile(
+        const eval_text = (await fs.readFile(
             path.join(__dirname, './eval.es'),
             'utf8'
-        ) as any as string;
+        )).toString();
 
         EVALUATOR = eval(eval_text);
     });

--- a/src/bidiMapper/scripts/eval.spec.ts
+++ b/src/bidiMapper/scripts/eval.spec.ts
@@ -13,150 +13,204 @@ describe('Evaluator', function () {
         const eval_text = await fs.readFile(
             path.join(__dirname, './eval.es'),
             'utf8'
-        );
+        ) as any as string;
 
         EVALUATOR = eval(eval_text);
     });
 
-    function checkSerializeAndDeserialize(originalObject: any, expectedSerializedObj: any, excluding: string[] = []) {
-        // Check serialize.
-        const serializedOrigianlObj = EVALUATOR.serialize(originalObject);
-        if (excluding.length > 0) {
-            chai.assert.deepEqualExcluding(
-                serializedOrigianlObj,
-                expectedSerializedObj,
-                excluding);
+    describe('serialize + deserialize', function () {
+        function checkSerializeAndDeserialize(originalObject: any, expectedSerializedObj: any, excluding: string[] = []) {
+            // Check serialize.
+            const serializedOrigianlObj = EVALUATOR.serialize(originalObject);
+            if (excluding.length > 0) {
+                chai.assert.deepEqualExcludingEvery(
+                    serializedOrigianlObj,
+                    expectedSerializedObj,
+                    excluding);
 
-        } else {
+            } else {
+                chai.assert.deepEqual(
+                    serializedOrigianlObj,
+                    expectedSerializedObj);
+            }
+
+            // Check deserialize.
+            const deserializedSerializedOrigianlObj = EVALUATOR.deserialize(serializedOrigianlObj)
             chai.assert.deepEqual(
-                serializedOrigianlObj,
-                expectedSerializedObj);
+                deserializedSerializedOrigianlObj,
+                originalObject);
         }
 
-        // Check deserialize.
-        const deserializedSerializedOrigianlObj = EVALUATOR.deserialize(serializedOrigianlObj)
-        chai.assert.deepEqual(
-            deserializedSerializedOrigianlObj,
-            originalObject);
-    }
-
-    describe('number', function () {
-        it(`natural number`, function () {
+        describe('number', function () {
+            it(`natural number`, function () {
+                checkSerializeAndDeserialize(
+                    42,
+                    {
+                        type: 'number',
+                        value: 42
+                    }
+                );
+            });
+            it(`NaN`, function () {
+                it(`serialize`, function () {
+                    checkSerializeAndDeserialize(
+                        NaN,
+                        {
+                            type: 'number',
+                            value: 'NaN'
+                        });
+                });
+            });
+            it(`-0`, function () {
+                it(`serialize`, function () {
+                    checkSerializeAndDeserialize(
+                        -0,
+                        {
+                            type: 'number',
+                            value: '-0'
+                        });
+                });
+            });
+            it(`-Infinity`, function () {
+                it(`serialize`, function () {
+                    checkSerializeAndDeserialize(
+                        -Infinity,
+                        {
+                            type: 'number',
+                            value: '-Infinity'
+                        });
+                });
+            });
+            it(`+Infinity`, function () {
+                it(`serialize`, function () {
+                    checkSerializeAndDeserialize(
+                        +Infinity,
+                        {
+                            type: 'number',
+                            value: '+Infinity'
+                        });
+                });
+            });
+        });
+        it('undefined', function () {
             checkSerializeAndDeserialize(
-                42,
+                undefined,
                 {
-                    type: 'number',
-                    value: 42
+                    type: 'undefined'
                 }
             );
         });
-        it(`NaN`, function () {
-            it(`serialize`, function () {
-                checkSerializeAndDeserialize(
-                    NaN,
-                    {
-                        type: 'number',
-                        value: 'NaN'
-                    });
-            });
-        });
-        it(`-0`, function () {
-            it(`serialize`, function () {
-                checkSerializeAndDeserialize(
-                    -0,
-                    {
-                        type: 'number',
-                        value: '-0'
-                    });
-            });
-        });
-        it(`-Infinity`, function () {
-            it(`serialize`, function () {
-                checkSerializeAndDeserialize(
-                    -Infinity,
-                    {
-                        type: 'number',
-                        value: '-Infinity'
-                    });
-            });
-        });
-        it(`+Infinity`, function () {
-            it(`serialize`, function () {
-                checkSerializeAndDeserialize(
-                    +Infinity,
-                    {
-                        type: 'number',
-                        value: '+Infinity'
-                    });
-            });
-        });
-    });
-    it('undefined', function () {
-        checkSerializeAndDeserialize(
-            undefined,
-            {
-                type: 'undefined'
-            }
-        );
-    });
-    it('boolean', function () {
-        checkSerializeAndDeserialize(
-            false,
-            {
-                type: 'boolean',
-                value: false
-            }
-        );
-        checkSerializeAndDeserialize(
-            true,
-            {
-                type: 'boolean',
-                value: true
-            }
-        );
-    });
-    describe('string', function () {
-        it('normal string', function () {
+        it('boolean', function () {
             checkSerializeAndDeserialize(
-                'SOME_STRING_HERE',
+                false,
                 {
-                    type: 'string',
-                    value: 'SOME_STRING_HERE'
+                    type: 'boolean',
+                    value: false
+                }
+            );
+            checkSerializeAndDeserialize(
+                true,
+                {
+                    type: 'boolean',
+                    value: true
                 }
             );
         });
-        it('empty string', function () {
-            checkSerializeAndDeserialize(
-                '',
-                {
-                    type: 'string',
-                    value: ''
-                }
-            );
+        describe('string', function () {
+            it('normal string', function () {
+                checkSerializeAndDeserialize(
+                    'SOME_STRING_HERE',
+                    {
+                        type: 'string',
+                        value: 'SOME_STRING_HERE'
+                    }
+                );
+            });
+            it('empty string', function () {
+                checkSerializeAndDeserialize(
+                    '',
+                    {
+                        type: 'string',
+                        value: ''
+                    }
+                );
+            });
         });
-    });
-    describe('object', function () {
-        it('normal obejct', function () {
+        describe('object', function () {
+            it('flat object', function () {
+                checkSerializeAndDeserialize(
+                    {
+                        SOME_PROPERTY: 'SOME_VALUE'
+                    },
+                    {
+                        type: 'object',
+                        value: [[
+                            "SOME_PROPERTY",
+                            {
+                                type: "string",
+                                value: "SOME_VALUE"
+                            }]],
+                        objectId: '__any_value__'
+                    },
+                    ["objectId"]
+                );
+            });
+            it('nested objects', function () {
+                checkSerializeAndDeserialize(
+                    {
+                        'foo': {
+                            'bar': 'baz'
+                        },
+                        'qux': 'quux'
+                    },
+                    {
+                        "type": "object",
+                        "objectId": "__any_value__",
+                        "value": [[
+                            "foo", {
+                                "type": "object",
+                                "objectId": "__any_value__"
+                            }], [
+                            "qux", {
+                                "type": "string",
+                                "value": "quux"
+                            }]]
+                    },
+                    ["objectId"]
+                );
+            });
+        });
+        it('function', function () {
             checkSerializeAndDeserialize(
+                function () { },
                 {
-                    SOME_PROPERTY: 'SOME_VALUE'
-                },
-                {
-                    type: 'object',
-                    objectId: '__IGNORED_OBJECT_ID'
+                    type: 'function',
+                    objectId: '__any_value__'
                 },
                 ["objectId"]
             );
         });
-    });
-    it('function', function () {
-        checkSerializeAndDeserialize(
-            function () { },
-            {
-                type: 'function',
-                objectId: '__IGNORED_OBJECT_ID'
-            },
-            ["objectId"]
-        );
+        it('array', function () {
+            checkSerializeAndDeserialize(
+                [1, 'a', { foo: 'bar' }, [2, [3, 4]]],
+                {
+                    type: "array",
+                    objectId: "__any_value__",
+                    value: [{
+                        type: "number",
+                        value: 1
+                    }, {
+                        type: "string",
+                        value: "a"
+                    }, {
+                        type: "object",
+                        objectId: "__any_value__"
+                    }, {
+                        type: "array",
+                        objectId: "__any_value__"
+                    }]
+                }, ["objectId"]
+            );
+        });
     });
 });

--- a/src/bidiMapper/scripts/eval.spec.ts
+++ b/src/bidiMapper/scripts/eval.spec.ts
@@ -1,0 +1,142 @@
+import fs from 'fs/promises';
+import path from 'path';
+import * as chai from 'chai';
+
+describe('Evaluator', function () {
+    let EVALUATOR: any;
+
+    // Get EVALUATOR.
+    before(async function () {
+        const eval_text = await fs.readFile(
+            path.join(__dirname, './eval.es'),
+            'utf8'
+        );
+
+        EVALUATOR = eval(eval_text);
+    });
+
+    function checkSerializeAndDeserialize(originalObject: any, serializedObj: any) {
+        // Check serialise.
+        chai.assert.deepEqual(
+            EVALUATOR.serialize(originalObject),
+            serializedObj);
+        // Check deserialise.
+        chai.assert.deepEqual(
+            EVALUATOR.deserialize(serializedObj),
+            originalObject);
+    }
+
+    describe('number', function () {
+        it(`natural number`, function () {
+            checkSerializeAndDeserialize(
+                42,
+                {
+                    type: 'number',
+                    value: 42
+                }
+            );
+        });
+        it(`NaN`, function () {
+            it(`serialize`, function () {
+                checkSerializeAndDeserialize(
+                    NaN,
+                    {
+                        type: 'number',
+                        value: 'NaN'
+                    });
+            });
+        });
+        it(`-0`, function () {
+            it(`serialize`, function () {
+                checkSerializeAndDeserialize(
+                    -0,
+                    {
+                        type: 'number',
+                        value: '-0'
+                    });
+            });
+        });
+        it(`-Infinity`, function () {
+            it(`serialize`, function () {
+                checkSerializeAndDeserialize(
+                    -Infinity,
+                    {
+                        type: 'number',
+                        value: '-Infinity'
+                    });
+            });
+        });
+        it(`+Infinity`, function () {
+            it(`serialize`, function () {
+                checkSerializeAndDeserialize(
+                    +Infinity,
+                    {
+                        type: 'number',
+                        value: '+Infinity'
+                    });
+            });
+        });
+    });
+    it('undefined', function () {
+        checkSerializeAndDeserialize(
+            undefined,
+            {
+                type: 'undefined'
+            }
+        );
+    });
+    it('boolean', function () {
+        checkSerializeAndDeserialize(
+            false,
+            {
+                type: 'boolean',
+                value: false
+            }
+        );
+        checkSerializeAndDeserialize(
+            true,
+            {
+                type: 'boolean',
+                value: true
+            }
+        );
+    });
+    describe('string', function () {
+        it('normal string', function () {
+            checkSerializeAndDeserialize(
+                'SOME_STRING_HERE',
+                {
+                    type: 'string',
+                    value: 'SOME_STRING_HERE'
+                }
+            );
+        });
+        it('empty string', function () {
+            checkSerializeAndDeserialize(
+                '',
+                {
+                    type: 'string',
+                    value: ''
+                }
+            );
+        });
+    });
+    describe('object', function () {
+        it('normal obejct', function () {
+            const obj = {
+                SOME_PROPERTY: 'SOME_VALUE'
+            };
+
+            const serialisedObj = EVALUATOR.serialize(obj);
+
+            // Assert only expected properties.
+            chai.assert.deepEqual(Object.keys(serialisedObj), ['type', 'objectId']);
+            // Assert type.
+            chai.assert.equal(serialisedObj.type, 'object');
+
+            const deserialisedObj = EVALUATOR.deserialize(serialisedObj);
+            chai.assert.strictEqual(deserialisedObj, obj);
+
+        });
+    });
+});

--- a/src/bidiMapper/scripts/eval.spec.ts
+++ b/src/bidiMapper/scripts/eval.spec.ts
@@ -57,7 +57,7 @@ describe('Evaluator', function () {
 
             // Check deserialize.
             const deserializedSerializedOrigianlObj = EVALUATOR.deserialize(serializedOrigianlObj)
-            chai.assert.deepEqual(
+            chai.assert.strictEqual(
                 deserializedSerializedOrigianlObj,
                 originalObject);
         }

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -765,7 +765,6 @@ async def assertSerialisation(jsStrObject, expectedSerialisedObject, websocket):
     recursiveCompare(expectedSerialisedObject, resp["result"]["result"], ["objectId"])
 
 @pytest.mark.asyncio
-# Not implemented yet.
 async def test_serialisation_undefined(websocket):
     await assertSerialisation(
         "undefined",
@@ -774,7 +773,6 @@ async def test_serialisation_undefined(websocket):
 
 
 @pytest.mark.asyncio
-# Not implemented yet.
 async def test_serialisation_null(websocket):
     await assertSerialisation(
         "null",
@@ -783,7 +781,6 @@ async def test_serialisation_null(websocket):
 
 # TODO: test escaping, null bytes string, lone surrogates.
 @pytest.mark.asyncio
-# Not implemented yet.
 async def test_serialisation_string(websocket):
     await assertSerialisation(
         "'someStr'",
@@ -793,7 +790,6 @@ async def test_serialisation_string(websocket):
         websocket)
 
 @pytest.mark.asyncio
-# Not implemented yet.
 async def test_serialisation_number(websocket):
     await assertSerialisation(
         "123",
@@ -809,7 +805,6 @@ async def test_serialisation_number(websocket):
         websocket)
 
 @pytest.mark.asyncio
-# Not implemented yet.
 async def test_serialisation_specialNumber(websocket):
     await assertSerialisation(
         "+Infinity",
@@ -837,7 +832,6 @@ async def test_serialisation_specialNumber(websocket):
         websocket)
 
 @pytest.mark.asyncio
-# Not implemented yet.
 async def test_serialisation_bool(websocket):
     await assertSerialisation(
         "true",
@@ -850,6 +844,54 @@ async def test_serialisation_bool(websocket):
         {
             "type":"boolean",
             "value":False},
+        websocket)
+
+@pytest.mark.asyncio
+async def test_serialisation_function(websocket):
+    await assertSerialisation(
+        "function(){}",
+        {
+            "type":"function",
+            "objectId":"__any_value__"
+        },
+        websocket)
+
+@pytest.mark.asyncio
+async def test_serialisation_object(websocket):
+    await assertSerialisation(
+        "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
+        {
+            "type":"object",
+            "objectId":"__any_value__",
+            "value":[[
+                "foo", {
+                    "type":"object",
+                    "objectId":"__any_value__"}],[
+                "qux", {
+                    "type":"string",
+                    "value":"quux"}]]},
+        websocket)
+
+
+@pytest.mark.asyncio
+async def test_serialisation_array(websocket):
+    await assertSerialisation(
+        "[1, 'a', {foo: 'bar'}, [2,[3,4]]]",
+        {
+            "type":"array",
+            "objectId":"__any_value__",
+            "value":[{
+                "type":"number",
+                "value":1
+            },{
+                "type":"string",
+                "value":"a"
+            },{
+                "type":"object",
+                "objectId":"__any_value__"
+            },{
+                "type":"array",
+                "objectId":"__any_value__"}]},
         websocket)
 
 @pytest.mark.asyncio
@@ -870,17 +912,6 @@ async def _ignore_test_serialisation_symbol(websocket):
         {
             "type":"symbol",
             "PROTO.description":"foo",
-            "objectId":"__any_value__"
-        },
-        websocket)
-
-@pytest.mark.asyncio
-# Not implemented yet.
-async def _ignore_test_serialisation_function(websocket):
-    await assertSerialisation(
-        "function(){}",
-        {
-            "type":"function",
             "objectId":"__any_value__"
         },
         websocket)
@@ -929,49 +960,6 @@ async def _ignore_test_serialisation_error(websocket):
             "type":"error",
             "objectId":"__any_value__"
         },
-        websocket)
-
-# TODO: implement after serialisation MaxDepth logic specified:
-# https://github.com/w3c/webdriver-bidi/issues/86
-@pytest.mark.asyncio
-# Not implemented yet.
-async def _ignore_test_serialisation_array(websocket):
-    await assertSerialisation(
-        "[1, 'a', {foo: 'bar'}, [2,[3,4]]]",
-        {
-            "type":"array",
-            "objectId":"__any_value__",
-            "value":[{
-                "type":"number",
-                "value":1
-            },{
-                "type":"string",
-                "value":"a"
-            },{
-                "type":"object",
-                "objectId":"__any_value__"
-            },{
-                "type":"array",
-                "objectId":"__any_value__"}]},
-        websocket)
-
-# TODO: implement after serialisation MaxDepth logic specified:
-# https://github.com/w3c/webdriver-bidi/issues/86
-@pytest.mark.asyncio
-# Not implemented yet.
-async def _ignore_test_serialisation_object(websocket):
-    await assertSerialisation(
-        "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
-        {
-            "type":"object",
-            "objectId":"__any_value__",
-            "value":[[
-                "foo", {
-                    "type":"object",
-                    "objectId":"__any_value__"}],[
-                "qux", {
-                    "type":"string",
-                    "value":"quux"}]]},
         websocket)
 
 # TODO: add `NodeProperties` after serialisation MaxDepth logic specified:


### PR DESCRIPTION
* Adding unit tests for serialization/deserialization logic.

Referencing `eval.es` from `eval.spec.ts` wouldn't work, because `eval.es` is excluded from the compilation. So the test reads the script code and eval it, as Mapper will do in the page context.