### PR TITLE
Align implementation with spec

### DIFF
--- a/runWPT.sh
+++ b/runWPT.sh
@@ -3,7 +3,7 @@
 # Go to the project root folder.
 cd "$(dirname $0)/"
 
-npm run build && \
+#npm run build && \
 ./wpt/wpt run \
   --webdriver-binary ./runBiDiServer.sh \
   --binary "$WPT_BROWSER_PATH" \

--- a/runWPT.sh
+++ b/runWPT.sh
@@ -3,7 +3,7 @@
 # Go to the project root folder.
 cd "$(dirname $0)/"
 
-#npm run build && \
+npm run build && \
 ./wpt/wpt run \
   --webdriver-binary ./runBiDiServer.sh \
   --binary "$WPT_BROWSER_PATH" \
@@ -12,3 +12,4 @@ cd "$(dirname $0)/"
   --log-wptreport wptreport.json \
   chromium \
   $1
+#  --timeout-multiplier 4 \

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -84,7 +84,7 @@ export class BrowsingContextProcessor {
 
   private _getKnownContext(contextId: string): Context {
     if (!this._hasKnownContext(contextId)) {
-      throw new Error('context not found');
+      throw new NoSuchFrameException(`Context ${contextId} not found`);
     }
     return this._contexts.get(contextId)!;
   }

--- a/src/bidiMapper/domains/context/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/context/scriptEvaluator.ts
@@ -123,10 +123,14 @@ export class ScriptEvaluator {
           cdpCallFunctionResult.exceptionDetails,
           this.#callFunctionStacktraceLineOffset
         ),
+        realm: 'TODO: ADD',
       };
     }
 
-    return { result: ScriptEvaluator.#cdpToBidiValue(cdpCallFunctionResult) };
+    return {
+      result: ScriptEvaluator.#cdpToBidiValue(cdpCallFunctionResult),
+      realm: 'TODO: ADD',
+    };
   }
 
   async #serializeCdpExceptionDetails(
@@ -199,6 +203,7 @@ export class ScriptEvaluator {
             cdpEvaluateResult.exceptionDetails,
             this.#evaluateStacktraceLineOffset
           ),
+          realm: 'TODO: ADD',
         },
       };
     }
