### PR TITLE
Terser minification: preserve only one copyright notice.

### DIFF
--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -13,6 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * @license
  */
 
 import { CommandProcessor } from './commandProcessor';

--- a/src/bidiMapper/rollup.config.js
+++ b/src/bidiMapper/rollup.config.js
@@ -41,10 +41,6 @@ export default {
     }),
     nodeResolve(),
     commonjs(),
-    terser({
-      format: {
-        comments: /copyright/i,
-      },
-    }),
+    terser(),
   ],
 };


### PR DESCRIPTION
From follow-up comments on #221, we do not need all copyright notices to
be preserved, only one of them should be enough.