### PR TITLE
Split `script.evaluate` into `eval` and `serialize`

### DIFF
--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -11,7 +11,7 @@ export namespace CommonDataTypes {
     text: string;
   }
   export interface StackTrace {
-    callFrames: [StackFrame];
+    callFrames: StackFrame[];
   }
   export interface StackFrame {
     url: string;

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -5,9 +5,9 @@ export namespace CommonDataTypes {
 
   export interface ExceptionDetails {
     columnNumber: number;
-    exception?: CommonDataTypes.RemoteValue;
+    exception: CommonDataTypes.RemoteValue;
     lineNumber: number;
-    stackTrace?: StackTrace;
+    stackTrace: StackTrace;
     text: string;
   }
   export interface StackTrace {

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -60,8 +60,8 @@ export class CommandProcessor {
   }
 
   private run() {
-    this._browserCdpClient.Target.on('attachedToTarget', (params) => {
-      this._contextProcessor.handleAttachedToTargetEvent(params);
+    this._browserCdpClient.Target.on('attachedToTarget', async (params) => {
+      await this._contextProcessor.handleAttachedToTargetEvent(params);
     });
     this._browserCdpClient.Target.on('targetInfoChanged', (params) => {
       this._contextProcessor.handleInfoChangedEvent(params);

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -46,14 +46,14 @@ export class BrowsingContextProcessor {
     this._onContextDestroyed = onContextDestroyed;
   }
 
-  private _getOrCreateContext(
+  private async _getOrCreateContext(
     contextId: string,
     cdpSessionId: string
-  ): Context {
+  ): Promise<Context> {
     let context = this._contexts.get(contextId);
     if (!context) {
       const sessionCdpClient = this._cdpConnection.sessionClient(cdpSessionId);
-      context = Context.create(contextId, sessionCdpClient);
+      context = await Context.create(contextId, sessionCdpClient);
       this._contexts.set(contextId, context);
     }
     return context;
@@ -69,13 +69,18 @@ export class BrowsingContextProcessor {
     return context;
   }
 
-  handleAttachedToTargetEvent(params: Protocol.Target.AttachedToTargetEvent) {
+  async handleAttachedToTargetEvent(
+    params: Protocol.Target.AttachedToTargetEvent
+  ) {
     logContext('AttachedToTarget event received', params);
 
     const { sessionId, targetInfo } = params;
     if (!this._isValidTarget(targetInfo)) return;
 
-    const context = this._getOrCreateContext(targetInfo.targetId, sessionId);
+    const context = await this._getOrCreateContext(
+      targetInfo.targetId,
+      sessionId
+    );
     context._updateTargetInfo(targetInfo);
 
     this._sessionToTargets.delete(sessionId);

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -161,7 +161,7 @@ export class BrowsingContextProcessor {
     );
     // TODO sadym: add arguments params after they are specified.
     // https://github.com/w3c/webdriver-bidi/pull/136#issuecomment-926700556
-    return await context.evaluateScript(
+    return await context.scriptEvaluate(
       params.expression,
       params.awaitPromise !== false // `awaitPromise` by default is `true`.
     );

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -161,7 +161,10 @@ export class BrowsingContextProcessor {
     );
     // TODO sadym: add arguments params after they are specified.
     // https://github.com/w3c/webdriver-bidi/pull/136#issuecomment-926700556
-    return await context.evaluateScript(params.expression);
+    return await context.evaluateScript(
+      params.expression,
+      params.awaitPromise !== false // `awaitPromise` by default is `true`.
+    );
   }
 
   _isValidTarget(target: Protocol.Target.TargetInfo) {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -148,7 +148,9 @@ export class BrowsingContextProcessor {
     });
   }
 
-  async process_script_evaluate(params: Script.ScriptEvaluateParameters): Promise<Script.ScriptEvaluateResult> {
+  async process_script_evaluate(
+    params: Script.ScriptEvaluateParameters
+  ): Promise<Script.ScriptEvaluateResult> {
     const context = this._getKnownContext(
       (params.target as Script.ContextTarget).context
     );

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -25,6 +25,8 @@ export class Context {
   _targetInfo?: Protocol.Target.TargetInfo;
   _sessionId?: string;
 
+  private _dummyContextObjectId: string = '';
+
   private constructor(
     private _contextId: string,
     private _cdpClient: CdpClient
@@ -40,6 +42,14 @@ export class Context {
     // Enabling Runtime doamin needed to have an exception stacktrace in
     // `evaluateScript`.
     await this._cdpClient.Runtime.enable();
+
+    // TODO sadym: `dummyContextObject` needed for the running context.
+    // Use the proper `executionContextId` instead:
+    // https://github.com/GoogleChromeLabs/chromium-bidi/issues/52
+    const dummyContextObject = await this._cdpClient.Runtime.evaluate({
+      expression: '(()=>{return {}})()',
+    });
+    this._dummyContextObjectId = dummyContextObject.result.objectId!;
   }
 
   _setSessionId(sessionId: string): void {
@@ -74,15 +84,9 @@ export class Context {
   private async _serializeCdpObject(
     cdpObject: Protocol.Runtime.RemoteObject
   ): Promise<CommonDataTypes.RemoteValue> {
-    // TODO sadym: `dummyContextObject` needed for the running context.
-    // Find a way to use the proper `executionContextId` instead.
-    const dummyContextObject = await this._cdpClient.Runtime.evaluate({
-      expression: '(()=>{return {}})()',
-    });
-
     const response = await this._cdpClient.Runtime.callFunctionOn({
       functionDeclaration: `${EVALUATOR_SCRIPT}.serialize`,
-      objectId: dummyContextObject.result.objectId,
+      objectId: this._dummyContextObjectId,
       arguments: [cdpObject],
       returnByValue: true,
     });
@@ -125,16 +129,15 @@ export class Context {
     };
   }
 
-  public async evaluateScript(
-    script: string,
+  public async scriptEvaluate(
+    expression: string,
     awaitPromise: boolean
   ): Promise<Script.ScriptEvaluateResult> {
     // Evaluate works with 2 DP calls:
-    // 1. Evaluates the script;
+    // 1. Evaluates the `script`;
     // 2. serializes the result or exception.
     // This needed to provide a detailed stacktrace in case of not `Error` but
     // anything else wihtout`stacktrace` is thrown.
-    const expression = script;
     const cdpEvaluateResult = await this._cdpClient.Runtime.evaluate({
       expression,
       awaitPromise,

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -70,6 +70,11 @@
         return result;
       }
 
+      if (value instanceof Promise) {
+        result.type = 'promise';
+        return result;
+      }
+
       if (Array.isArray(value)) {
         result.type = "array";
       } else {
@@ -123,6 +128,7 @@
       case 'boolean': {
         return value.value;
       }
+      case 'promise':
       case 'array':
       case 'function':
       case 'object': {

--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -153,19 +153,11 @@
   }
 
   function evaluate(script, args) {
-    try {
       const deserializedArgs = args.map((arg) => deserialize(arg));
-      const func = new Function(`return (${script})`);
+      const func = new Function(`return (\n${script}\n)`);
       const result = func.apply(null, deserializedArgs);
       const serializedResult = serialize(result);
-      return { result: serializedResult };
-    } catch (e) {
-      if (e instanceof Error) {
-        return { exceptionDetails: { message: e.message, stacktrace: e.stack } };
-      } else {
-        return { exceptionDetails: { value: serialize(e) } };
-      }
-    }
+      return serializedResult;
   };
 
   return {

--- a/src/bidiMapper/scripts/eval.spec.ts
+++ b/src/bidiMapper/scripts/eval.spec.ts
@@ -236,5 +236,15 @@ describe('Evaluator', function () {
                 }, ["objectId"]
             );
         });
+        it('promise', function () {
+            checkSerializeAndDeserialize(
+                Promise.resolve(),
+                {
+                    type: 'promise',
+                    objectId: '__any_value__'
+                },
+                ["objectId"]
+            );
+        });
     });
 });

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -26,6 +26,12 @@ async def websocket():
     async with websockets.connect(url) as connection:
         yield connection
 
+@pytest.fixture(autouse=True)
+async def before_each_test(websocket):
+    # Read initial event `browsingContext.contextCreated`
+    resp = await read_JSON_message(websocket)
+    assert resp['method'] == 'browsingContext.contextCreated'
+
 # Compares 2 objects recursively ignoring values of specific attributes.
 def recursiveCompare(expected, actual, ignoreAttributes):
     assert type(expected) == type(actual)


### PR DESCRIPTION
To provide a stacktrace in case of not-`Error` thrown, the exception should not be caught in the evaluated script itself.

Another advantage of splitting `eval` and `serialize` is there is no need in parsing text stacktrace from JS `Error` object, and no need in correction stacktrace positions because of the script wrapping.