@@ -206,6 +211,7 @@ export class ScriptEvaluator {
     return {
       result: {
         result: ScriptEvaluator.#cdpToBidiValue(cdpEvaluateResult),
+        realm: 'TODO: ADD',
       },
     };
   }

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -386,10 +386,12 @@ export namespace Script {
   export type ScriptResult = ScriptResultSuccess | ScriptResultException;
   export type ScriptResultSuccess = {
     result: CommonDataTypes.RemoteValue;
+    realm: string;
   };
 
   export type ScriptResultException = {
     exceptionDetails: ExceptionDetails;
+    realm: string;
   };
 
   export type ExceptionDetails = {
@@ -428,6 +430,8 @@ export namespace Script {
   const TargetSchema = zod.union([ContextTargetSchema, RealmTargetSchema]);
   export type Target = zod.infer<typeof TargetSchema>;
 
+  const OwnershipModelSchema = zod.enum(['root', 'none']);
+
   // ScriptEvaluateParameters = {
   //   expression: text;
   //   target: Target;
@@ -438,6 +442,7 @@ export namespace Script {
     expression: zod.string(),
     awaitPromise: zod.boolean().optional(),
     target: TargetSchema,
+    resultOwnership: OwnershipModelSchema.optional(),
   });
 
   export type EvaluateParameters = zod.infer<
@@ -463,15 +468,13 @@ export namespace Script {
   ]);
   export type ArgumentValue = zod.infer<typeof ArgumentValueSchema>;
 
-  const OwnershipModelSchema = zod.enum(['root', 'none']);
-
   const ScriptCallFunctionParametersSchema = zod.object({
     functionDeclaration: zod.string(),
     target: TargetSchema,
     arguments: zod.array(ArgumentValueSchema).optional(),
     this: ArgumentValueSchema.optional(),
     awaitPromise: zod.boolean().optional(),
-    ownership: OwnershipModelSchema.optional(),
+    resultOwnership: OwnershipModelSchema.optional(),
   });
 
   export type CallFunctionParameters = zod.infer<

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -72,13 +72,14 @@ async def subscribe(websocket, event_names, context_ids=None):
     await execute_command(websocket, command)
 
 
-# Compares 2 objects recursively ignoring values of specific attributes.
-def recursiveCompare(expected, actual, ignore_attributes=[]):
+# Compares 2 objects recursively.
+# Expected value can be a callable delegate, asserting the value.
+def recursive_compare(expected, actual):
     assert type(expected) == type(actual)
     if type(expected) is list:
         assert len(expected) == len(actual)
         for index, val in enumerate(expected):
-            recursiveCompare(expected[index], actual[index], ignore_attributes)
+            recursive_compare(expected[index], actual[index])
         return
 
     if type(expected) is dict:
@@ -87,11 +88,30 @@ def recursiveCompare(expected, actual, ignore_attributes=[]):
             f"\nNot present: {set(expected.keys()) - set(actual.keys())}" \
             f"\nUnexpected: {set(actual.keys()) - set(expected.keys())}"
         for index, val in enumerate(expected):
-            if val not in ignore_attributes:
-                recursiveCompare(expected[val], actual[val], ignore_attributes)
+            if callable(expected[val]):
+                expected[val](actual[val])
+            else:
+                recursive_compare(expected[val], actual[val])
         return
 
     assert expected == actual
+
+
+def any_string(expected):
+    assert isinstance(expected, str), \
+        f"'{expected}' should be string, " \
+        f"but is {type(expected)} instead."
+
+
+def any_timestamp(expected):
+    assert isinstance(expected, float), \
+        f"'{expected}' should be a float, " \
+        f"but is {type(expected)} instead."
+
+
+# noinspection PyUnusedLocal
+def any_value(expected):
+    return
 
 
 # Returns an id of an open context.

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -261,10 +261,9 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
             "url": url_with_hash_1,
             "wait": "none",
             "context": context_id}})
-    recursiveCompare({
-        'navigation': '__any_value__',
-        'url': url_with_hash_1},
-        resp, "navigation")
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_1}
 
     resp = await execute_command(websocket, {
         "method": "browsingContext.navigate",
@@ -272,10 +271,9 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
             "url": url_with_hash_2,
             "wait": "none",
             "context": context_id}})
-    recursiveCompare({
-        'navigation': '__any_value__',
-        'url': url_with_hash_2},
-        resp, "navigation")
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_2}
 
     # Navigate back and forth in the same document with `wait:interactive`.
     resp = await execute_command(websocket, {
@@ -284,10 +282,9 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
             "url": url_with_hash_1,
             "wait": "interactive",
             "context": context_id}})
-    recursiveCompare({
-        'navigation': '__any_value__',
-        'url': url_with_hash_1},
-        resp, "navigation")
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_1}
 
     resp = await execute_command(websocket, {
         "method": "browsingContext.navigate",
@@ -295,10 +292,9 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
             "url": url_with_hash_2,
             "wait": "interactive",
             "context": context_id}})
-    recursiveCompare({
-        'navigation': '__any_value__',
-        'url': url_with_hash_2},
-        resp, "navigation")
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_2}
 
     # Navigate back and forth in the same document with `wait:complete`.
     resp = await execute_command(websocket, {
@@ -307,10 +303,9 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
             "url": url_with_hash_1,
             "wait": "complete",
             "context": context_id}})
-    recursiveCompare({
-        'navigation': '__any_value__',
-        'url': url_with_hash_1},
-        resp, "navigation")
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_1}
 
     resp = await execute_command(websocket, {
         "method": "browsingContext.navigate",
@@ -318,10 +313,9 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
             "url": url_with_hash_2,
             "wait": "complete",
             "context": context_id}})
