### PR TITLE
Add `PROTO.binding` type to Local Value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ python3 examples/cross-browser.py
 
 ## WPT
 
-WPT is added as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
-To get run WPT tests:
+WPT is added as
+a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). To get
+run WPT tests:
 
 ### Check out WPT and setup
 
@@ -145,11 +146,15 @@ cd wpt
 
 #### 3. Set up virtualenv
 
-Follow the [*System Setup*](https://web-platform-tests.org/running-tests/from-local-system.html#system-setup) instructions.
+Follow the [_System
+Setup_](https://web-platform-tests.org/running-tests/from-local-system.html#system-setup)
+instructions.
 
 #### 4. Setup `hosts` file
 
-Follow the [`hosts` File Setup](https://web-platform-tests.org/running-tests/from-local-system.html#hosts-file-setup) instructions.
+Follow
+the [`hosts` File Setup](https://web-platform-tests.org/running-tests/from-local-system.html#hosts-file-setup)
+instructions.
 
 ##### On Linux, macOS or other UNIX-like system
 
@@ -165,7 +170,8 @@ This must be run in a PowerShell session with Administrator privileges:
 python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts -Encoding ascii -Append
 ```
 
-If you are behind a proxy, you also need to make sure the domains above are excluded from your proxy lookups.
+If you are behind a proxy, you also need to make sure the domains above are
+excluded from your proxy lookups.
 
 #### 5. Set the `WPT_BROWSER_PATH` environment variable to a Chrome, Edge or Chromium binary to launch. For example, on macOS:
 
@@ -176,11 +182,15 @@ export WPT_BROWSER_PATH="/Applications/Chromium.app/Contents/MacOS/Chromium"
 ```
 
 ### Run WPT tests
+
 #### 1. Build ChromeDriver BiDi
+
 ```sh
 npm run build
 ```
+
 #### 2. Run
+
 ```sh
 ./wpt/wpt run \
   --webdriver-binary ./runBiDiServer.sh \
@@ -191,10 +201,10 @@ npm run build
   webdriver/tests/bidi/
 ```
 
-
 ### Update WPT expectations if needed
 
 #### 1. Run WPT tests with custom `log-wptreport`:
+
 ```sh
 ./wpt/wpt run \
   --webdriver-binary ./runBiDiServer.sh \
@@ -206,8 +216,8 @@ npm run build
   webdriver/tests/bidi/
 ```
 
-
 #### 2. Update expectations based on the previous test run:
+
 ```sh
 ./wpt/wpt update-expectations \
   --product chrome \
@@ -216,11 +226,11 @@ npm run build
   ./wptreport.json
 ```
 
-
 # How does it work?
 
 The architecture is described in the
-[WebDriver BiDi in Chrome Context implementation plan](https://docs.google.com/document/d/1VfQ9tv0wPSnb5TI-MOobjoQ5CXLnJJx9F_PxOMQc8kY).
+[WebDriver BiDi in Chrome Context implementation plan](https://docs.google.com/document/d/1VfQ9tv0wPSnb5TI-MOobjoQ5CXLnJJx9F_PxOMQc8kY)
+.
 
 There are 2 main modules:
 

--- a/src/bidiMapper/bidiProtocolTypes.ts
+++ b/src/bidiMapper/bidiProtocolTypes.ts
@@ -16,7 +16,7 @@ export namespace Message {
     | Script.CommandResult
     | Session.CommandResult;
 
-  export type Event = BrowsingContext.Event;
+  export type Event = BrowsingContext.Event | Script.Event;
 
   export type Error = {
     id?: number;
@@ -250,6 +250,7 @@ export namespace CommonDataTypes {
 export namespace Script {
   export type Command = EvaluateCommand | CallFunctionCommand;
   export type CommandResult = EvaluateResult | CallFunctionResult;
+  export type Event = PROTO.CalledEvent;
 
   export type RealmTarget = {
     // TODO sadym: implement.
@@ -306,6 +307,18 @@ export namespace Script {
   export type ArgumentValue =
     | CommonDataTypes.RemoteReference
     | CommonDataTypes.LocalValue;
+
+  export namespace PROTO {
+    export type CalledEvent = {
+      method: 'PROTO.script.called';
+      params: CalledEventParams;
+    };
+
+    export type CalledEventParams = {
+      id: string;
+      arguments: CommonDataTypes.RemoteValue[];
+    };
+  }
 }
 
 // https://w3c.github.io/webdriver-bidi/#module-browsingContext

--- a/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.spec.ts
@@ -68,7 +68,13 @@ describe('BrowsingContextProcessor', function () {
 
     // Actual `Context.create` logic involves several CDP calls, so mock it to avoid all the simulations.
     Context.create = sinon.fake(
-      async (_1: string, _2: CdpClient, _3: string) => {
+      async (
+        _1: string,
+        _2: CdpClient,
+        _3: IBidiServer,
+        _4: IEventManager,
+        _5: string
+      ) => {
         return sinon.createStubInstance(Context) as unknown as Context;
       }
     );

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -409,3 +409,39 @@ async def test_script_evaluateWithNode_resultReceived(websocket, context_id):
     assert result == {
         "type": "string",
         "value": "!!@@##, test"}
+
+
+@pytest.mark.asyncio
+async def test_script_callFunctionWithBindingAndCallBinding_bindingCalled(
+      websocket, context_id):
+    # Send command.
+    command_id = get_next_command_id()
+
+    await send_JSON_command(websocket, {
+        "id": command_id,
+        "method": "script.callFunction",
+        "params": {
+            "functionDeclaration": "(callback) => {callback('CALLBACK_ARGUMENT'); return 'SOME_RESULT';}",
+            "args": [{
+                "type": "PROTO.binding",
+                "id": "BINDING_NAME"}],
+            "target": {"context": context_id}
+        }})
+
+    # Assert callback is called.
+    resp = await read_JSON_message(websocket)
+    assert resp == {
+        "method": "PROTO.script.called",
+        "params": {
+            "arguments": [{
+                "type": "string",
+                "value": "CALLBACK_ARGUMENT"}],
+            "id": "BINDING_NAME"}}
+
+    # Assert command done.
+    resp = await read_JSON_message(websocket)
+    assert resp == {
+        "id": command_id,
+        "result": {
+            "type": "string",
+            "value": "SOME_RESULT"}}


### PR DESCRIPTION
https://github.com/GoogleChromeLabs/chromium-bidi/issues/79

Based on discussion https://github.com/w3c/webdriver-bidi/issues/157

> Instead of adding global bindings, pass bindings as deserializable arguments to `script.callFunction`. 
...
The argument can be something like:
> 
> ```
> {
>   type: "binding", 
>   value: "SOME_BINDING_NAME"
> }
> ```
> 
> , which will be deserialized to a callback. Calling that callback with any arguments will cause the BiDi event with those arguments like:
> 
> ```
> {
>   method: "script.bindingCalled",
>   params: {
>     arguments: [... remote values ...],
>     name: "SOME_BINDING_NAME"
>   }
> }
> ```
