### PR TITLE
Fix Evaluate and CallFunction types

### DIFF
--- a/examples/cross-browser.py
+++ b/examples/cross-browser.py
@@ -143,18 +143,20 @@ async def main():
     # {
     #     "id": 1002,
     #     "result": {
-    #         "objectId": "__SOME_OBJECT_ID__",
-    #         "type": "array",
-    #         "value": [
-    #             {
-    #                 "type": "string",
-    #                 "value": "__SOME_STRING_VALUE__"
-    #             },
-    #             ... // other values
-    #         ]
+    #         "result": {
+    #             "objectId": "__SOME_OBJECT_ID__",
+    #             "type": "array",
+    #             "value": [
+    #                 {
+    #                     "type": "string",
+    #                     "value": "__SOME_STRING_VALUE__"
+    #                 },
+    #                 ... // other values
+    #             ]
+    #         }
     #     }
     # }
-    links = command_result["result"]
+    links = command_result["result"]["result"]
 
     # Puppeteer:
     # console.log(links.join('\n'));

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -143,12 +143,14 @@ export class Context {
     args: Script.ArgumentValue[],
     awaitPromise: boolean
   ): Promise<Script.CallFunctionResult> {
-    return this.#scriptEvaluator.callFunction(
-      functionDeclaration,
-      _this,
-      args,
-      awaitPromise
-    );
+    return {
+      result: await this.#scriptEvaluator.callFunction(
+        functionDeclaration,
+        _this,
+        args,
+        awaitPromise
+      ),
+    };
   }
 
   public async findElement(
@@ -159,14 +161,17 @@ export class Context {
     );
     const args: Script.ArgumentValue[] = [{ type: 'string', value: selector }];
 
-    return (await this.#scriptEvaluator.callFunction(
+    // TODO(sadym): handle not found exception.
+    const result = await this.#scriptEvaluator.callFunction(
       functionDeclaration,
       {
         type: 'undefined',
       },
       args,
       true
-    )) as BrowsingContext.PROTO.FindElementResult;
+    );
+
+    return { result } as any;
   }
 
   async #initialize() {

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -171,7 +171,8 @@ export class Context {
       true
     );
 
