### PR TITLE
Add terser minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "rollup": "^2.74.1",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-string": "^3.0.0",
+    "rollup-plugin-terser": "^7.0.2",
     "sinon": "^14.0.0",
+    "terser": "^5.14.2",
     "typescript": "^4.7.2",
     "zod": "^3.17.3"
   }

--- a/src/bidiMapper/rollup.config.js
+++ b/src/bidiMapper/rollup.config.js
@@ -19,6 +19,7 @@ import typescript from '@rollup/plugin-typescript';
 import nodePolyfills from 'rollup-plugin-node-polyfills';
 import json from '@rollup/plugin-json';
 import { string } from 'rollup-plugin-string';
+import { terser } from 'rollup-plugin-terser';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
@@ -40,5 +41,10 @@ export default {
     }),
     nodeResolve(),
     commonjs(),
+    terser({
+      format: {
+        comments: /copyright/i,
+      },
+    }),
   ],
 };


### PR DESCRIPTION
The rolled-up src/.build/bidiMapper/mapper.js script has a size of 936K.
With the terser minification it gets reduced to 528K (43% size
reduction).

Integrate terser to the build process as a rollup plug-in.

Bug: #89