### PR TITLE
Document how to `npm publish`

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,7 @@ There are 2 main modules:
 The BiDi commands are processed in the `src/bidiMapper/commandProcessor.ts`. To
 add a new command, add it to `_processCommand`, write and call processor for it.
 
-## For maintainers
-
-### How to publish a new release
+## Publish new `npm` release
 
 1. On the `main` branch, bump the chromium-bidi version number in `package.json`:
 

--- a/README.md
+++ b/README.md
@@ -243,3 +243,25 @@ There are 2 main modules:
 
 The BiDi commands are processed in the `src/bidiMapper/commandProcessor.ts`. To
 add a new command, add it to `_processCommand`, write and call processor for it.
+
+## For maintainers
+
+### How to publish a new release
+
+1. On the `main` branch, bump the chromium-bidi version number in `package.json`:
+
+    ```sh
+    npm version patch -m 'Release v%s'
+    ```
+
+    Instead of `patch`, use `minor` or `major` [as needed](https://semver.org/).
+
+    Note that this produces a Git commit + tag.
+
+1. Push the release commit and tag:
+
+    ```sh
+    git push && git push --tags
+    ```
+
+    Our CI then automatically publishes the new release to npm.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromium-bidi",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "An implementation of the WebDriver BiDi protocol for Chromium implemented as a JavaScript layer translating between BiDi and CDP, running inside a Chrome tab.",
   "main": "index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromium-bidi",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "An implementation of the WebDriver BiDi protocol for Chromium implemented as a JavaScript layer translating between BiDi and CDP, running inside a Chrome tab.",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
I’m still trying to work out some issues with the Wombat service, but once those are resolved this patch describes how the process will work.