-    recursiveCompare({
-        'navigation': '__any_value__',
-        'url': url_with_hash_2},
-        resp, "navigation")
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_2}
 
 
 @pytest.mark.asyncio
@@ -340,9 +334,11 @@ async def test_PROTO_browsingContext_findElement_findsElement(websocket,
             "selector": "body > .container",
             "context": context_id}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "node",
+            "handle": any_string,
             "value": {
                 "nodeType": 1,
                 "nodeValue": "",
@@ -379,10 +375,8 @@ async def test_PROTO_browsingContext_findElement_findsElement(websocket,
                         "namespaceURI": "http://www.w3.org/1999/xhtml",
                         "childNodeCount": 1,
                         "attributes": {
-                            "class": "child_2"}}
-                }]
-            }, "handle": "__SOME_handle_1__"
-        }}, result, ["handle"])
+                            "class": "child_2"}}}]}}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -397,7 +391,11 @@ async def test_PROTO_browsingContext_findElementMissingElement_missingElement(
             "selector": "body > h3",
             "context": context_id}})
 
-    assert result == {"result": {"type": "null"}}
+    recursive_compare({
+        "realm": any_string,
+        "result": {
+            "type": "null"}},
+        result)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -24,10 +24,9 @@ async def test_cdp_sendCommand_commandResultReturned(websocket):
             "cdpMethod": "Target.getTargets",
             "cdpParams": {}}})
 
-    recursiveCompare(
-        {"targetInfos": "__any_value_here__"},
-        command_result,
-        ["targetInfos"])
+    recursive_compare({
+        "targetInfos": any_value},
+        command_result)
 
 
 @pytest.mark.asyncio
@@ -51,7 +50,7 @@ async def test_cdp_subscribeCdpEvents_cdpEventReceived(websocket, context_id):
 
     resp = await read_JSON_message(websocket)
 
-    recursiveCompare({
+    recursive_compare({
         "method": "PROTO.cdp.eventReceived",
         "params": {
             "cdpMethod": "Runtime.consoleAPICalled",
@@ -61,8 +60,8 @@ async def test_cdp_subscribeCdpEvents_cdpEventReceived(websocket, context_id):
                     "type": "number",
                     "value": 1,
                     "description": "1"}],
-                "executionContextId": "__any_value__",
-                "timestamp": "__any_value__",
-                "stackTrace": "__any_value__"},
+                "executionContextId": any_value,
+                "timestamp": any_value,
+                "stackTrace": any_value},
             "session": session_id}},