-    return { result } as any;
+    // TODO(sadym): handle type properly.
+    return { result } as any as BrowsingContext.PROTO.FindElementResult;
   }
 
   async #initialize() {

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -25,12 +25,7 @@ export namespace Message {
     | Script.CommandResult
     | Session.CommandResult
     | CDP.CommandResult
-    | ExceptionResult
     | ErrorResult;
-
-  export type ExceptionResult = {
-    exceptionDetails: CommonDataTypes.ExceptionDetails;
-  };
 
   export type EventMessage = BrowsingContext.Event | Log.Event | CDP.Event;
 
@@ -254,6 +249,22 @@ export namespace CommonDataTypes {
   export type WindowProxyRemoteValue = RemoteReference & {
     type: 'window';
   };
+}
+
+export namespace Script {
+  export type Command = EvaluateCommand | CallFunctionCommand;
+  export type CommandResult = EvaluateResult | CallFunctionResult;
+
+  export type Realm = string;
+
+  export type ScriptResult = ScriptResultSuccess | ScriptResultException;
+  export type ScriptResultSuccess = {
+    result: CommonDataTypes.RemoteValue;
+  };
+
+  export type ScriptResultException = {
+    exceptionDetails: ExceptionDetails;
+  };
 
   export type ExceptionDetails = {
     columnNumber: number;
@@ -262,12 +273,6 @@ export namespace CommonDataTypes {
     stackTrace: Script.StackTrace;
     text: string;
   };
-}
-
-export namespace Script {
-  export type Command = EvaluateCommand | CallFunctionCommand;
-  export type CommandResult = EvaluateResult | CallFunctionResult;
-  export type Realm = string;
 
   export type RealmTarget = {
     // TODO sadym: implement.
@@ -281,18 +286,17 @@ export namespace Script {
 
   export type EvaluateCommand = {
     method: 'script.evaluate';
-    params: ScriptEvaluateParameters;
+    params: EvaluateParameters;
   };
 
-  export type ScriptEvaluateParameters = {
+  export type EvaluateParameters = {
     expression: string;
     awaitPromise?: boolean;
     target: Target;
   };
 
-  export type EvaluateResult = EvaluateSuccessResult | Message.ExceptionResult;
-  export type EvaluateSuccessResult = {
-    result: CommonDataTypes.RemoteValue;
+  export type EvaluateResult = {
+    result: ScriptResult;
   };
 
   export type CallFunctionCommand = {
@@ -308,11 +312,8 @@ export namespace Script {
     target: Target;
   };
 
-  export type CallFunctionResult =
-    | CallFunctionSuccessResult
-    | Message.ExceptionResult;
-  export type CallFunctionSuccessResult = {
-    result: CommonDataTypes.RemoteValue;
+  export type CallFunctionResult = {
+    result: ScriptResult;
   };
 
   export type ArgumentValue =
@@ -469,9 +470,7 @@ export namespace BrowsingContext {
       context: BrowsingContext;
     };
 
-    export type FindElementResult =
-      | FindElementSuccessResult
-      | Message.ExceptionResult;
+    export type FindElementResult = FindElementSuccessResult;
 
     export type FindElementSuccessResult = {
       result: CommonDataTypes.NodeRemoteValue;

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -214,47 +214,48 @@ async def test_PROTO_browsingContext_findElement_findsElement(websocket,
             "context": context_id}})
 
     recursiveCompare({
-        "type": "node",
-        "value": {
-            "nodeType": 1,
-            "nodeValue": "",
-            "nodeName": "",
-            "localName": "div",
-            "namespaceURI": "http://www.w3.org/1999/xhtml",
-            "childNodeCount": 3,
-            "attributes": {
-                "class": "container"},
-            "children": [{
-                "type": "node",
-                "value": {
-                    "nodeType": 3,
-                    "nodeValue": "container text",
-                    "nodeName": "container text"}
-            }, {
-                "type": "node",
-                "value": {
-                    "nodeType": 1,
-                    "nodeValue": "",
-                    "nodeName": "",
-                    "localName": "h2",
-                    "namespaceURI": "http://www.w3.org/1999/xhtml",
-                    "childNodeCount": 1,
-                    "attributes": {
-                        "class": "child_1"}}
-            }, {
-                "type": "node",
-                "value": {
-                    "nodeType": 1,
-                    "nodeValue": "",
-                    "nodeName": "",
-                    "localName": "h2",
-                    "namespaceURI": "http://www.w3.org/1999/xhtml",
-                    "childNodeCount": 1,
-                    "attributes": {
-                        "class": "child_2"}}
-            }]
-        }, "objectId": "__SOME_OBJECT_ID_1__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "node",
+            "value": {
+                "nodeType": 1,
+                "nodeValue": "",
+                "nodeName": "",
+                "localName": "div",
+                "namespaceURI": "http://www.w3.org/1999/xhtml",
+                "childNodeCount": 3,
+                "attributes": {
+                    "class": "container"},
+                "children": [{
+                    "type": "node",
+                    "value": {
+                        "nodeType": 3,
+                        "nodeValue": "container text",
+                        "nodeName": "container text"}
+                }, {
+                    "type": "node",
+                    "value": {
+                        "nodeType": 1,
+                        "nodeValue": "",
+                        "nodeName": "",
+                        "localName": "h2",
+                        "namespaceURI": "http://www.w3.org/1999/xhtml",
+                        "childNodeCount": 1,
+                        "attributes": {
+                            "class": "child_1"}}
+                }, {
+                    "type": "node",
+                    "value": {
+                        "nodeType": 1,
+                        "nodeValue": "",
+                        "nodeName": "",
+                        "localName": "h2",
+                        "namespaceURI": "http://www.w3.org/1999/xhtml",
+                        "childNodeCount": 1,
+                        "attributes": {
+                            "class": "child_2"}}
+                }]
+            }, "objectId": "__SOME_OBJECT_ID_1__"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -269,7 +270,7 @@ async def test_PROTO_browsingContext_findElementMissingElement_missingElement(
             "selector": "body > h3",
             "context": context_id}})
 
-    assert result == {"type": "null"}
+    assert result == {"result": {"type": "null"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -19,47 +19,48 @@ from _helpers import *
 @pytest.mark.asyncio
 async def test_script_evaluateThrowingPrimitive_exceptionReturned(websocket,
       context_id):
-    exception_details = await execute_command(websocket, {
+    result = await execute_command(websocket, {
         "id": 45,
         "method": "script.evaluate",
         "params": {
             "expression": "(()=>{const a=()=>{throw 1;}; const b=()=>{a();};\nconst c=()=>{b();};c();})()",
-            "target": {"context": context_id}}}, "exceptionDetails")
+            "target": {"context": context_id}}})
 
     recursiveCompare({
-        "text": "1",
-        "columnNumber": 19,
-        "lineNumber": 0,
-        "exception": {
-            "type": "number",
-            "value": 1},
-        "stackTrace": {
-            "callFrames": [{
-                "url": "",
-                "functionName": "a",
-                "lineNumber": 0,
-                "columnNumber": 19
-            }, {
-                "url": "",
-                "functionName": "b",
-                "lineNumber": 0,
-                "columnNumber": 43
-            }, {
-                "url": "",
-                "functionName": "c",
-                "lineNumber": 1,
-                "columnNumber": 13
-            }, {
-                "url": "",
-                "functionName": "",
-                "lineNumber": 1,
-                "columnNumber": 19
-            }, {
-                "url": "",
-                "functionName": "",
-                "lineNumber": 1,
-                "columnNumber": 25}]}
-    }, exception_details, ["objectId"])
+        "exceptionDetails": {
+            "text": "1",
+            "columnNumber": 19,
+            "lineNumber": 0,
+            "exception": {
+                "type": "number",
+                "value": 1},
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "",
+                    "functionName": "a",
+                    "lineNumber": 0,
+                    "columnNumber": 19
+                }, {
+                    "url": "",
+                    "functionName": "b",
+                    "lineNumber": 0,
+                    "columnNumber": 43
+                }, {
+                    "url": "",
+                    "functionName": "c",
+                    "lineNumber": 1,
+                    "columnNumber": 13
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 19
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 25}]}
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -70,43 +71,44 @@ async def test_script_evaluateThrowingError_exceptionReturned(websocket,
         "method": "script.evaluate",
         "params": {
             "expression": "(()=>{const a=()=>{throw new Error('foo');}; const b=()=>{a();};\nconst c=()=>{b();};c();})()",
-            "target": {"context": context_id}}}, "exceptionDetails")
+            "target": {"context": context_id}}})
 
     recursiveCompare({
-        "text": "Error: foo",
-        "columnNumber": 19,
-        "lineNumber": 0,
-        "exception": {
-            "type": "error",
-            "objectId": "__any_value__"
-        },
-        "stackTrace": {
-            "callFrames": [{
-                "url": "",
-                "functionName": "a",
-                "lineNumber": 0,
-                "columnNumber": 25
-            }, {
-                "url": "",
-                "functionName": "b",
-                "lineNumber": 0,
-                "columnNumber": 58
-            }, {
-                "url": "",
-                "functionName": "c",
-                "lineNumber": 1,
-                "columnNumber": 13
-            }, {
-                "url": "",
-                "functionName": "",
-                "lineNumber": 1,
-                "columnNumber": 19
-            }, {
-                "url": "",
-                "functionName": "",
-                "lineNumber": 1,
-                "columnNumber": 25}]}
-    }, exception_details, ["objectId"])
+        "exceptionDetails": {
+            "text": "Error: foo",
+            "columnNumber": 19,
+            "lineNumber": 0,
+            "exception": {
+                "type": "error",
+                "objectId": "__any_value__"
+            },
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "",
+                    "functionName": "a",
+                    "lineNumber": 0,
+                    "columnNumber": 25
+                }, {
+                    "url": "",
+                    "functionName": "b",
+                    "lineNumber": 0,
+                    "columnNumber": 58
+                }, {
+                    "url": "",
+                    "functionName": "c",
+                    "lineNumber": 1,
+                    "columnNumber": 13
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 19
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 25}]}
+        }}, exception_details, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -121,9 +123,10 @@ async def test_script_evaluateDontWaitPromise_promiseReturned(websocket,
 
     # Compare ignoring `objectId`.
     recursiveCompare({
-        "type": "promise",
-        "objectId": "__any_value__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "promise",
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 # Uncomment after behaviour is clarified:
@@ -160,9 +163,10 @@ async def test_script_evaluateWaitPromise_resultReturned(websocket, context_id):
 
     # Compare ignoring `objectId`.
     recursiveCompare({
-        "type": "string",
-        "value": "SOME_RESULT"
-    }, result, ["objectId"])
+        "result": {
+            "type": "string",
+            "value": "SOME_RESULT"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -188,14 +192,15 @@ async def test_script_evaluateChangingObject_resultObjectDidNotChange(
 
     # Verify the object wasn't changed.
     recursiveCompare({
-        "type": "object",
-        "value": [[
-            "i", {
-                "type": "number",
-                "value": 0
-            }]],
-        "objectId": "__any_value__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "object",
+            "value": [[
+                "i", {
+                    "type": "number",
+                    "value": 0
+                }]],
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -209,8 +214,9 @@ async def test_script_evaluateInteractsWithDom_resultReceived(websocket,
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "!!@@##, about:blank"}
+        "result": {
+            "type": "string",
+            "value": "!!@@##, about:blank"}}
 
 
 @pytest.mark.asyncio
@@ -229,15 +235,16 @@ async def test_script_callFunctionWithArgs_resultReturn(websocket, context_id):
             "target": {"context": context_id}}})
 
     recursiveCompare({
-        "type": "array",
-        "value": [{
-            "type": 'string',
-            "value": 'ARGUMENT_STRING_VALUE'
-        }, {
-            "type": 'number',
-            "value": 42}],
-        "objectId": "__any_value__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "array",
+            "value": [{
+                "type": 'string',
+                "value": 'ARGUMENT_STRING_VALUE'
+            }, {
+                "type": 'number',
+                "value": 42}],
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 # Uncomment after behaviour is clarified:
@@ -286,9 +293,10 @@ async def test_script_callFunctionWithArgsAndDoNotAwaitPromise_promiseReturn(
             "target": {"context": context_id}}})
 
     recursiveCompare({
-        "type": "promise",
-        "objectId": "__any_value__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "promise",
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -301,7 +309,7 @@ async def test_script_callFunctionWithRemoteValueArgument_resultReturn(
             "awaitPromise": True,
             "target": {"context": context_id}}})
 
-    object_id = result["objectId"]
+    object_id = result["result"]["objectId"]
 
     result = await execute_command(websocket, {
         "method": "script.callFunction",
@@ -313,8 +321,9 @@ async def test_script_callFunctionWithRemoteValueArgument_resultReturn(
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "SOME_VALUE"}
+        "result": {
+            "type": "string",
+            "value": "SOME_VALUE"}}
 
 
 @pytest.mark.asyncio
@@ -332,8 +341,9 @@ async def test_script_callFunctionWithAsyncArrowFunctionAndAwaitPromise_resultRe
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "SOME_VALUE"}
+        "result": {
+            "type": "string",
+            "value": "SOME_VALUE"}}
 
 
 @pytest.mark.asyncio
@@ -351,9 +361,10 @@ async def test_script_callFunctionWithAsyncArrowFunctionAndAwaitPromiseFalse_pro
             "target": {"context": context_id}}})
 
     recursiveCompare({
-        "type": "promise",
-        "objectId": "__any_value__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "promise",
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -371,8 +382,9 @@ async def test_script_callFunctionWithAsyncClassicFunctionAndAwaitPromise_result
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "SOME_VALUE"}
+        "result": {
+            "type": "string",
+            "value": "SOME_VALUE"}}
 
 
 @pytest.mark.asyncio
