### PR TITLE
Improvements for WPT

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -177,15 +177,21 @@ export class BrowsingContextProcessor {
   async process_browsingContext_getTree(
     commandData: BrowsingContext.GetTreeCommand
   ): Promise<BrowsingContext.GetTreeResult> {
+    // TODO sadym: consider replacing with known targets.
     const { targetInfos } = await this._cdpConnection
       .browserClient()
       .Target.getTargets();
     // TODO sadym: implement.
-    if (commandData.params.maxDepth || commandData.params.parent)
-      throw new Error('not implemented yet');
+    if (commandData.params.maxDepth) throw new Error('not implemented yet');
     const contexts = targetInfos
       // Don't expose any information about the tab with Mapper running.
       .filter((target) => this._isValidTarget(target))
+      // Filter by `root`, if specified.
+      .filter(
+        (target) =>
+          commandData.params.root === undefined ||
+          commandData.params.root === target.targetId
+      )
       .map(BrowsingContextProcessor._targetToBiDiContext);
     return { result: { contexts } };
   }

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -103,32 +103,37 @@ export class Context {
     wait: BrowsingContext.ReadinessState
   ): Promise<BrowsingContext.NavigateResult> {
     // TODO: handle loading errors.
-    // noinspection TypeScriptValidateJSTypes
     const cdpNavigateResult = await this.#cdpClient.Page.navigate({ url });
 
-    // Wait for `wait` condition.
-    switch (wait) {
-      case 'none':
-        break;
+    // No `loaderId` means same-document navigation.
+    if (cdpNavigateResult.loaderId !== undefined) {
+      // Wait for `wait` condition.
+      switch (wait) {
+        case 'none':
+          break;
 
-      case 'interactive':
-        await this.#waitPageLifeCycleEvent(
-          'DOMContentLoaded',
-          cdpNavigateResult.loaderId!
-        );
-        break;
+        case 'interactive':
+          await this.#waitPageLifeCycleEvent(
+            'DOMContentLoaded',
+            cdpNavigateResult.loaderId!
+          );
+          break;
 
-      case 'complete':
-        await this.#waitPageLifeCycleEvent('load', cdpNavigateResult.loaderId!);
-        break;
+        case 'complete':
+          await this.#waitPageLifeCycleEvent(
+            'load',
+            cdpNavigateResult.loaderId!
+          );
+          break;
 
-      default:
-        throw new Error(`Not implemented wait '${wait}'`);
+        default:
+          throw new Error(`Not implemented wait '${wait}'`);
+      }
     }
 
     return {
       result: {
-        navigation: cdpNavigateResult.loaderId,
+        navigation: cdpNavigateResult.loaderId || null,
         url: url,
       },
     };

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -363,7 +363,7 @@ export namespace BrowsingContext {
 
   export type BrowsingContextGetTreeParameters = {
     maxDepth?: number;
-    parent?: BrowsingContext;
+    root?: BrowsingContext;
   };
 
   export type GetTreeResult = {

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -395,7 +395,7 @@ export namespace BrowsingContext {
   export type ReadinessState = 'none' | 'interactive' | 'complete';
   export type NavigateResult = {
     result: {
-      navigation?: Navigation;
+      navigation: Navigation | null;
       url: string;
     };
   };

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -37,9 +37,44 @@ async def test_browsingContext_getTree_contextReturned(websocket):
 
 @pytest.mark.asyncio
 # Not implemented yet.
-async def _ignore_test_browsingContext_getTreeWithGivenParent_contextReturned():
-    ignore = True
-    # TODO sadym: implement
+async def test_browsingContext_getTreeWithRoot_contextReturned(websocket,
+      context_id):
+    result = await execute_command(websocket, {
+        "method": "browsingContext.create",
+        "params": {"type": "tab"}})
+    new_context_id = result["context"]
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {}})
+
+    assert len(result['contexts']) == 2
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": new_context_id}})
+
+    assert result == {
+        "contexts": [{
+            "context": new_context_id,
+            "parent": None,
+            "url": "about:blank",
+            "children": None
+        }]}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": context_id}})
+
+    assert result == {
+        "contexts": [{
+            "context": context_id,
+            "parent": None,
+            "url": "about:blank",
+            "children": None
+        }]}
 
 
 @pytest.mark.asyncio

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -241,6 +241,92 @@ async def test_browsingContext_navigateWaitInteractive_navigated(websocket,
 
 
 @pytest.mark.asyncio
+async def test_browsingContext_navigateSameDocumentNavigation_navigated(
+      websocket,
+      context_id):
+    url = "data:text/html,<h2>test</h2>"
+    url_with_hash_1 = url + "#1"
+    url_with_hash_2 = url + "#2"
+
+    # Initial navigation.
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url,
+            "wait": "complete",
+            "context": context_id}})
+
+    # Navigate back and forth in the same document with `wait:none`.
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "none",
+            "context": context_id}})
+    recursiveCompare({
+        'navigation': '__any_value__',
+        'url': url_with_hash_1},
+        resp, "navigation")
+
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_2,
+            "wait": "none",
+            "context": context_id}})
+    recursiveCompare({
+        'navigation': '__any_value__',
+        'url': url_with_hash_2},
+        resp, "navigation")
+
+    # Navigate back and forth in the same document with `wait:interactive`.
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "interactive",
+            "context": context_id}})
+    recursiveCompare({
+        'navigation': '__any_value__',
+        'url': url_with_hash_1},
+        resp, "navigation")
+
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_2,
+            "wait": "interactive",
+            "context": context_id}})
+    recursiveCompare({
+        'navigation': '__any_value__',
+        'url': url_with_hash_2},
+        resp, "navigation")
+
+    # Navigate back and forth in the same document with `wait:complete`.
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "complete",
+            "context": context_id}})
+    recursiveCompare({
+        'navigation': '__any_value__',
+        'url': url_with_hash_1},
+        resp, "navigation")
+
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_2,
+            "wait": "complete",
+            "context": context_id}})
+    recursiveCompare({
+        'navigation': '__any_value__',
+        'url': url_with_hash_2},
+        resp, "navigation")
+
+
+@pytest.mark.asyncio
 async def test_PROTO_browsingContext_findElement_findsElement(websocket,
       context_id):
     await goto_url(websocket, context_id,

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/context_created/context_created.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/context_created/context_created.py.ini
@@ -1,5 +1,4 @@
 [context_created.py]
-  expected: TIMEOUT
   [test_new_context[tab\]]
     expected: FAIL
 

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/context_created/context_created.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/context_created/context_created.py.ini
@@ -1,4 +1,5 @@
 [context_created.py]
+  expected: TIMEOUT
   [test_new_context[tab\]]
     expected: FAIL
 

--- a/wpt-metadata/webdriver/tests/bidi/log/entry_added/stacktrace.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/log/entry_added/stacktrace.py.ini
@@ -8,9 +8,6 @@
   [test_console_entry_sync_callstack[error-True\]]
     expected: FAIL
 
-  [test_console_entry_sync_callstack[info-False\]]
-    expected: FAIL
-
   [test_console_entry_sync_callstack[log-False\]]
     expected: FAIL
 
@@ -24,4 +21,7 @@
     expected: FAIL
 
   [test_javascript_entry_sync_callstack]
+    expected: FAIL
+
+  [test_console_entry_sync_callstack[info-False\]]
     expected: FAIL


### PR DESCRIPTION
Required by `browsing_context/navigate` WPT tests:
* [getTree](https://github.com/web-platform-tests/wpt/blob/b293894e545af62931b996700bcfe06b5786414b/webdriver/tests/bidi/browsing_context/navigate/__init__.py#L8)
* [handle in-the-same-document navigation](https://github.com/web-platform-tests/wpt/blob/b293894e545af62931b996700bcfe06b5786414b/webdriver/tests/bidi/browsing_context/navigate/hash.py) 

Done:
* Add `root` parameter to `browsingContext.getTree`
* Handle in-the-same-document navigation
* Add e2e test

Out of scope: 
* Handle nested contexts.