### PR TITLE
Align BrowsingContextInfo serialization with spec

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -86,7 +86,9 @@ export class BrowsingContextProcessor {
     Context.addContext(context);
 
     await this.#eventManager.sendEvent(
-      new BrowsingContext.ContextCreatedEvent(context.serializeToBidiValue(0)),
+      new BrowsingContext.ContextCreatedEvent(
+        context.serializeToBidiValue(0, true)
+      ),
       context.getContextId()
     );
   }
@@ -111,7 +113,7 @@ export class BrowsingContextProcessor {
     Context.removeContext(contextId);
     await this.#eventManager.sendEvent(
       new BrowsingContext.ContextDestroyedEvent(
-        context.serializeToBidiValue(0)
+        context.serializeToBidiValue(0, true)
       ),
       contextId
     );
@@ -128,7 +130,7 @@ export class BrowsingContextProcessor {
     return {
       result: {
         contexts: resultContexts.map((c) =>
-          c.serializeToBidiValue(params.maxDepth ?? Number.MAX_VALUE)
+          c.serializeToBidiValue(params.maxDepth ?? Number.MAX_VALUE, true)
         ),
       },
     };

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -97,15 +97,20 @@ export abstract class Context implements IContext {
     awaitPromise: boolean
   ): Promise<Script.EvaluateResult>;
 
-  public serializeToBidiValue(maxDepth: number): BrowsingContext.Info {
+  public serializeToBidiValue(
+    maxDepth: number,
+    isRoot: boolean
+  ): BrowsingContext.Info {
     return {
       context: this.#contextId,
-      parent: this.#parentId,
       url: this.#url,
       children:
         maxDepth > 0
-          ? this.getChildren().map((c) => c.serializeToBidiValue(maxDepth - 1))
+          ? this.getChildren().map((c) =>
+              c.serializeToBidiValue(maxDepth - 1, false)
+            )
           : null,
+      ...(isRoot ? { parent: this.#parentId } : {}),
     };
   }
 

--- a/src/bidiMapper/domains/context/iContext.ts
+++ b/src/bidiMapper/domains/context/iContext.ts
@@ -26,7 +26,7 @@ export interface IContext {
 
   getChildren(): IContext[];
 
-  serializeToBidiValue(maxDepth: number): BrowsingContext.Info;
+  serializeToBidiValue(maxDepth: number, isRoot: boolean): BrowsingContext.Info;
 
   navigate(
     url: string,

--- a/src/bidiMapper/domains/context/targetContext.ts
+++ b/src/bidiMapper/domains/context/targetContext.ts
@@ -225,7 +225,7 @@ export class TargetContext extends Context {
 
         await this.#eventManager.sendEvent(
           new BrowsingContext.ContextCreatedEvent(
-            frameContext.serializeToBidiValue(0)
+            frameContext.serializeToBidiValue(0, true)
           ),
           frameContext.getContextId()
         );

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -80,7 +80,6 @@ async def test_browsingContext_getTreeWithNestedSameOriginContexts_contextsRetur
             "context": context_id,
             "children": [{
                 "context": any_string,
-                "parent": context_id,
                 "url": nested_iframe,
                 "children": []
             }],
@@ -112,7 +111,6 @@ async def test_browsingContext_getTreeWithNestedCrossOriginContexts_contextsRetu
             "context": context_id,
             "children": [{
                 "context": any_string,
-                "parent": context_id,
                 "url": nested_iframe,
                 "children": []
             }],
@@ -202,12 +200,10 @@ async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCr
             "url": top_level_page,
             "children": [{
                 "context": any_string,
-                "parent": any_string,
                 # It's not guaranteed the nested page is already loaded.
                 "url": any_string,
                 "children": [{
                     "context": any_string,
-                    "parent": any_string,
                     # It's not guaranteed the nested page is already loaded.
                     "url": any_string,
                     "children": []}]}, ]}]


### PR DESCRIPTION
`parent` should be present only in the root serialized context: https://w3c.github.io/webdriver-bidi/#type-browsingContext-BrowsingContextInfo