### PR TITLE
Use the proper WebSocket endpoint

### DIFF
--- a/examples/cross-browser.py
+++ b/examples/cross-browser.py
@@ -24,7 +24,7 @@ import websockets
 
 async def get_websocket():
     port = os.getenv('PORT', 8080)
-    url = f'ws://localhost:{port}'
+    url = f'ws://localhost:{port}/session'
     return await websockets.connect(url)
 
 

--- a/src/bidiServerRunner.ts
+++ b/src/bidiServerRunner.ts
@@ -44,10 +44,10 @@ export class BidiServerRunner {
 
       if (!request.url) return response.end(404);
 
-      // Needed for WPT compatibility.
+      // https://w3c.github.io/webdriver-bidi/#transport, step 2.
       if (request.url.startsWith('/session')) {
         response.writeHead(200, {
-          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Type': 'application/json;charset=utf-8',
           'Cache-Control': 'no-cache',
         });
         response.write(


### PR DESCRIPTION
Per step 2 of https://w3c.github.io/webdriver-bidi/#transport, the endpoint is supposed to be `/session` (with an optional query string attached to it).

Issue: #110