### PR TITLE
`browsingContext` events + `browsingContext.navigate` `wait` param.

### DIFF
--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -296,6 +296,7 @@ export namespace BrowsingContext {
     | BrowsingContextNavigateResult
     | BrowsingContextCreateResult;
   export type EventType =
+    | BrowsingContextLoadEvent
     | BrowsingContextDomContentLoadedEvent
     | BrowsingContextCreatedEvent
     | BrowsingContextDestroyedEvent;
@@ -337,8 +338,7 @@ export namespace BrowsingContext {
     wait?: ReadinessState;
   };
 
-  export type ReadinessState = 'none';
-  // TODO sadym: implement 'interactive' and 'complete' states.
+  export type ReadinessState = 'none' | 'interactive' | 'complete';
   export type BrowsingContextNavigateResult = {
     navigation?: Navigation;
     url: string;
@@ -360,6 +360,11 @@ export namespace BrowsingContext {
   };
 
   // events
+  export type BrowsingContextLoadEvent = {
+    method: 'browsingContext.load';
+    params: NavigationInfo;
+  };
+
   export type BrowsingContextDomContentLoadedEvent = {
     method: 'browsingContext.domContentLoaded';
     params: NavigationInfo;
@@ -367,8 +372,8 @@ export namespace BrowsingContext {
 
   export type NavigationInfo = {
     context: BrowsingContext;
+    navigation: Navigation | null;
     // TODO: implement or remove from specification.
-    // navigation: Navigation | null;
     // url: string;
   };
 

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -367,8 +367,9 @@ export namespace BrowsingContext {
 
   export type NavigationInfo = {
     context: BrowsingContext;
-    navigation: Navigation | null;
-    url: string;
+    // TODO: implement or remove from specification.
+    // navigation: Navigation | null;
+    // url: string;
   };
 
   export type BrowsingContextCreatedEvent = {

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -63,6 +63,22 @@ export class Context {
     await this._cdpClient.Runtime.enable();
     await this._cdpClient.Page.enable();
     await this._cdpClient.Page.setLifecycleEventsEnabled({ enabled: true });
+    this._initializeEventListeners();
+  }
+
+  private _initializeEventListeners() {
+    this._handleDomContentEvent();
+  }
+
+  private _handleDomContentEvent() {
+    this._cdpClient.Page.on('domContentEventFired', async (params) => {
+      await this._bidiServer.sendMessage({
+        method: 'browsingContext.domContentLoaded',
+        params: {
+          context: this._contextId,
+        },
+      });
+    });
   }
 
   // TODO sadym: `dummyContextObject` needed for the running context.

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -34,6 +34,15 @@ async def before_each_test(websocket):
     resp = await read_JSON_message(websocket)
     assert resp['method'] == 'browsingContext.contextCreated'
 
+    # TODO: check why the initial event order is different form the navigation.
+    # Read initial event `browsingContext.domContentLoaded`
+    resp = await read_JSON_message(websocket)
+    assert resp['method'] == 'browsingContext.domContentLoaded'
+
+    # Read initial event `browsingContext.load`
+    resp = await read_JSON_message(websocket)
+    assert resp['method'] == 'browsingContext.load'
+
 
 # Compares 2 objects recursively ignoring values of specific attributes.
 def recursiveCompare(expected, actual, ignore_attributes):
@@ -88,10 +97,11 @@ async def goto_url(websocket, context_id, url):
             "wait": "interactive"}}
     await send_JSON_command(websocket, command)
 
-    # Wait for the page loaded.
+    # Wait for the page events.
     resp = await read_JSON_message(websocket)
-    assert resp ==  {'method': 'browsingContext.domContentLoaded',
-                     'params': {'context': context_id}}
+    assert resp['method'] == 'browsingContext.load'
+    resp = await read_JSON_message(websocket)
+    assert resp['method'] == 'browsingContext.domContentLoaded'
 
     # Wait the "browsingContext.navigate" command is done.
     resp = await read_JSON_message(websocket)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -84,10 +84,17 @@ async def goto_url(websocket, context_id, url):
         "method": "browsingContext.navigate",
         "params": {
             "url": url,
-            "context": context_id}}
+            "context": context_id,
+            "wait": "interactive"}}
     await send_JSON_command(websocket, command)
 
-    # Assert "browsingContext.navigate" command done.
+    # Wait for the page loaded.
+    resp = await read_JSON_message(websocket)
+    assert resp ==  {'method': 'browsingContext.domContentLoaded',
+                     'params': {'context': context_id}}
+
+    # Wait the "browsingContext.navigate" command is done.
     resp = await read_JSON_message(websocket)
     assert resp["id"] == 9998
+
     return context_id

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -534,6 +534,12 @@ async def test_PROTO_browsingContext_findElement_findsElement(websocket):
             "context": context_id}})
 
     resp = await read_JSON_message(websocket)
