### PR TITLE
Evaluate and serialize in the same call.

### DIFF
--- a/src/bidiMapper/scripts/eval.es
+++ b/src/bidiMapper/scripts/eval.es
@@ -158,16 +158,7 @@
       + '.' + (Math.random() + '').substr(2);
   }
 
-  function evaluate(script, args) {
-      const deserializedArgs = args.map((arg) => deserialize(arg));
-      const func = new Function(`return (\n${script}\n)`);
-      const result = func.apply(null, deserializedArgs);
-      const serializedResult = serialize(result);
-      return serializedResult;
-  };
-
   return {
-    evaluate,
     serialize,
     deserialize
   }

--- a/src/bidiMapper/scripts/eval.spec.ts
+++ b/src/bidiMapper/scripts/eval.spec.ts
@@ -25,7 +25,6 @@ chai.use(chaiExclude);
 
 describe('Evaluator', function () {
     let EVALUATOR: {
-        evaluate: Function,
         serialize: (x: any) => CommonDataTypes.RemoteValue,
         deserialize: (x: CommonDataTypes.RemoteValue) => any
     };

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -859,7 +859,18 @@ async def test_scriptEvaluateChangingObject_resultObjectDidNotChange(websocket):
         "id": 47,
         "method": "script.evaluate",
         "params": {
-            "expression": "(()=>{const a={i:0};const f=()=>{ setTimeout(()=>{ a.i++; f(); }, 0); };f();return a;})()",
+            # Create an object and schedule its property to be changed by
+            # `setTimeout(..., 0)`. This allows to verify if the object was
+            # serialized at the moment of the call or later.
+            "expression": """(() => {
+                const someObject = { i: 0 };
+                const changeObjectAfterCurrentJsThread = () => {
+                    setTimeout(() => {
+                            someObject.i++;
+                            changeObjectAfterCurrentJsThread(); },
+                        0); };
+                changeObjectAfterCurrentJsThread();
+                return someObject; })()""",
             "awaitPromise": True,
             "target": {"context": contextID}}})
 


### PR DESCRIPTION
I make this in separate PR to keep previous PR reviewable.

In this PR the [suggestion to avoid race condition](https://github.com/GoogleChromeLabs/chromium-bidi/pull/51#issuecomment-931737752) is implemented. Evaluation and serialization are done in the same call, and serialization results retrieved by another call.

`test_scriptEvaluateChangingObject_resultObjectDidNotChange` fails on the #51 but passes in this PR.