-        resp, ["timestamp", "executionContextId", "stackTrace"])
+        resp)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -30,13 +30,13 @@ async def test_consoleLog_logEntryAddedEventEmitted(websocket, context_id):
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert "log.entryAdded" event emitted.
-    recursiveCompare({
+    recursive_compare({
         "method": "log.entryAdded",
         "params": {
             # BaseLogEntry
             "level": "info",
             "text": "some log message\u0020line 2",
-            "timestamp": "__any_value__",
+            "timestamp": any_timestamp,
             "stackTrace": {
                 "callFrames": [{
                     "url": "",
@@ -52,8 +52,7 @@ async def test_consoleLog_logEntryAddedEventEmitted(websocket, context_id):
                 "value": "some log message"}, {
                 "type": "string",
                 "value": "line 2"}]}},
-        event_response,
-        ["timestamp"])
+        event_response)
 
 
 @pytest.mark.asyncio
@@ -71,13 +70,13 @@ async def test_consoleLogWithNullUndefinedValues_logEntryAddedEventEmitted(
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert "log.entryAdded" event emitted.
-    recursiveCompare({
+    recursive_compare({
         "method": "log.entryAdded",
         "params": {
             # BaseLogEntry
             "level": "info",
             "text": "null\u0020undefined",
-            "timestamp": "__any_value__",
+            "timestamp": any_timestamp,
             "stackTrace": {
                 "callFrames": [{
                     "url": "",
@@ -91,8 +90,7 @@ async def test_consoleLogWithNullUndefinedValues_logEntryAddedEventEmitted(
             "args": [
                 {"type": "null"},
                 {"type": "undefined"}]}},
-        event_response,
-        ["timestamp"])
+        event_response)
 
 
 @pytest.mark.asyncio
@@ -149,7 +147,7 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert "log.entryAdded" event emitted.
-    recursiveCompare({
+    recursive_compare({
         "method": "log.entryAdded",
         "params": {
             # BaseLogEntry
@@ -157,7 +155,7 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
             "text": "format specificier, string: line 2, integer: 1, integer: "
                     "-2, float: 1.234, \"abc\", {\"id\": 1}, {\"font-size\": "
                     "\"20px\"}",
-            "timestamp": "__any_value__",
+            "timestamp": any_timestamp,
             "stackTrace": {
                 "callFrames": [{
                     "url": "",
@@ -188,7 +186,7 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
                 "type": "string",
                 "value": "abc"
             }, {
-                "handle": "__any_value__",
+                "handle": any_string,
                 "type": "object",
                 "value": [
                     ["id", {
@@ -196,15 +194,14 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
                         "value": 1
                     }]]
             }, {
-                "handle": "__any_value__",
+                "handle": any_string,
                 "type": "object",
                 "value": [[
                     "font-size", {
                         "type": "string",
                         "value": "20px"
                     }]]}]}},
-        event_response,
-        ("timestamp", "handle"))
+        event_response)
 
 
 @pytest.mark.asyncio
@@ -223,14 +220,14 @@ async def test_exceptionThrown_logEntryAddedEventEmitted(websocket, context_id):
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert "log.entryAdded" event emitted.
-    recursiveCompare(
+    recursive_compare(
         {
             "method": "log.entryAdded",
             "params": {
                 # BaseLogEntry
                 "level": "error",
                 "text": "Error: some error",
-                "timestamp": "__any_value__",
+                "timestamp": any_timestamp,
                 "stackTrace": {
                     "callFrames": [{
                         "url": "",
@@ -240,5 +237,4 @@ async def test_exceptionThrown_logEntryAddedEventEmitted(websocket, context_id):
                 # ConsoleLogEntry
                 "type": "javascript",
                 "realm": context_id}},
-        event_response,
-        ["timestamp"])
+        event_response)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -25,7 +25,8 @@ async def test_script_evaluateThrowingPrimitive_exceptionReturned(websocket,
             "expression": "(()=>{const a=()=>{throw 1;}; const b=()=>{a();};\nconst c=()=>{b();};c();})()",
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "exceptionDetails": {
             "text": "1",
             "columnNumber": 19,
@@ -58,8 +59,8 @@ async def test_script_evaluateThrowingPrimitive_exceptionReturned(websocket,
                     "url": "",
                     "functionName": "",
                     "lineNumber": 1,
-                    "columnNumber": 25}]}
-        }}, result, ["handle"])
+                    "columnNumber": 25}]}}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -71,14 +72,15 @@ async def test_script_evaluateThrowingError_exceptionReturned(websocket,
             "expression": "(()=>{const a=()=>{throw new Error('foo');}; const b=()=>{a();};\nconst c=()=>{b();};c();})()",
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "exceptionDetails": {
             "text": "Error: foo",
             "columnNumber": 19,
             "lineNumber": 0,
             "exception": {
                 "type": "error",
-                "handle": "__any_value__"
+                "handle": any_string
             },
             "stackTrace": {
                 "callFrames": [{
@@ -105,8 +107,8 @@ async def test_script_evaluateThrowingError_exceptionReturned(websocket,
                     "url": "",
                     "functionName": "",
                     "lineNumber": 1,
-                    "columnNumber": 25}]}
-        }}, exception_details, ["handle"])
+                    "columnNumber": 25}]}}},
+        exception_details)
 
 
 @pytest.mark.asyncio
