### PR TITLE
Respect `url` changes from `Page` events

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -146,7 +146,9 @@ export class BrowsingContextProcessor {
         if (!Context.hasKnownContext(contextId)) {
           return;
         }
-        Context.getKnownContext(contextId).setUrl(params.frame.url);
+        Context.getKnownContext(contextId).setUrl(
+          params.frame.url + (params.frame.urlFragment ?? '')
+        );
       }
     );
   }

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -151,6 +151,17 @@ export class BrowsingContextProcessor {
         );
       }
     );
+
+    sessionCdpClient.Page.on(
+      'navigatedWithinDocument',
+      async function (params: Protocol.Page.NavigatedWithinDocumentEvent) {
+        const contextId = params.frameId;
+        if (!Context.hasKnownContext(contextId)) {
+          return;
+        }
+        Context.getKnownContext(contextId).setUrl(params.url);
+      }
+    );
   }
 
   async #handleAttachedToTargetEvent(

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -59,7 +59,7 @@ async def test_browsingContext_getTreeWithRoot_contextReturned(websocket,
 
 
 @pytest.mark.asyncio
-async def test_navigateToPageWithHash_contxtInfoUpdated(
+async def test_navigateToPageWithHash_contextInfoUpdated(
       websocket,
       context_id):
     url = "data:text/html,<h2>test</h2>"

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -59,6 +59,33 @@ async def test_browsingContext_getTreeWithRoot_contextReturned(websocket,
 
 
 @pytest.mark.asyncio
+async def test_navigateToPageWithHash_contxtInfoUpdated(
+      websocket,
+      context_id):
+    url = "data:text/html,<h2>test</h2>"
+    url_with_hash_1 = url + "#1"
+
+    # Initial navigation.
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "complete",
+            "context": context_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {}})
+
+    assert result == {
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_1}]}
+
+
+@pytest.mark.asyncio
 async def test_browsingContext_getTreeWithNestedSameOriginContexts_contextsReturned(
       websocket, context_id):
     nested_iframe = 'data:text/html,<h1>CHILD_PAGE</h1>'

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -414,8 +414,7 @@ async def test_browsingContext_navigateWaitComplete_navigated(websocket,
 
 @pytest.mark.asyncio
 async def test_browsingContext_navigateSameDocumentNavigation_navigated(
-      websocket,
-      context_id):
+      websocket, context_id):
     url = "data:text/html,<h2>test</h2>"
     url_with_hash_1 = url + "#1"
     url_with_hash_2 = url + "#2"
@@ -460,6 +459,19 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
         'navigation': None,
         'url': url_with_hash_1}
 
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": context_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_1}]},
+        result)
+
     resp = await execute_command(websocket, {
         "method": "browsingContext.navigate",
         "params": {
@@ -469,6 +481,19 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
     assert resp == {
         'navigation': None,
         'url': url_with_hash_2}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": context_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_2}]},
+        result)
 
     # Navigate back and forth in the same document with `wait:complete`.
     resp = await execute_command(websocket, {
@@ -481,6 +506,19 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
         'navigation': None,
         'url': url_with_hash_1}
 
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": context_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_1}]},
+        result)
+
     resp = await execute_command(websocket, {
         "method": "browsingContext.navigate",
         "params": {
@@ -490,6 +528,19 @@ async def test_browsingContext_navigateSameDocumentNavigation_navigated(
     assert resp == {
         'navigation': None,
         'url': url_with_hash_2}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": context_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_2}]},
+        result)
 
 
 @pytest.mark.asyncio

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -17,6 +17,34 @@ from _helpers import *
 
 
 @pytest.mark.asyncio
+async def test_iframe_navigateToPageWithHash_contextInfoUpdated(websocket,
+      iframe_id):
+    url = "data:text/html,<h2>test</h2>"
+    url_with_hash_1 = url + "#1"
+
+    # Initial navigation.
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "complete",
+            "context": iframe_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": any_string,
+            "url": url_with_hash_1}]},
+        result);
+
+
+@pytest.mark.asyncio
 async def test_iframe_navigateWaitNone_navigated(websocket, iframe_id):
     await subscribe(websocket, ["browsingContext.domContentLoaded",
                                 "browsingContext.load"])

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -41,7 +41,7 @@ async def test_iframe_navigateToPageWithHash_contextInfoUpdated(websocket,
             "children": [],
             "parent": any_string,
             "url": url_with_hash_1}]},
-        result);
+        result)
 
 
 @pytest.mark.asyncio
@@ -163,3 +163,134 @@ async def test_iframe_navigateWaitComplete_navigated(websocket, iframe_id):
         "params": {
             "context": iframe_id,
             "navigation": navigation_id}}
+
+
+@pytest.mark.asyncio
+async def test_iframe_navigateSameDocumentNavigation_navigated(
+      websocket, iframe_id):
+    url = "data:text/html,<h2>test</h2>"
+    url_with_hash_1 = url + "#1"
+    url_with_hash_2 = url + "#2"
+
+    # Initial navigation.
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url,
+            "wait": "complete",
+            "context": iframe_id}})
+
+    # Navigate back and forth in the same document with `wait:none`.
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "none",
+            "context": iframe_id}})
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_1}
+
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_2,
+            "wait": "none",
+            "context": iframe_id}})
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_2}
+
+    # Navigate back and forth in the same document with `wait:interactive`.
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "interactive",
+            "context": iframe_id}})
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_1}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": any_string,
+            "url": url_with_hash_1}]},
+        result)
+
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_2,
+            "wait": "interactive",
+            "context": iframe_id}})
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_2}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": any_string,
+            "url": url_with_hash_2}]},
+        result)
+
+    # Navigate back and forth in the same document with `wait:complete`.
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_1,
+            "wait": "complete",
+            "context": iframe_id}})
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_1}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": any_string,
+            "url": url_with_hash_1}]},
+        result)
+
+    resp = await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": url_with_hash_2,
+            "wait": "complete",
+            "context": iframe_id}})
+    assert resp == {
+        'navigation': None,
+        'url': url_with_hash_2}
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {
+            "root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": any_string,
+            "url": url_with_hash_2}]},
+        result)

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/navigate/hash.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/navigate/hash.py.ini
@@ -1,3 +1,0 @@
-[hash.py]
-  [test_navigate_in_iframe]
-    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/navigate/hash.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/navigate/hash.py.ini
@@ -1,18 +1,3 @@
 [hash.py]
-  [test_navigate_in_the_same_document[with different hashes\]]
-    expected: FAIL
-
-  [test_navigate_in_the_same_document[with identical hashes\]]
-    expected: FAIL
-
-  [test_navigate_in_the_same_document[with hash to without hash\]]
-    expected: FAIL
-
-  [test_navigate_different_documents[with identical hashes\]]
-    expected: FAIL
-
-  [test_navigate_different_documents[with different hashes\]]
-    expected: FAIL
-
   [test_navigate_in_iframe]
     expected: FAIL


### PR DESCRIPTION
1. Respect `urlFragment` when processing event [`Page.frameNavigated`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-frameNavigated):
* `url`: Frame document's URL without fragment.
* `urlFragment`: Frame document's URL fragment including the '#'.
2. Respect `url` change from `Page.navigatedWithinDocument`.