### PR TITLE
`create` and `navigate.browsingContext`

### DIFF
--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -95,6 +95,7 @@ export namespace Script {
 // https://w3c.github.io/webdriver-bidi/#module-browsingContext
 export namespace BrowsingContext {
   export type BrowsingContext = string;
+  export type Navigation = string;
 
   export type BrowsingContextGetTreeCommand = {
     method: 'browsingContext.getTree';
@@ -128,10 +129,29 @@ export namespace BrowsingContext {
   export type BrowsingContextCreateType = 'tab' | 'window';
 
   export type BrowsingContextCreateParameters = {
-    type: BrowsingContextCreateType;
+    type?: BrowsingContextCreateType;
   };
+
   export type BrowsingContextCreateResult = {
     context: BrowsingContext;
+  };
+
+  export type BrowsingContextNavigateCommand = {
+    method: 'browsingContext.navigate';
+    params: BrowsingContextNavigateParameters;
+  };
+
+  export type BrowsingContextNavigateParameters = {
+    context: BrowsingContext;
+    url: string;
+    wait?: ReadinessState;
+  };
+
+  export type ReadinessState = 'none';
+  // TODO sadym: implement 'interactive' and 'complete' states.
+  export type BrowsingContextNavigateResult = {
+    navigation?: Navigation;
+    url: string;
   };
 }
 

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -136,23 +136,25 @@ export namespace BrowsingContext {
     context: BrowsingContext;
   };
 
-  export type BrowsingContextNavigateCommand = {
-    method: 'browsingContext.navigate';
-    params: BrowsingContextNavigateParameters;
-  };
+  export namespace PROTO {
+    export type BrowsingContextNavigateCommand = {
+      method: 'PROTO.browsingContext.navigate';
+      params: BrowsingContextNavigateParameters;
+    };
 
-  export type BrowsingContextNavigateParameters = {
-    context: BrowsingContext;
-    url: string;
-    wait?: ReadinessState;
-  };
+    export type BrowsingContextNavigateParameters = {
+      context: BrowsingContext;
+      url: string;
+      wait?: ReadinessState;
+    };
 
-  export type ReadinessState = 'none';
-  // TODO sadym: implement 'interactive' and 'complete' states.
-  export type BrowsingContextNavigateResult = {
-    navigation?: Navigation;
-    url: string;
-  };
+    export type ReadinessState = 'none';
+    // TODO sadym: implement 'interactive' and 'complete' states.
+    export type BrowsingContextNavigateResult = {
+      navigation?: Navigation;
+      url: string;
+    };
+  }
 }
 
 export namespace Session {

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -120,22 +120,6 @@ export namespace BrowsingContext {
     children: BrowsingContextInfoList;
   };
 
-  // `browsingContext.create`
-  export type BrowsingContextCreateCommand = {
-    method: 'browsingContext.create';
-    params: BrowsingContextCreateParameters;
-  };
-
-  export type BrowsingContextCreateType = 'tab' | 'window';
-
-  export type BrowsingContextCreateParameters = {
-    type?: BrowsingContextCreateType;
-  };
-
-  export type BrowsingContextCreateResult = {
-    context: BrowsingContext;
-  };
-
   export type BrowsingContextNavigateCommand = {
     method: 'browsingContext.navigate';
     params: BrowsingContextNavigateParameters;
@@ -154,7 +138,24 @@ export namespace BrowsingContext {
     url: string;
   };
 
-  export namespace PROTO {}
+  export namespace PROTO {
+    // `browsingContext.create`:
+    // https://github.com/w3c/webdriver-bidi/pull/133
+    export type BrowsingContextCreateCommand = {
+      method: 'PROTO.browsingContext.create';
+      params: BrowsingContextCreateParameters;
+    };
+
+    export type BrowsingContextCreateType = 'tab' | 'window';
+
+    export type BrowsingContextCreateParameters = {
+      type?: BrowsingContextCreateType;
+    };
+
+    export type BrowsingContextCreateResult = {
+      context: BrowsingContext;
+    };
+  }
 }
 
 export namespace Session {

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -136,25 +136,25 @@ export namespace BrowsingContext {
     context: BrowsingContext;
   };
 
-  export namespace PROTO {
-    export type BrowsingContextNavigateCommand = {
-      method: 'PROTO.browsingContext.navigate';
-      params: BrowsingContextNavigateParameters;
-    };
+  export type BrowsingContextNavigateCommand = {
+    method: 'browsingContext.navigate';
+    params: BrowsingContextNavigateParameters;
+  };
 
-    export type BrowsingContextNavigateParameters = {
-      context: BrowsingContext;
-      url: string;
-      wait?: ReadinessState;
-    };
+  export type BrowsingContextNavigateParameters = {
+    context: BrowsingContext;
+    url: string;
+    wait?: ReadinessState;
+  };
 
-    export type ReadinessState = 'none';
-    // TODO sadym: implement 'interactive' and 'complete' states.
-    export type BrowsingContextNavigateResult = {
-      navigation?: Navigation;
-      url: string;
-    };
-  }
+  export type ReadinessState = 'none';
+  // TODO sadym: implement 'interactive' and 'complete' states.
+  export type BrowsingContextNavigateResult = {
+    navigation?: Navigation;
+    url: string;
+  };
+
+  export namespace PROTO {}
 }
 
 export namespace Session {

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -179,11 +179,11 @@ export class CommandProcessor {
         return await this._contextProcessor.process_browsingContext_create(
           commandData as BrowsingContext.BrowsingContextCreateCommand
         );
-      case 'browsingContext.navigate':
-        return await this._contextProcessor.process_browsingContext_navigate(
-          commandData as BrowsingContext.BrowsingContextNavigateCommand
-        );
 
+      case 'PROTO.browsingContext.navigate':
+        return await this._contextProcessor.process_PROTO_browsingContext_navigate(
+          commandData as BrowsingContext.PROTO.BrowsingContextNavigateCommand
+        );
       case 'PROTO.script.invoke':
         return await this._contextProcessor.process_PROTO_script_invoke(
           commandData as Script.PROTO.ScriptInvokeCommand

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -185,6 +185,10 @@ export class CommandProcessor {
         return await this._contextProcessor.process_createContext(
           commandData as BrowsingContext.BrowsingContextCreateCommand
         );
+      case 'browsingContext.navigate':
+        return await this._contextProcessor.process_navigate(
+          commandData as BrowsingContext.BrowsingContextNavigateCommand
+        );
 
       case 'PROTO.script.invoke':
         return await this._contextProcessor.process_PROTO_script_invoke(

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -179,11 +179,11 @@ export class CommandProcessor {
         return await this._contextProcessor.process_browsingContext_create(
           commandData as BrowsingContext.BrowsingContextCreateCommand
         );
-
-      case 'PROTO.browsingContext.navigate':
-        return await this._contextProcessor.process_PROTO_browsingContext_navigate(
-          commandData as BrowsingContext.PROTO.BrowsingContextNavigateCommand
+      case 'browsingContext.navigate':
+        return await this._contextProcessor.process_browsingContext_navigate(
+          commandData as BrowsingContext.BrowsingContextNavigateCommand
         );
+
       case 'PROTO.script.invoke':
         return await this._contextProcessor.process_PROTO_script_invoke(
           commandData as Script.PROTO.ScriptInvokeCommand

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -64,16 +64,6 @@ export class CommandProcessor {
   }
 
   private run() {
-    this._browserCdpClient.Target.on('attachedToTarget', async (params) => {
-      await this._contextProcessor.handleAttachedToTargetEvent(params);
-    });
-    this._browserCdpClient.Target.on('targetInfoChanged', (params) => {
-      this._contextProcessor.handleInfoChangedEvent(params);
-    });
-    this._browserCdpClient.Target.on('detachedFromTarget', (params) => {
-      this._contextProcessor.handleDetachedFromTargetEvent(params);
-    });
-
     this._bidiServer.on('message', (messageObj) => {
       return this._onBidiMessage(messageObj);
     });
@@ -186,11 +176,11 @@ export class CommandProcessor {
           commandData as Script.ScriptEvaluateCommand
         );
       case 'browsingContext.create':
-        return await this._contextProcessor.process_createContext(
+        return await this._contextProcessor.process_browsingContext_create(
           commandData as BrowsingContext.BrowsingContextCreateCommand
         );
       case 'browsingContext.navigate':
-        return await this._contextProcessor.process_navigate(
+        return await this._contextProcessor.process_browsingContext_navigate(
           commandData as BrowsingContext.BrowsingContextNavigateCommand
         );
 

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -29,12 +29,14 @@ export class CommandProcessor {
   static run(
     cdpConnection: CdpConnection,
     bidiServer: IBidiServer,
-    selfTargetId: string
+    selfTargetId: string,
+    EVALUATOR_SCRIPT: string
   ) {
     const commandProcessor = new CommandProcessor(
       cdpConnection,
       bidiServer,
-      selfTargetId
+      selfTargetId,
+      EVALUATOR_SCRIPT
     );
 
     commandProcessor.run();
@@ -43,7 +45,8 @@ export class CommandProcessor {
   private constructor(
     private _cdpConnection: CdpConnection,
     private _bidiServer: IBidiServer,
-    private _selfTargetId: string
+    private _selfTargetId: string,
+    EVALUATOR_SCRIPT: string
   ) {
     this._browserCdpClient = this._cdpConnection.browserClient();
 
@@ -55,7 +58,8 @@ export class CommandProcessor {
       },
       (t: Context) => {
         return this._onContextDestroyed(t);
-      }
+      },
+      EVALUATOR_SCRIPT
     );
   }
 

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -175,9 +175,9 @@ export class CommandProcessor {
         return await this._contextProcessor.process_script_evaluate(
           commandData as Script.ScriptEvaluateCommand
         );
-      case 'browsingContext.create':
-        return await this._contextProcessor.process_browsingContext_create(
-          commandData as BrowsingContext.BrowsingContextCreateCommand
+      case 'PROTO.browsingContext.create':
+        return await this._contextProcessor.process_PROTO_browsingContext_create(
+          commandData as BrowsingContext.PROTO.BrowsingContextCreateCommand
         );
       case 'browsingContext.navigate':
         return await this._contextProcessor.process_browsingContext_navigate(

--- a/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StubTransport } from '../../../tests/stubTransport.spec';
+
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import * as sinon from 'sinon';
+
+import { BrowsingContextProcessor } from './browsingContextProcessor';
+import { CdpConnection, CdpClient } from '../../../cdp';
+import { Context } from './context';
+import { BrowsingContext } from '../../bidiProtocolTypes';
+
+describe('BrowsingContextProcessor', function () {
+  let mockCdpServer: StubTransport;
+  let browsingContextProcessor: BrowsingContextProcessor;
+
+  beforeEach(async function () {
+    mockCdpServer = new StubTransport();
+
+    const onContextCreated = sinon.fake as unknown as (
+      t: Context
+    ) => Promise<void>;
+    const onContextDestroyed = sinon.fake as unknown as (
+      t: Context
+    ) => Promise<void>;
+
+    browsingContextProcessor = new BrowsingContextProcessor(
+      new CdpConnection(mockCdpServer),
+      'SELF_TARGET_ID',
+      onContextCreated,
+      onContextDestroyed,
+      'EVALUATOR_SCRIPT'
+    );
+
+    // Actual `Context.create` logic involves several CDP calls, so mock it to avoid all the simulations.
+    Context.create = async (
+      contextId: string,
+      cdpClient: CdpClient,
+      EVALUATOR_SCRIPT: string
+    ) => {
+      return sinon.createStubInstance(Context) as unknown as Context;
+    };
+  });
+
+  describe('`process_browsingContext_create`', async function () {
+    const NEW_CONTEXT_ID = 'NEW_CONTEXT_ID';
+
+    const BROWSING_CONTEXT_CREATE_COMMAND: BrowsingContext.BrowsingContextCreateCommand =
+      {
+        method: 'browsingContext.create',
+        params: {},
+      };
+
+    const EXPECTED_TARGET_CREATE_TARGET_CALL = {
+      id: 0,
+      method: 'Target.createTarget',
+      params: {
+        url: 'about:blank',
+        newWindow: false,
+      },
+    };
+
+    const TARGET_CREATE_TARGET_RESPONSE = {
+      id: 0,
+      result: {
+        targetId: NEW_CONTEXT_ID,
+      },
+    };
+
+    const TARGET_ATTACHED_TO_TARGET_EVENT = {
+      method: 'Target.attachedToTarget',
+      params: {
+        sessionId: '_ANY_VALUE_',
+        targetInfo: {
+          targetId: NEW_CONTEXT_ID,
+          type: 'page',
+          title: '',
+          url: '',
+          attached: true,
+          canAccessOpener: false,
+          browserContextId: '_ANY_ANOTHER_VALUE_',
+        },
+        waitingForDebugger: false,
+      },
+    };
+
+    it('Target.attachedToTarget before command finished', async function () {
+      const createResultPromise =
+        browsingContextProcessor.process_browsingContext_create(
+          BROWSING_CONTEXT_CREATE_COMMAND
+        );
+
+      sinon.assert.calledOnceWithExactly(
+        mockCdpServer.sendMessage,
+        JSON.stringify(EXPECTED_TARGET_CREATE_TARGET_CALL)
+      );
+
+      await mockCdpServer.emulateIncomingMessage(
+        TARGET_ATTACHED_TO_TARGET_EVENT
+      );
+
+      await mockCdpServer.emulateIncomingMessage(TARGET_CREATE_TARGET_RESPONSE);
+
+      await createResultPromise;
+    });
+
+    it('Target.attachedToTarget after command finished', async function () {
+      const createResultPromise =
+        browsingContextProcessor.process_browsingContext_create(
+          BROWSING_CONTEXT_CREATE_COMMAND
+        );
+
+      sinon.assert.calledOnceWithExactly(
+        mockCdpServer.sendMessage,
+        JSON.stringify(EXPECTED_TARGET_CREATE_TARGET_CALL)
+      );
+
+      await mockCdpServer.emulateIncomingMessage(TARGET_CREATE_TARGET_RESPONSE);
+
+      await mockCdpServer.emulateIncomingMessage(
+        TARGET_ATTACHED_TO_TARGET_EVENT
+      );
+
+      await createResultPromise;
+    });
+  });
+});

--- a/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
@@ -58,8 +58,8 @@ describe('BrowsingContextProcessor', function () {
     browsingContextProcessor = new BrowsingContextProcessor(
       cdpConnection,
       'SELF_TARGET_ID',
-      sinon.fake as unknown as (t: Context) => Promise<void>,
-      sinon.fake as unknown as (t: Context) => Promise<void>,
+      sinon.fake(),
+      sinon.fake(),
       EVALUATOR_SCRIPT
     );
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
@@ -86,10 +86,10 @@ describe('BrowsingContextProcessor', function () {
     });
   });
 
-  describe('handle `process_browsingContext_create`', async function () {
-    const BROWSING_CONTEXT_CREATE_COMMAND: BrowsingContext.BrowsingContextCreateCommand =
+  describe('handle `process_PROTO_browsingContext_create`', async function () {
+    const BROWSING_CONTEXT_CREATE_COMMAND: BrowsingContext.PROTO.BrowsingContextCreateCommand =
       {
-        method: 'browsingContext.create',
+        method: 'PROTO.browsingContext.create',
         params: {},
       };
 
@@ -111,7 +111,7 @@ describe('BrowsingContextProcessor', function () {
 
     it('Target.attachedToTarget before command finished', async function () {
       const createResultPromise =
-        browsingContextProcessor.process_browsingContext_create(
+        browsingContextProcessor.process_PROTO_browsingContext_create(
           BROWSING_CONTEXT_CREATE_COMMAND
         );
 
@@ -131,7 +131,7 @@ describe('BrowsingContextProcessor', function () {
 
     it('Target.attachedToTarget after command finished', async function () {
       const createResultPromise =
-        browsingContextProcessor.process_browsingContext_create(
+        browsingContextProcessor.process_PROTO_browsingContext_create(
           BROWSING_CONTEXT_CREATE_COMMAND
         );
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -16,7 +16,7 @@
  */
 
 import { log } from '../../../utils/log';
-import { CdpConnection } from '../../../cdp';
+import { CdpConnection, CdpClient } from '../../../cdp';
 import { Context } from './context';
 import { BrowsingContext, Script } from '../../bidiProtocolTypes';
 import Protocol from 'devtools-protocol';
@@ -24,7 +24,7 @@ import Protocol from 'devtools-protocol';
 const logContext = log('context');
 
 export class BrowsingContextProcessor {
-  private _contexts: Map<string, Context> = new Map();
+  private _contexts: Map<string, Promise<Context>> = new Map();
   private _sessionToTargets: Map<string, Context> = new Map();
 
   // Set from outside.
@@ -45,36 +45,56 @@ export class BrowsingContextProcessor {
     this._selfTargetId = selfTargetId;
     this._onContextCreated = onContextCreated;
     this._onContextDestroyed = onContextDestroyed;
+
+    this._setCdpEventListeners(this._cdpConnection.browserClient());
   }
 
+  private _setCdpEventListeners(browserCdpClient: CdpClient) {
+    browserCdpClient.Target.on('attachedToTarget', async (params) => {
+      await this._handleAttachedToTargetEvent(params);
+    });
+    browserCdpClient.Target.on('targetInfoChanged', (params) => {
+      this._handleInfoChangedEvent(params);
+    });
+    browserCdpClient.Target.on('detachedFromTarget', (params) => {
+      this._handleDetachedFromTargetEvent(params);
+    });
+  }
+
+  // Creation of `Context` can take quite a while. To avoid race condition, in
+  // the map kept Pmomise, eventualy resolved with the`Context`.
   private async _getOrCreateContext(
     contextId: string,
     cdpSessionId: string
   ): Promise<Context> {
-    let context = this._contexts.get(contextId);
-    if (!context) {
-      const sessionCdpClient = this._cdpConnection.sessionClient(cdpSessionId);
-      context = await Context.create(
+    let contextPromise = this._contexts.get(contextId);
+    if (!contextPromise) {
+      const sessionCdpClient = this._cdpConnection.getCdpClient(cdpSessionId);
+
+      // Don't wait for actual creation. Just put the Promise into map.
+      contextPromise = Context.create(
         contextId,
         sessionCdpClient,
         this.EVALUATOR_SCRIPT
       );
-      this._contexts.set(contextId, context);
+      this._contexts.set(contextId, contextPromise);
     }
-    return context;
+    return contextPromise;
   }
 
-  private _tryGetContext(contextId: string): Context | undefined {
-    return this._contexts.get(contextId);
+  private async _tryGetContext(
+    contextId: string
+  ): Promise<Context | undefined> {
+    return await this._contexts.get(contextId);
   }
 
-  private _getKnownContext(contextId: string): Context {
-    const context = this._contexts.get(contextId);
+  private async _getKnownContext(contextId: string): Promise<Context> {
+    const context = await this._contexts.get(contextId);
     if (!context) throw new Error('context not found');
     return context;
   }
 
-  async handleAttachedToTargetEvent(
+  private async _handleAttachedToTargetEvent(
     params: Protocol.Target.AttachedToTargetEvent
   ) {
     logContext('AttachedToTarget event received', params);
@@ -87,37 +107,40 @@ export class BrowsingContextProcessor {
       sessionId
     );
     context._updateTargetInfo(targetInfo);
-
     this._sessionToTargets.delete(sessionId);
-
     this._sessionToTargets.set(sessionId, context);
-
-    // context._setSessionId(eventData.params.sessionId);
+    context._setSessionId(sessionId);
 
     this._onContextCreated(context);
   }
 
-  handleInfoChangedEvent(params: Protocol.Target.TargetInfoChangedEvent) {
+  private async _handleInfoChangedEvent(
+    params: Protocol.Target.TargetInfoChangedEvent
+  ) {
     logContext('infoChangedEvent event received', params);
 
     const targetInfo = params.targetInfo;
     if (!this._isValidTarget(targetInfo)) return;
 
-    const context = this._tryGetContext(targetInfo.targetId);
+    const context = await this._tryGetContext(targetInfo.targetId);
     if (context) {
       context._onInfoChangedEvent(targetInfo);
     }
   }
 
-  // { "method": "Target.detachedFromTarget", "params": { "sessionId": "7EFBFB2A4942A8989B3EADC561BC46E9", "targetId": "19416886405CBA4E03DBB59FA67FF4E8" } }
-  handleDetachedFromTargetEvent(
+  // { "method": "Target.detachedFromTarget",
+  //   "params": {
+  //     "sessionId": "7EFBFB2A4942A8989B3EADC561BC46E9",
+  //     "targetId": "19416886405CBA4E03DBB59FA67FF4E8" } }
+  private async _handleDetachedFromTargetEvent(
     params: Protocol.Target.DetachedFromTargetEvent
   ) {
     logContext('detachedFromTarget event received', params);
 
-    // TODO: params.targetId is deprecated. Update this class to track using params.sessionId instead.
+    // TODO: params.targetId is deprecated. Update this class to track using
+    // params.sessionId instead.
     const targetId = params.targetId!;
-    const context = this._tryGetContext(targetId);
+    const context = await this._tryGetContext(targetId);
     if (context) {
       this._onContextDestroyed(context);
 
@@ -127,13 +150,26 @@ export class BrowsingContextProcessor {
     }
   }
 
-  async process_createContext(
+  async process_browsingContext_create(
     commandData: BrowsingContext.BrowsingContextCreateCommand
   ): Promise<BrowsingContext.BrowsingContextCreateResult> {
     const params = commandData.params;
 
     return new Promise(async (resolve) => {
-      let targetId: string;
+      const browserCdpClient = this._cdpConnection.browserClient();
+
+      const result = await browserCdpClient.Target.createTarget({
+        url: 'about:blank',
+        newWindow: params.type === 'window',
+      });
+
+      const targetId = result.targetId;
+
+      const existingContext = await this._tryGetContext(targetId);
+      if (existingContext) {
+        resolve(existingContext.toBidi());
+        return;
+      }
 
       const onAttachedToTarget = async (
         attachToTargetEventParams: Protocol.Target.AttachedToTargetEvent
@@ -152,22 +188,15 @@ export class BrowsingContextProcessor {
         }
       };
 
-      const browserCdpClient = this._cdpConnection.browserClient();
       browserCdpClient.Target.on('attachedToTarget', onAttachedToTarget);
-
-      const result = await browserCdpClient.Target.createTarget({
-        url: 'about:blank',
-        newWindow: params.type === 'window',
-      });
-      targetId = result.targetId;
     });
   }
 
-  async process_navigate(
+  async process_browsingContext_navigate(
     commandData: BrowsingContext.BrowsingContextNavigateCommand
   ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
     const params = commandData.params;
-    const context = this._getKnownContext(params.context);
+    const context = await this._getKnownContext(params.context);
 
     return await context.navigate(params.url, params.wait);
   }
@@ -176,7 +205,7 @@ export class BrowsingContextProcessor {
     commandData: Script.ScriptEvaluateCommand
   ): Promise<Script.ScriptEvaluateResult> {
     const params = commandData.params;
-    const context = this._getKnownContext(
+    const context = await this._getKnownContext(
       (params.target as Script.ContextTarget).context
     );
     return await context.scriptEvaluate(
@@ -189,7 +218,7 @@ export class BrowsingContextProcessor {
     commandData: Script.PROTO.ScriptInvokeCommand
   ): Promise<Script.PROTO.ScriptInvokeResult> {
     const params = commandData.params;
-    const context = this._getKnownContext(
+    const context = await this._getKnownContext(
       (params.target as Script.ContextTarget).context
     );
     return await context.PROTO_scriptInvoke(

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -192,9 +192,9 @@ export class BrowsingContextProcessor {
     });
   }
 
-  async process_browsingContext_navigate(
-    commandData: BrowsingContext.BrowsingContextNavigateCommand
-  ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
+  async process_PROTO_browsingContext_navigate(
+    commandData: BrowsingContext.PROTO.BrowsingContextNavigateCommand
+  ): Promise<BrowsingContext.PROTO.BrowsingContextNavigateResult> {
     const params = commandData.params;
     const context = await this._getKnownContext(params.context);
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -61,8 +61,8 @@ export class BrowsingContextProcessor {
     });
   }
 
-  // Creation of `Context` can take quite a while. To avoid race condition, in
-  // the map kept Pmomise, eventualy resolved with the`Context`.
+  // Creation of `Context` can take quite a while. To avoid race condition, keep
+  // a Promise in the map, eventually resolved with the `Context`.
   private async _getOrCreateContext(
     contextId: string,
     cdpSessionId: string

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -150,9 +150,9 @@ export class BrowsingContextProcessor {
     }
   }
 
-  async process_browsingContext_create(
-    commandData: BrowsingContext.BrowsingContextCreateCommand
-  ): Promise<BrowsingContext.BrowsingContextCreateResult> {
+  async process_PROTO_browsingContext_create(
+    commandData: BrowsingContext.PROTO.BrowsingContextCreateCommand
+  ): Promise<BrowsingContext.PROTO.BrowsingContextCreateResult> {
     const params = commandData.params;
 
     return new Promise(async (resolve) => {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -38,7 +38,8 @@ export class BrowsingContextProcessor {
     cdpConnection: CdpConnection,
     selfTargetId: string,
     onContextCreated: (t: Context) => Promise<void>,
-    onContextDestroyed: (t: Context) => Promise<void>
+    onContextDestroyed: (t: Context) => Promise<void>,
+    private EVALUATOR_SCRIPT: string
   ) {
     this._cdpConnection = cdpConnection;
     this._selfTargetId = selfTargetId;
@@ -53,7 +54,11 @@ export class BrowsingContextProcessor {
     let context = this._contexts.get(contextId);
     if (!context) {
       const sessionCdpClient = this._cdpConnection.sessionClient(cdpSessionId);
-      context = await Context.create(contextId, sessionCdpClient);
+      context = await Context.create(
+        contextId,
+        sessionCdpClient,
+        this.EVALUATOR_SCRIPT
+      );
       this._contexts.set(contextId, context);
     }
     return context;

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -192,9 +192,9 @@ export class BrowsingContextProcessor {
     });
   }
 
-  async process_PROTO_browsingContext_navigate(
-    commandData: BrowsingContext.PROTO.BrowsingContextNavigateCommand
-  ): Promise<BrowsingContext.PROTO.BrowsingContextNavigateResult> {
+  async process_browsingContext_navigate(
+    commandData: BrowsingContext.BrowsingContextNavigateCommand
+  ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
     const params = commandData.params;
     const context = await this._getKnownContext(params.context);
 

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -89,8 +89,8 @@ export class Context {
 
   public async navigate(
     url: string,
-    wait: BrowsingContext.PROTO.ReadinessState = 'none'
-  ): Promise<BrowsingContext.PROTO.BrowsingContextNavigateResult> {
+    wait: BrowsingContext.ReadinessState = 'none'
+  ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
     // TODO sadym: implement.
     if (wait !== 'none') {
       throw new Error(`Not implenented wait '${wait}'`);

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -89,8 +89,8 @@ export class Context {
 
   public async navigate(
     url: string,
-    wait: BrowsingContext.ReadinessState = 'none'
-  ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
+    wait: BrowsingContext.PROTO.ReadinessState = 'none'
+  ): Promise<BrowsingContext.PROTO.BrowsingContextNavigateResult> {
     // TODO sadym: implement.
     if (wait !== 'none') {
       throw new Error(`Not implenented wait '${wait}'`);

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -17,7 +17,11 @@
 
 import { Protocol } from 'devtools-protocol';
 import { CdpClient } from '../../../cdp';
-import { Script, CommonDataTypes } from '../../bidiProtocolTypes';
+import {
+  BrowsingContext,
+  CommonDataTypes,
+  Script,
+} from '../../bidiProtocolTypes';
 
 import EVALUATOR_SCRIPT from '../../scripts/eval.es';
 
@@ -77,6 +81,23 @@ export class Context {
       context: this._targetInfo!.targetId,
       parent: this._targetInfo!.openerId ? this._targetInfo!.openerId : null,
       url: this._targetInfo!.url,
+    };
+  }
+
+  public async navigate(
+    url: string,
+    wait: BrowsingContext.ReadinessState = 'none'
+  ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
+    // TODO sadym: implement.
+    if (wait !== 'none') {
+      throw new Error(`Not implenented wait '${wait}'`);
+    }
+
+    const cdpNavigateResult = await this._cdpClient.Page.navigate({ url });
+
+    return {
+      navigation: cdpNavigateResult.loaderId,
+      url: url,
     };
   }
 

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -89,7 +89,7 @@ export class Context {
 
   public async navigate(
     url: string,
-    wait: BrowsingContext.ReadinessState = 'none'
+    wait: BrowsingContext.ReadinessState
   ): Promise<BrowsingContext.BrowsingContextNavigateResult> {
     // TODO sadym: implement.
     if (wait !== 'none') {

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -21,6 +21,8 @@ import { CdpClient, CdpConnection } from '../cdp';
 import { BidiServer } from './utils/bidiServer';
 import { ITransport } from '../utils/transport';
 
+import EVALUATOR_SCRIPT from './scripts/eval.es';
+
 import { log } from '../utils/log';
 const logSystem = log('system');
 
@@ -60,7 +62,12 @@ const _waitSelfTargetIdPromise = _waitSelfTargetId();
 
   // The command processor needs to start running before calling _prepareCdp
   // so that it has a chance to set up event listeners for tracking targets.
-  CommandProcessor.run(cdpConnection, bidiServer, selfTargetId);
+  CommandProcessor.run(
+    cdpConnection,
+    bidiServer,
+    selfTargetId,
+    EVALUATOR_SCRIPT
+  );
 
   // Needed to get events about new targets.
   await _prepareCdp(cdpClient);

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -67,7 +67,7 @@ export class CdpConnection {
    * @param sessionId The sessionId of the CdpClient to retrieve.
    * @returns The CdpClient object attached to the given session, or null if the session is not attached.
    */
-  sessionClient(sessionId: string): CdpClient {
+  getCdpClient(sessionId: string): CdpClient {
     const cdpClient = this._sessionCdpClients.get(sessionId);
     if (!cdpClient) {
       throw new Error('Unknown CDP session ID');

--- a/src/mapperServer.ts
+++ b/src/mapperServer.ts
@@ -130,7 +130,7 @@ export class MapperServer {
     const { sessionId: mapperSessionId } =
       await browserClient.Target.attachToTarget({ targetId, flatten: true });
 
-    const mapperCdpClient = cdpConnection.sessionClient(mapperSessionId);
+    const mapperCdpClient = cdpConnection.getCdpClient(mapperSessionId);
     if (!mapperCdpClient) {
       throw new Error('Unable to connect to mapper CDP target');
     }

--- a/src/tests/stubTransport.spec.ts
+++ b/src/tests/stubTransport.spec.ts
@@ -32,9 +32,15 @@ export class StubTransport implements ITransport {
   sendMessage: TypedSpy<ITransport['sendMessage']>;
   close: TypedSpy<ITransport['close']>;
 
-  getOnMessage(): (string: string) => void {
+  private _getOnMessage(): (string: string) => void {
     assert.called(this.setOnMessage);
     return this.setOnMessage.getCall(0).args[0];
+  }
+
+  public async emulateIncomingMessage(messageObject: unknown) {
+    this._getOnMessage()(JSON.stringify(messageObject));
+    // `setTimeout` allows the message to be processed.
+    await new Promise((resolve) => setTimeout(resolve, 0));
   }
 
   constructor() {

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -169,12 +169,12 @@ async def ignore_test_getTreeWithNestedContexts_contextReturned(websocket):
     # TODO sadym: implement
 
 @pytest.mark.asyncio
-async def test_createContext_eventContextCreatedEmittedAndContextCreated(websocket):
+async def test_PROTO_browsingContextCreate_eventContextCreatedEmittedAndContextCreated(websocket):
     initialContextID = await get_open_context_id(websocket)
 
     command = {
         "id": 9,
-        "method": "browsingContext.create",
+        "method": "PROTO.browsingContext.create",
         "params": {}}
     await send_JSON_command(websocket, command)
 

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -220,30 +220,39 @@ async def _ignore_test_PageClose_browsingContextContextDestroyedEmitted(websocke
             "url": "about:blank"}}
 
 @pytest.mark.asyncio
-# Not implemented yet.
-async def _ignore_test_navigate_eventPageLoadEmittedAndNavigated(websocket):
+async def test_navigateWaitNone_navigated(websocket):
     contextID = await get_open_context_id(websocket)
 
     # Send command.
     command = {
         "id": 15,
-        "method": "PROTO.browsingContext.navigate",
+        "method": "browsingContext.navigate",
         "params": {
             "url": "data:text/html,<h2>test</h2>",
-            "waitUntil": ["load", "domcontentloaded", "networkidle0", "networkidle2"],
+            "wait": "none",
             "context": contextID}}
     await send_JSON_command(websocket, command)
 
-    # Assert "DEBUG.Page.load" event emitted.
-    resp = await read_JSON_message(websocket)
-    assert resp == {
-        "method": "DEBUG.Page.load",
-        "params": {
-            "context": contextID}}
-
     # Assert command done.
     resp = await read_JSON_message(websocket)
-    assert resp == {"id": 15, "result": {}}
+    recursiveCompare(
+        resp,
+        {
+            "id": 15,
+            "result": {
+                "navigation": "F595626837D41F9A72482D53B0C22F25",
+                "url": "data:text/html,<h2>test</h2>"}},
+        ["navigation"])
+
+@pytest.mark.asyncio
+# Not implemented yet.
+async def _ignore_test_navigateWaitInteractive_navigated(websocket):
+    ignore = True
+
+@pytest.mark.asyncio
+# Not implemented yet.
+async def _ignore_test_navigateWaitComplete_navigated(websocket):
+    ignore = True
 
 @pytest.mark.asyncio
 # Not implemented yet.

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -239,13 +239,13 @@ async def _ignore_test_PageClose_browsingContextContextDestroyedEmitted(websocke
             "url": "about:blank"}}
 
 @pytest.mark.asyncio
-async def test_navigateWaitNone_navigated(websocket):
+async def test_PROTO_navigateWaitNone_navigated(websocket):
     contextID = await get_open_context_id(websocket)
 
     # Send command.
     command = {
         "id": 15,
-        "method": "browsingContext.navigate",
+        "method": "PROTO.browsingContext.navigate",
         "params": {
             "url": "data:text/html,<h2>test</h2>",
             "wait": "none",
@@ -265,17 +265,17 @@ async def test_navigateWaitNone_navigated(websocket):
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_navigateWaitInteractive_navigated(websocket):
+async def _ignore_test_PROTO_navigateWaitInteractive_navigated(websocket):
     ignore = True
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_navigateWaitComplete_navigated(websocket):
+async def _ignore_test_PROTO_navigateWaitComplete_navigated(websocket):
     ignore = True
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_navigateWithShortTimeout_timeoutOccuredAndEventPageLoadEmitted(websocket):
+async def _ignore_test_PROTO_navigateWithShortTimeout_timeoutOccuredAndEventPageLoadEmitted(websocket):
     contextID = await get_open_context_id(websocket)
 
     # Send command.

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -169,9 +169,9 @@ async def ignore_test_getTreeWithNestedContexts_contextReturned(websocket):
     # TODO sadym: implement
 
 @pytest.mark.asyncio
-# Not implemented yet.
-async def _ignore_test_createContext_eventContextCreatedEmittedAndContextCreated(websocket):
-    # Send command.
+async def test_createContext_eventContextCreatedEmittedAndContextCreated(websocket):
+    initialContextID = await get_open_context_id(websocket)
+
     command = {
         "id": 9,
         "method": "browsingContext.create",
@@ -180,11 +180,11 @@ async def _ignore_test_createContext_eventContextCreatedEmittedAndContextCreated
 
     # Assert "browsingContext.contextCreated" event emitted.
     resp = await read_JSON_message(websocket)
-    contextID = resp['params']['context']
+    newContextID = resp['params']['context']
     assert resp == {
         "method": "browsingContext.contextCreated",
         "params": {
-            "context":contextID,
+            "context": newContextID,
             "parent": None,
             "url": ""}}
 
@@ -193,9 +193,28 @@ async def _ignore_test_createContext_eventContextCreatedEmittedAndContextCreated
     assert resp == {
         "id": 9,
         "result": {
-            "context": contextID,
+            "context": newContextID,
             "parent": None,
             "url": ""}}
+
+    # Get all contexts and assert new context is created.
+    command = {"id": 10, "method": "browsingContext.getTree", "params": {}}
+    await send_JSON_command(websocket, command)
+
+    # Assert "browsingContext.getTree" command done.
+    # TODO sadym: make order-agnostic. Maybe order by `context`?
+    resp = await read_JSON_message(websocket)
+    assert resp == {
+        "id": 10,
+        "result": {
+            "contexts": [{
+                "context": newContextID,
+                "url": "about:blank",
+                "children": []
+            }, {
+                "context": initialContextID,
+                "url": "about:blank",
+                "children": [] }]}}
 
 @pytest.mark.asyncio
 # Not implemented yet.

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -71,10 +71,10 @@ async def read_JSON_message(websocket):
 
 # Open given URL in the given context.
 async def goto_url(websocket, contextID, url):
-    # Send "PROTO.browsingContext.navigate" command.
+    # Send "browsingContext.navigate" command.
     command = {
         "id": 9998,
-        "method": "PROTO.browsingContext.navigate",
+        "method": "browsingContext.navigate",
         "params": {
             "url": url,
             "context": contextID}}
@@ -84,7 +84,7 @@ async def goto_url(websocket, contextID, url):
     resp = await read_JSON_message(websocket)
     assert resp["method"] == "DEBUG.Page.load"
 
-    # Assert "PROTO.browsingContext.navigate" command done.
+    # Assert "browsingContext.navigate" command done.
     resp = await read_JSON_message(websocket)
     assert resp["id"] == 9998
     return contextID
@@ -239,13 +239,13 @@ async def _ignore_test_PageClose_browsingContextContextDestroyedEmitted(websocke
             "url": "about:blank"}}
 
 @pytest.mark.asyncio
-async def test_PROTO_navigateWaitNone_navigated(websocket):
+async def test_navigateWaitNone_navigated(websocket):
     contextID = await get_open_context_id(websocket)
 
     # Send command.
     command = {
         "id": 15,
-        "method": "PROTO.browsingContext.navigate",
+        "method": "browsingContext.navigate",
         "params": {
             "url": "data:text/html,<h2>test</h2>",
             "wait": "none",
@@ -265,23 +265,23 @@ async def test_PROTO_navigateWaitNone_navigated(websocket):
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_PROTO_navigateWaitInteractive_navigated(websocket):
+async def _ignore_test_navigateWaitInteractive_navigated(websocket):
     ignore = True
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_PROTO_navigateWaitComplete_navigated(websocket):
+async def _ignore_test_navigateWaitComplete_navigated(websocket):
     ignore = True
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_PROTO_navigateWithShortTimeout_timeoutOccuredAndEventPageLoadEmitted(websocket):
+async def _ignore_test_navigateWithShortTimeout_timeoutOccuredAndEventPageLoadEmitted(websocket):
     contextID = await get_open_context_id(websocket)
 
     # Send command.
     command = {
         "id": 16,
-        "method": "PROTO.browsingContext.navigate",
+        "method": "browsingContext.navigate",
         "params": {
             "url": "data:text/html,<h2>test</h2>",
             "context": contextID,


### PR DESCRIPTION
* Implement [`browsingContext.navigate`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-navigate) command.
* Add `browsingContext.create` -> `params.type`.
* Add unit test for different event orders in `browsingContext.create`.
* Made `EVALUATOR_SCRIPT` a property to allow unit testing.
* `BrowsingContextProcessor` is responsible for handling events for testability.