@@ -120,11 +122,12 @@ async def test_script_evaluateDontWaitPromise_promiseReturned(websocket,
             "target": {"context": context_id}}})
 
     # Compare ignoring `handle`.
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "promise",
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
 
 # Uncomment after behaviour is clarified:
@@ -160,11 +163,12 @@ async def test_script_evaluateWaitPromise_resultReturned(websocket, context_id):
             "target": {"context": context_id}}})
 
     # Compare ignoring `handle`.
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "SOME_RESULT"
-        }}, result, ["handle"])
+            "value": "SOME_RESULT"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -189,7 +193,8 @@ async def test_script_evaluateChangingObject_resultObjectDidNotChange(
             "target": {"context": context_id}}})
 
     # Verify the object wasn't changed.
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "object",
             "value": [[
@@ -197,8 +202,8 @@ async def test_script_evaluateChangingObject_resultObjectDidNotChange(
                     "type": "number",
                     "value": 0
                 }]],
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -211,10 +216,12 @@ async def test_script_evaluateInteractsWithDom_resultReceived(websocket,
             "expression": "'!!@@##, ' + window.location.href",
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "!!@@##, about:blank"}}
+            "value": "!!@@##, about:blank"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -232,7 +239,8 @@ async def test_script_callFunctionWithArgs_resultReturn(websocket, context_id):
             }],
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "array",
             "value": [{
@@ -241,8 +249,8 @@ async def test_script_callFunctionWithArgs_resultReturn(websocket, context_id):
             }, {
                 "type": 'number',
                 "value": 42}],
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
 
 # Uncomment after behaviour is clarified:
@@ -265,7 +273,7 @@ async def test_script_callFunctionWithArgs_resultReturn(websocket, context_id):
 #             "target": {"context": context_id}}})
 #
 #     recursiveCompare({
-#         "handle": "__any_value__",
+#         "handle": any_string,
 #         "type": "object",
 #         "value": [[
 #             "then", {
@@ -290,11 +298,12 @@ async def test_script_callFunctionWithArgsAndDoNotAwaitPromise_promiseReturn(
             "awaitPromise": False,
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "promise",
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -318,10 +327,12 @@ async def test_script_callFunctionWithRemoteValueArgument_resultReturn(
             }],
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "SOME_VALUE"}}
+            "value": "SOME_VALUE"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -338,10 +349,12 @@ async def test_script_callFunctionWithAsyncArrowFunctionAndAwaitPromise_resultRe
             "awaitPromise": True,
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "SOME_VALUE"}}
+            "value": "SOME_VALUE"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -358,11 +371,12 @@ async def test_script_callFunctionWithAsyncArrowFunctionAndAwaitPromiseFalse_pro
             "awaitPromise": False,
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "promise",
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -379,10 +393,12 @@ async def test_script_callFunctionWithAsyncClassicFunctionAndAwaitPromise_result
             "awaitPromise": True,
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "SOME_VALUE"}}
+            "value": "SOME_VALUE"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -399,11 +415,12 @@ async def test_script_callFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_p
             "awaitPromise": False,
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "promise",
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -419,10 +436,12 @@ async def test_script_callFunctionWithArrowFunctionAndThisParameter_thisIsIgnore
             },
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "Window"}}
+            "value": "Window"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -438,10 +457,12 @@ async def test_script_callFunctionWithClassicFunctionAndThisParameter_thisIsUsed
             },
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "Number"}}
+            "value": "Number"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -458,10 +479,12 @@ async def _ignore_test_script_callFunctionWithClassicFunctionAndThisParameter_th
             },
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "number",
-            "value": 42}}
+            "value": 42}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -490,10 +513,12 @@ async def test_script_callFunctionWithNode_resultReceived(websocket,
                 "handle": handle}],
             "target": {"context": context_id}}})
 
-    assert result == {
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "string",
-            "value": "!!@@##, test"}}
+            "value": "!!@@##, test"}},
+        result)
 
 
 @pytest.mark.asyncio
