### PR TITLE
github workflow: add step to print the mapper file size

### DIFF
--- a/.github/workflows/unit.js.yml
+++ b/.github/workflows/unit.js.yml
@@ -21,6 +21,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Verify mapper size
+        run: du -sh src/.build/bidiMapper/mapper.js
       - name: Run unit tests
         run: npm run unit
 env:


### PR DESCRIPTION
This adds a straightforward way to measure the effectiveness of #89
wherein we intend to optimize mapper compiled code.