+    assert resp == {
+        'method': 'browsingContext.domContentLoaded',
+        'params': {
+            'context': context_id}}
+
+    resp = await read_JSON_message(websocket)
     recursiveCompare({
         "id": 59,
         "result": {

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -38,14 +38,16 @@ async def test_browsingContext_getTree_contextReturned(websocket):
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_browsingContext_getTreeWithGivenParent_contextReturned(websocket):
+async def _ignore_test_browsingContext_getTreeWithGivenParent_contextReturned(
+      websocket):
     ignore = True
     # TODO sadym: implement
 
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_browsingContext_getTreeWithNestedContexts_contextReturned(websocket):
+async def _ignore_test_browsingContext_getTreeWithNestedContexts_contextReturned(
+      websocket):
     ignore = True
     # TODO sadym: implement
 
@@ -149,19 +151,22 @@ async def test_browsingContext_navigateWaitNone_navigated(websocket):
 
     # Assert command done.
     resp = await read_JSON_message(websocket)
-    recursiveCompare(
-        resp,
-        {
-            "id": 13,
-            "result": {
-                "navigation": "F595626837D41F9A72482D53B0C22F25",
-                "url": "data:text/html,<h2>test</h2>"}},
-        ["navigation"])
+    recursiveCompare({
+        "id": 13,
+        "result": {
+            "navigation": "F595626837D41F9A72482D53B0C22F25",
+            "url": "data:text/html,<h2>test</h2>"}},
+        resp, ["navigation"])
+
+    # Wait for document loaded event.
+    resp = await read_JSON_message(websocket)
+    assert resp == {
+        "method": "browsingContext.domContentLoaded",
+        "params": {
+            "context": context_id}}
 
 
 @pytest.mark.asyncio
-# TODO sadym: find a way to test if the command ended only after the DOM
-# actually loaded.
 async def test_browsingContext_navigateWaitInteractive_navigated(websocket):
     context_id = await get_open_context_id(websocket)
 
@@ -175,21 +180,28 @@ async def test_browsingContext_navigateWaitInteractive_navigated(websocket):
             "context": context_id}}
     await send_JSON_command(websocket, command)
 
+    # Wait for document loaded event.
+    resp = await read_JSON_message(websocket)
+    assert resp == {
+        "method": "browsingContext.domContentLoaded",
+        "params": {
+            "context": context_id}}
+
     # Assert command done.
     resp = await read_JSON_message(websocket)
     recursiveCompare(
-        resp,
         {
             "id": 14,
             "result": {
                 "navigation": "F595626837D41F9A72482D53B0C22F25",
                 "url": "data:text/html,<h2>test</h2>"}},
-        ["navigation"])
+        resp, ["navigation"])
 
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_browsingContext_navigateWaitComplete_navigated(websocket):
+async def _ignore_test_browsingContext_navigateWaitComplete_navigated(
+      websocket):
     ignore = True
 
 
@@ -545,7 +557,8 @@ async def test_PROTO_browsingContext_findElement_findsElement(websocket):
 
 
 @pytest.mark.asyncio
-async def test_PROTO_browsingContext_findElementMissingElement_missingElement(websocket):
+async def test_PROTO_browsingContext_findElementMissingElement_missingElement(
+      websocket):
     context_id = await get_open_context_id(websocket)
     await goto_url(websocket, context_id,
                    "data:text/html,<h2>test</h2>")


### PR DESCRIPTION
1. Emit `browsingContext.load` when `Page.lifecycleEvent` fired with `name="load"`.
2. Emit `browsingContext.domContentLoaded` when `Page.lifecycleEvent` fire with `name="DOMContentLoaded"`.
3. Added and implement `interactive` and `complete` params to `browsingContext.navigate` command.