@@ -390,9 +402,10 @@ async def test_script_callFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_p
             "target": {"context": context_id}}})
 
     recursiveCompare({
-        "type": "promise",
-        "objectId": "__any_value__"
-    }, result, ["objectId"])
+        "result": {
+            "type": "promise",
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -409,8 +422,9 @@ async def test_script_callFunctionWithArrowFunctionAndThisParameter_thisIsIgnore
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "Window"}
+        "result": {
+            "type": "string",
+            "value": "Window"}}
 
 
 @pytest.mark.asyncio
@@ -427,8 +441,9 @@ async def test_script_callFunctionWithClassicFunctionAndThisParameter_thisIsUsed
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "Number"}
+        "result": {
+            "type": "string",
+            "value": "Number"}}
 
 
 @pytest.mark.asyncio
@@ -446,7 +461,7 @@ async def test_script_callFunctionWithNode_resultReceived(websocket,
             "selector": "body > h2",
             "context": context_id}})
 
-    object_id = result["objectId"]
+    object_id = result["result"]["objectId"]
 
     # 2. Evaluate script on it.
     result = await execute_command(websocket, {
@@ -458,8 +473,9 @@ async def test_script_callFunctionWithNode_resultReceived(websocket,
             "target": {"context": context_id}}})
 
     assert result == {
-        "type": "string",
-        "value": "!!@@##, test"}
+        "result": {
+            "type": "string",
+            "value": "!!@@##, test"}}
 
 # TODO(sadym): re-enable after binding is specified and implemented.
 # @pytest.mark.asyncio

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -412,34 +412,35 @@ async def test_serialization_node(websocket, context_id):
             "context": context_id}})
 
     recursiveCompare({
-        "type": "node",
-        "value": {
-            "nodeType": 1,
-            "nodeValue": "",
-            "nodeName": "",
-            "localName": "div",
-            "namespaceURI": "http://www.w3.org/1999/xhtml",
-            "childNodeCount": 2,
-            "attributes": {
-                "some_attr_name": "some_attr_value"},
-            "children": [{
-                "type": "node",
-                "value": {
-                    "nodeType": 3,
-                    "nodeValue": "some text",
-                    "nodeName": "some text"}
-            }, {
-                "type": "node",
-                "value": {
-                    "nodeType": 1,
-                    "nodeValue": "",
-                    "nodeName": "",
-                    "localName": "h2",
-                    "namespaceURI": "http://www.w3.org/1999/xhtml",
-                    "childNodeCount": 1,
-                    "attributes": {}}}]},
-        "objectId": "__any_value__"},
-        result, ["objectId"])
+        "result": {
+            "type": "node",
+            "value": {
+                "nodeType": 1,
+                "nodeValue": "",
+                "nodeName": "",
+                "localName": "div",
+                "namespaceURI": "http://www.w3.org/1999/xhtml",
+                "childNodeCount": 2,
+                "attributes": {
+                    "some_attr_name": "some_attr_value"},
+                "children": [{
+                    "type": "node",
+                    "value": {
+                        "nodeType": 3,
+                        "nodeValue": "some text",
+                        "nodeName": "some text"}
+                }, {
+                    "type": "node",
+                    "value": {
+                        "nodeType": 1,
+                        "nodeValue": "",
+                        "nodeName": "",
+                        "localName": "h2",
+                        "namespaceURI": "http://www.w3.org/1999/xhtml",
+                        "childNodeCount": 1,
+                        "attributes": {}}}]},
+            "objectId": "__any_value__"
+        }}, result, ["objectId"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,7 +27,7 @@ async def assertSerialization(websocket, context_id, js_str_object,
             "awaitPromise": False, }})
 
     # Compare ignoring `objectId`.
-    recursiveCompare(expected_serialized_object, result, ["objectId"])
+    recursiveCompare(expected_serialized_object, result["result"], ["objectId"])
 
 
 # Testing serialization.
@@ -47,7 +47,7 @@ async def assertDeserializationAndSerialization(websocket, context_id,
             "awaitPromise": False,
             "target": {"context": context_id}}})
     # Compare ignoring `objectId`.
-    recursiveCompare(expected_serialized_object, result, ["objectId"])
+    recursiveCompare(expected_serialized_object, result["result"], ["objectId"])
 
 
 @pytest.mark.asyncio
@@ -378,7 +378,7 @@ async def test_deserialization_serialization_date(websocket, context_id):
     # TODO(sadym): Add value check after date format is fixed.
     # https://github.com/w3c/webdriver-bidi/issues/202
     # assert result["value"] == "__some_specific_result__"
-    assert result["type"] == "date"
+    assert result["result"]["type"] == "date"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Align CallFunction and Evaluate results with the [W3C BiDi spec](https://w3c.github.io/webdriver-bidi/#type-script-Result):
```
{
    result: {
        result | exceptionDetails: {...}
    }
}
```