@@ -505,11 +530,12 @@ async def test_script_evaluate_windowOpen_windowOpened(websocket,
             "expression": "window.open()",
             "target": {"context": context_id}}})
 
-    recursiveCompare({
+    recursive_compare({
+        "realm": any_string,
         "result": {
             "type": "window",
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+            "handle": any_string}},
+        result)
 
     result = await execute_command(websocket,
                                    {"method": "browsingContext.getTree",

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,7 +27,7 @@ async def assertSerialization(websocket, context_id, js_str_object,
             "awaitPromise": False, }})
 
     # Compare ignoring `handle`.
-    recursiveCompare(expected_serialized_object, result["result"], ["handle"])
+    recursive_compare(expected_serialized_object, result["result"])
 
 
 # Testing serialization.
@@ -47,7 +47,7 @@ async def assertDeserializationAndSerialization(websocket, context_id,
             "awaitPromise": False,
             "target": {"context": context_id}}})
     # Compare ignoring `handle`.
-    recursiveCompare(expected_serialized_object, result["result"], ["handle"])
+    recursive_compare(expected_serialized_object, result["result"])
 
 
 @pytest.mark.asyncio
@@ -122,7 +122,7 @@ async def test_serialization_function(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "function(){}", {
                                   "type": "function",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -131,7 +131,7 @@ async def test_serialization_promise(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "Promise.resolve(1)", {
                                   "type": "promise",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -140,7 +140,7 @@ async def test_serialization_weakMap(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "new WeakMap()", {
                                   "type": "weakmap",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -149,7 +149,7 @@ async def test_serialization_weakSet(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "new WeakSet()", {
                                   "type": "weakset",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -159,7 +159,7 @@ async def test_serialization_proxy(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "new Proxy({}, {})", {
                                   "type": "proxy",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -168,7 +168,7 @@ async def test_serialization_typedarray(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "new Int32Array()", {
                                   "type": "typedarray",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -177,7 +177,7 @@ async def test_serialization_object(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "{'foo': {'bar': 'baz'}, 'qux': 'quux'}", {
                                   "type": "object",
-                                  "handle": "__any_value__",
+                                  "handle": any_string,
                                   "value": [[
                                       "foo", {
                                           "type": "object"}], [
@@ -203,7 +203,7 @@ async def test_deserialization_serialization_object(websocket, context_id):
                                                         "value": "quux"}]]},
                                                 {
                                                     "type": "object",
-                                                    "handle": "__any_value__",
+                                                    "handle": any_string,
                                                     "value": [[
                                                         "foo", {
                                                             "type": "object"}
@@ -230,7 +230,7 @@ async def test_deserialization_serialization_map(websocket, context_id):
                                                         "value": "quux"}]]},
                                                 {
                                                     "type": "map",
-                                                    "handle": "__any_value__",
+                                                    "handle": any_string,
                                                     "value": [[
                                                         "foo", {
                                                             "type": "object"}
@@ -253,7 +253,7 @@ async def test_deserialization_serialization_array(websocket, context_id):
                                                         "value": "a"
                                                     }]}, {
                                                     "type": "array",
-                                                    "handle": "__any_value__",
+                                                    "handle": any_string,
                                                     "value": [{
                                                         "type": "number",
                                                         "value": 1
@@ -268,7 +268,7 @@ async def test_serialization_array(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "[1, 'a', {foo: 'bar'}, [2,[3,4]]]", {
                                   "type": "array",
-                                  "handle": "__any_value__",
+                                  "handle": any_string,
                                   "value": [{
                                       "type": "number",
                                       "value": 1
@@ -294,7 +294,7 @@ async def test_deserialization_serialization_set(websocket, context_id):
                                                         "value": "a"
                                                     }]}, {
                                                     "type": "set",
-                                                    "handle": "__any_value__",
+                                                    "handle": any_string,
                                                     "value": [{
                                                         "type": "number",
                                                         "value": 1
@@ -309,7 +309,7 @@ async def test_serialization_set(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "new Set([1, 'a', {foo: 'bar'}, [2,[3,4]]])", {
                                   "type": "set",
-                                  "handle": "__any_value__",
+                                  "handle": any_string,
                                   "value": [{
                                       "type": "number",
                                       "value": 1
@@ -336,7 +336,7 @@ async def test_serialization_symbol(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "Symbol('foo')", {
                                   "type": "symbol",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -351,7 +351,7 @@ async def test_deserialization_serialization_regExp(websocket, context_id):
                                                     }
                                                 }, {
                                                     "type": "regexp",
-                                                    "handle": "__any_value__",
+                                                    "handle": any_string,
                                                     "value": {
                                                         "pattern": "ab+c",
                                                         "flags": "i"
@@ -386,7 +386,7 @@ async def test_serialization_windowProxy(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "this.window", {
                                   "type": "window",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -395,7 +395,7 @@ async def test_serialization_error(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "new Error('Woops!')", {
                                   "type": "error",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -411,36 +411,35 @@ async def test_serialization_node(websocket, context_id):
             "selector": "body > div",
             "context": context_id}})
 
-    recursiveCompare({
-        "result": {
-            "type": "node",
-            "value": {
-                "nodeType": 1,
-                "nodeValue": "",
-                "nodeName": "",
-                "localName": "div",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "childNodeCount": 2,
-                "attributes": {
-                    "some_attr_name": "some_attr_value"},
-                "children": [{
-                    "type": "node",
-                    "value": {
-                        "nodeType": 3,
-                        "nodeValue": "some text",
-                        "nodeName": "some text"}
-                }, {
-                    "type": "node",
-                    "value": {
-                        "nodeType": 1,
-                        "nodeValue": "",
-                        "nodeName": "",
-                        "localName": "h2",
-                        "namespaceURI": "http://www.w3.org/1999/xhtml",
-                        "childNodeCount": 1,
-                        "attributes": {}}}]},
-            "handle": "__any_value__"
-        }}, result, ["handle"])
+    recursive_compare({
+        "type": "node",
+        "handle": any_string,
+        "value": {
+            "nodeType": 1,
+            "nodeValue": "",
+            "nodeName": "",
+            "localName": "div",
+            "namespaceURI": "http://www.w3.org/1999/xhtml",
+            "childNodeCount": 2,
+            "attributes": {
+                "some_attr_name": "some_attr_value"},
+            "children": [{
+                "type": "node",
+                "value": {
+                    "nodeType": 3,
+                    "nodeValue": "some text",
+                    "nodeName": "some text"}
+            }, {
+                "type": "node",
+                "value": {
+                    "nodeType": 1,
+                    "nodeValue": "",
+                    "nodeName": "",
+                    "localName": "h2",
+                    "namespaceURI": "http://www.w3.org/1999/xhtml",
+                    "childNodeCount": 1,
+                    "attributes": {}}}]}},
+        result["result"])
 
 
 @pytest.mark.asyncio
@@ -449,7 +448,7 @@ async def _ignore_test_serialization_iterator(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "[].entries()", {
                                   "type": "iterator",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })
 
 
@@ -459,5 +458,5 @@ async def _ignore_test_serialization_generator(websocket, context_id):
     await assertSerialization(websocket, context_id,
                               "function* (){}", {
                                   "type": "generator",
-                                  "handle": "__any_value__"
+                                  "handle": any_string
                               })

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/navigate/invalid.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/navigate/invalid.py.ini
@@ -2,9 +2,6 @@
   [test_params_context_invalid_value[\]]
     expected: FAIL
 
-  [test_params_context_invalid_value[somestring\]]
-    expected: FAIL
-
   [test_params_url_invalid_type[None\]]
     expected: ERROR
 


### PR DESCRIPTION
* Align `browsingContext.created` with spec.
* Delegate waiting for initiated logic to `Context`.
* Refactor `recursive_compare` to support custom validators.