### PR TITLE
Rename `PROTO.script.callFunction` -> `script.callFunction`

### DIFF
--- a/examples/cross-browser.py
+++ b/examples/cross-browser.py
@@ -64,7 +64,7 @@ async def main():
     # https://github.com/puppeteer/puppeteer/blob/4c3caaa3f99f0c31333a749ec50f56180507a374/examples/cross-browser.js#L31
     command_result = await run_and_wait_command({
         "id": 1000,
-        "method": "PROTO.browsingContext.create",
+        "method": "browsingContext.create",
         "params": {}}, websocket)
 
     # Part 2. Get the command result.

--- a/examples/cross-browser.py
+++ b/examples/cross-browser.py
@@ -106,7 +106,7 @@ async def main():
     # https://github.com/puppeteer/puppeteer/blob/4c3caaa3f99f0c31333a749ec50f56180507a374/examples/cross-browser.js#L38
     command_result = await run_and_wait_command({
         "id": 1002,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": """(resultsSelector) => {
                 const anchors = Array.from(document.querySelectorAll(resultsSelector));

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -290,11 +290,11 @@ export namespace BrowsingContext {
   export type CommandType =
     | BrowsingContextGetTreeCommand
     | BrowsingContextNavigateCommand
-    | PROTO.BrowsingContextCreateCommand;
+    | BrowsingContextCreateCommand;
   export type ResultType =
     | BrowsingContextGetTreeResult
     | BrowsingContextNavigateResult
-    | PROTO.BrowsingContextCreateResult;
+    | BrowsingContextCreateResult;
   export type EventType =
     | BrowsingContextDomContentLoadedEvent
     | BrowsingContextCreatedEvent
@@ -344,6 +344,21 @@ export namespace BrowsingContext {
     url: string;
   };
 
+  export type BrowsingContextCreateCommand = {
+    method: 'browsingContext.create';
+    params: BrowsingContextCreateParameters;
+  };
+
+  export type BrowsingContextCreateType = 'tab' | 'window';
+
+  export type BrowsingContextCreateParameters = {
+    type?: BrowsingContextCreateType;
+  };
+
+  export type BrowsingContextCreateResult = {
+    context: BrowsingContext;
+  };
+
   // events
   export type BrowsingContextDomContentLoadedEvent = {
     method: 'browsingContext.domContentLoaded';
@@ -368,23 +383,6 @@ export namespace BrowsingContext {
 
   // proto
   export namespace PROTO {
-    // `browsingContext.create`:
-    // https://github.com/w3c/webdriver-bidi/pull/133
-    export type BrowsingContextCreateCommand = {
-      method: 'PROTO.browsingContext.create';
-      params: BrowsingContextCreateParameters;
-    };
-
-    export type BrowsingContextCreateType = 'tab' | 'window';
-
-    export type BrowsingContextCreateParameters = {
-      type?: BrowsingContextCreateType;
-    };
-
-    export type BrowsingContextCreateResult = {
-      context: BrowsingContext;
-    };
-
     // `browsingContext.findElement`:
     // https://github.com/GoogleChromeLabs/chromium-bidi/issues/67
     export type BrowsingContextFindElementCommand = {

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -223,12 +223,8 @@ export namespace CommonDataTypes {
 }
 
 export namespace Script {
-  export type CommandType =
-    | ScriptEvaluateCommand
-    | PROTO.ScriptCallFunctionCommand;
-  export type ResultType =
-    | ScriptEvaluateResult
-    | PROTO.ScriptCallFunctionResult;
+  export type CommandType = ScriptEvaluateCommand | ScriptCallFunctionCommand;
+  export type ResultType = ScriptEvaluateResult | ScriptCallFunctionResult;
 
   export type RealmTarget = {
     // TODO sadym: implement.
@@ -263,32 +259,30 @@ export namespace Script {
     exceptionDetails: CommonDataTypes.ExceptionDetails;
   };
 
-  export namespace PROTO {
-    export type ScriptCallFunctionCommand = {
-      method: 'PROTO.script.callFunction';
-      params: ScriptCallFunctionParameters;
-    };
+  export type ScriptCallFunctionCommand = {
+    method: 'script.callFunction';
+    params: ScriptCallFunctionParameters;
+  };
 
-    export type ScriptCallFunctionParameters = {
-      functionDeclaration: string;
-      args?: ArgumentValue[];
-      this?: ArgumentValue;
-      awaitPromise?: boolean;
-      target: Target;
-    };
+  export type ScriptCallFunctionParameters = {
+    functionDeclaration: string;
+    args?: ArgumentValue[];
+    this?: ArgumentValue;
+    awaitPromise?: boolean;
+    target: Target;
+  };
 
-    export type ScriptCallFunctionResult =
-      | ScriptCallFunctionSuccessResult
-      | ScriptExceptionResult;
+  export type ScriptCallFunctionResult =
+    | ScriptCallFunctionSuccessResult
+    | ScriptExceptionResult;
 
-    export type ScriptCallFunctionSuccessResult = {
-      result: CommonDataTypes.RemoteValue;
-    };
+  export type ScriptCallFunctionSuccessResult = {
+    result: CommonDataTypes.RemoteValue;
+  };
 
-    export type ArgumentValue =
-      | CommonDataTypes.RemoteReference
-      | CommonDataTypes.LocalValue;
-  }
+  export type ArgumentValue =
+    | CommonDataTypes.RemoteReference
+    | CommonDataTypes.LocalValue;
 }
 
 // https://w3c.github.io/webdriver-bidi/#module-browsingContext

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -147,26 +147,28 @@ export class CommandProcessor {
         return await this._process_session_status(
           commandData as Session.SessionStatusCommand
         );
+
       case 'browsingContext.getTree':
         return await this._process_browsingContext_getTree(
           commandData as BrowsingContext.BrowsingContextGetTreeCommand
-        );
-      case 'script.evaluate':
-        return await this._contextProcessor.process_script_evaluate(
-          commandData as Script.ScriptEvaluateCommand
         );
       case 'browsingContext.navigate':
         return await this._contextProcessor.process_browsingContext_navigate(
           commandData as BrowsingContext.BrowsingContextNavigateCommand
         );
 
+      case 'script.callFunction':
+        return await this._contextProcessor.process_script_callFunction(
+          commandData as Script.ScriptCallFunctionCommand
+        );
+      case 'script.evaluate':
+        return await this._contextProcessor.process_script_evaluate(
+          commandData as Script.ScriptEvaluateCommand
+        );
+
       case 'PROTO.browsingContext.create':
         return await this._contextProcessor.process_PROTO_browsingContext_create(
           commandData as BrowsingContext.PROTO.BrowsingContextCreateCommand
-        );
-      case 'PROTO.script.callFunction':
-        return await this._contextProcessor.process_PROTO_script_callFunction(
-          commandData as Script.PROTO.ScriptCallFunctionCommand
         );
       case 'PROTO.browsingContext.findElement':
         return await this._contextProcessor.PROTO_browsingContext_findElement(

--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -148,6 +148,10 @@ export class CommandProcessor {
           commandData as Session.SessionStatusCommand
         );
 
+      case 'browsingContext.create':
+        return await this._contextProcessor.process_browsingContext_create(
+          commandData as BrowsingContext.BrowsingContextCreateCommand
+        );
       case 'browsingContext.getTree':
         return await this._process_browsingContext_getTree(
           commandData as BrowsingContext.BrowsingContextGetTreeCommand
@@ -166,15 +170,10 @@ export class CommandProcessor {
           commandData as Script.ScriptEvaluateCommand
         );
 
-      case 'PROTO.browsingContext.create':
-        return await this._contextProcessor.process_PROTO_browsingContext_create(
-          commandData as BrowsingContext.PROTO.BrowsingContextCreateCommand
-        );
       case 'PROTO.browsingContext.findElement':
         return await this._contextProcessor.PROTO_browsingContext_findElement(
           commandData as BrowsingContext.PROTO.BrowsingContextFindElementCommand
         );
-
       case 'DEBUG.Page.close':
         return await this._process_DEBUG_Page_close(commandData.params as any);
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
@@ -87,9 +87,9 @@ describe('BrowsingContextProcessor', function () {
   });
 
   describe('handle `process_PROTO_browsingContext_create`', async function () {
-    const BROWSING_CONTEXT_CREATE_COMMAND: BrowsingContext.PROTO.BrowsingContextCreateCommand =
+    const BROWSING_CONTEXT_CREATE_COMMAND: BrowsingContext.BrowsingContextCreateCommand =
       {
-        method: 'PROTO.browsingContext.create',
+        method: 'browsingContext.create',
         params: {},
       };
 
@@ -111,7 +111,7 @@ describe('BrowsingContextProcessor', function () {
 
     it('Target.attachedToTarget before command finished', async function () {
       const createResultPromise =
-        browsingContextProcessor.process_PROTO_browsingContext_create(
+        browsingContextProcessor.process_browsingContext_create(
           BROWSING_CONTEXT_CREATE_COMMAND
         );
 
@@ -131,7 +131,7 @@ describe('BrowsingContextProcessor', function () {
 
     it('Target.attachedToTarget after command finished', async function () {
       const createResultPromise =
-        browsingContextProcessor.process_PROTO_browsingContext_create(
+        browsingContextProcessor.process_browsingContext_create(
           BROWSING_CONTEXT_CREATE_COMMAND
         );
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -164,9 +164,9 @@ export class BrowsingContextProcessor {
     }
   }
 
-  async process_PROTO_browsingContext_create(
-    commandData: BrowsingContext.PROTO.BrowsingContextCreateCommand
-  ): Promise<BrowsingContext.PROTO.BrowsingContextCreateResult> {
+  async process_browsingContext_create(
+    commandData: BrowsingContext.BrowsingContextCreateCommand
+  ): Promise<BrowsingContext.BrowsingContextCreateResult> {
     const params = commandData.params;
 
     return new Promise(async (resolve) => {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -231,9 +231,9 @@ export class BrowsingContextProcessor {
     );
   }
 
-  async process_PROTO_script_callFunction(
-    commandData: Script.PROTO.ScriptCallFunctionCommand
-  ): Promise<Script.PROTO.ScriptCallFunctionResult> {
+  async process_script_callFunction(
+    commandData: Script.ScriptCallFunctionCommand
+  ): Promise<Script.ScriptCallFunctionResult> {
     const params = commandData.params;
     const context = await this._getKnownContext(
       (params.target as Script.ContextTarget).context

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -23,7 +23,7 @@ import {
   Script,
 } from '../../bidiProtocolTypes';
 import { IBidiServer } from '../../utils/bidiServer';
-import ArgumentValue = Script.PROTO.ArgumentValue;
+import ArgumentValue = Script.ArgumentValue;
 
 export class Context {
   _targetInfo?: Protocol.Target.TargetInfo;
@@ -246,8 +246,8 @@ export class Context {
 
   public async _executeCallFunction(
     functionDeclaration: string,
-    _this: Script.PROTO.ArgumentValue,
-    args: Script.PROTO.ArgumentValue[],
+    _this: Script.ArgumentValue,
+    args: Script.ArgumentValue[],
     awaitPromise: boolean
   ): Promise<Protocol.Runtime.CallFunctionOnResponse> {
     // TODO sadym: add error handling for serialization/deserialization errors.
@@ -276,10 +276,10 @@ export class Context {
 
   public async callFunction(
     functionDeclaration: string,
-    _this: Script.PROTO.ArgumentValue,
-    args: Script.PROTO.ArgumentValue[],
+    _this: Script.ArgumentValue,
+    args: Script.ArgumentValue[],
     awaitPromise: boolean
-  ): Promise<Script.PROTO.ScriptCallFunctionResult> {
+  ): Promise<Script.ScriptCallFunctionResult> {
     const cdpCallFunctionResult = await this._executeCallFunction(
       functionDeclaration,
       _this,

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -979,13 +979,13 @@ async def test_scriptEvaluateChangingObject_resultObjectDidNotChange(websocket):
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithArgs_resultReturn(websocket):
+async def test_scriptCallFunctionWithArgs_resultReturn(websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 48,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "(...args)=>{return Promise.resolve(args);}",
             "args": [{
@@ -1014,14 +1014,14 @@ async def test_PROTO_scriptCallFunctionWithArgs_resultReturn(websocket):
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithThenableArgsAndAwaitParam_thenableReturn(
+async def test_scriptCallFunctionWithThenableArgsAndAwaitParam_thenableReturn(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 49,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "(...args)=>({then: (r)=>{r(args);}})",
             "args": [{
@@ -1053,14 +1053,14 @@ async def test_PROTO_scriptCallFunctionWithThenableArgsAndAwaitParam_thenableRet
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithArgsAndDoNotAwaitPromise_promiseReturn(
+async def test_scriptCallFunctionWithArgsAndDoNotAwaitPromise_promiseReturn(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 49,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "(...args)=>{return Promise.resolve(args);}",
             "args": [{
@@ -1084,7 +1084,7 @@ async def test_PROTO_scriptCallFunctionWithArgsAndDoNotAwaitPromise_promiseRetur
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithRemoteValueArgument_resultReturn(
+async def test_scriptCallFunctionWithRemoteValueArgument_resultReturn(
       websocket):
     context_id = await get_open_context_id(websocket)
 
@@ -1106,7 +1106,7 @@ async def test_PROTO_scriptCallFunctionWithRemoteValueArgument_resultReturn(
     # Send command.
     await send_JSON_command(websocket, {
         "id": 51,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "(obj)=>{return obj.SOME_PROPERTY;}",
             "args": [{
@@ -1124,14 +1124,14 @@ async def test_PROTO_scriptCallFunctionWithRemoteValueArgument_resultReturn(
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithAsyncArrowFunctionAndAwaitPromise_resultReturned(
+async def test_scriptCallFunctionWithAsyncArrowFunctionAndAwaitPromise_resultReturned(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 52,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "async ()=>{return 'SOME_VALUE'}",
             "this": {
@@ -1151,14 +1151,14 @@ async def test_PROTO_scriptCallFunctionWithAsyncArrowFunctionAndAwaitPromise_res
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithAsyncArrowFunctionAndAwaitPromiseFalse_promiseReturned(
+async def test_scriptCallFunctionWithAsyncArrowFunctionAndAwaitPromiseFalse_promiseReturned(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 53,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "async ()=>{return 'SOME_VALUE'}",
             "this": {
@@ -1179,14 +1179,14 @@ async def test_PROTO_scriptCallFunctionWithAsyncArrowFunctionAndAwaitPromiseFals
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromise_resultReturned(
+async def test_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromise_resultReturned(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 54,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "async function(){return 'SOME_VALUE'}",
             "this": {
@@ -1206,13 +1206,13 @@ async def test_PROTO_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromise_r
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_promiseReturned(websocket):
+async def test_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_promiseReturned(websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 55,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "async function(){return 'SOME_VALUE'}",
             "this": {
@@ -1233,14 +1233,14 @@ async def test_PROTO_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromiseFa
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithArrowFunctionAndThisParameter_thisIsIgnoredAndWindowUsedInstead(
+async def test_scriptCallFunctionWithArrowFunctionAndThisParameter_thisIsIgnoredAndWindowUsedInstead(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 56,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "()=>{return this.constructor.name}",
             "this": {
@@ -1259,14 +1259,14 @@ async def test_PROTO_scriptCallFunctionWithArrowFunctionAndThisParameter_thisIsI
 
 
 @pytest.mark.asyncio
-async def test_PROTO_scriptCallFunctionWithClassicFunctionAndThisParameter_thisIsUsed(
+async def test_scriptCallFunctionWithClassicFunctionAndThisParameter_thisIsUsed(
       websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
     await send_JSON_command(websocket, {
         "id": 57,
-        "method": "PROTO.script.callFunction",
+        "method": "script.callFunction",
         "params": {
             "functionDeclaration": "function(){return this.constructor.name}",
             "this": {

--- a/tests/test_bidi.py
+++ b/tests/test_bidi.py
@@ -180,13 +180,13 @@ async def _ignore_test_getTreeWithNestedContexts_contextReturned(websocket):
 
 
 @pytest.mark.asyncio
-async def test_PROTO_browsingContextCreate_eventContextCreatedEmittedAndContextCreated(
+async def test_browsingContextCreate_eventContextCreatedEmittedAndContextCreated(
       websocket):
     initial_context_id = await get_open_context_id(websocket)
 
     command = {
         "id": 9,
-        "method": "PROTO.browsingContext.create",
+        "method": "browsingContext.create",
         "params": {}}
     await send_JSON_command(websocket, command)
 
@@ -231,7 +231,7 @@ async def test_PROTO_browsingContextCreate_eventContextCreatedEmittedAndContextC
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_PageClose_browsingContextContextDestroyedEmitted(
+async def test_PROTO_PageClose_browsingContextContextDestroyedEmitted(
       websocket):
     context_id = await get_open_context_id(websocket)
 
@@ -240,18 +240,18 @@ async def _ignore_test_PageClose_browsingContextContextDestroyedEmitted(
                "params": {"context": context_id}}
     await send_JSON_command(websocket, command)
 
-    # Assert command done.
-    resp = await read_JSON_message(websocket)
-    assert resp == {"id": 12, "result": {}}
-
     # Assert "browsingContext.contextCreated" event emitted.
     resp = await read_JSON_message(websocket)
     assert resp == {
         "method": "browsingContext.contextDestroyed",
         "params": {
             "context": context_id,
-            "parent": None,
-            "url": "about:blank"}}
+            "url": "about:blank",
+            "children": []}}
+
+    # Assert command done.
+    resp = await read_JSON_message(websocket)
+    assert resp == {"id": 12, "result": {}}
 
 
 @pytest.mark.asyncio
@@ -1206,7 +1206,8 @@ async def test_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromise_resultR
 
 
 @pytest.mark.asyncio
-async def test_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_promiseReturned(websocket):
+async def test_scriptCallFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_promiseReturned(
+      websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.
@@ -1356,7 +1357,8 @@ async def test_selectElementMissingElement_missingElement(websocket):
 
 
 # Testing serialization.
-async def assertSerialization(js_str_object, expected_serialized_object, websocket):
+async def assertSerialization(js_str_object, expected_serialized_object,
+      websocket):
     context_id = await get_open_context_id(websocket)
 
     # Send command.


### PR DESCRIPTION
After https://github.com/w3c/webdriver-bidi/pull/142 is merged, `script.callFunction` is not a prototype anymore.