### PR TITLE
Deferred

### DIFF
--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -97,14 +97,17 @@ export abstract class Context {
     this.#sessionId = sessionId;
     this.cdpClient = cdpClient;
 
-    this.setCDPListeners();
+    this.#setCdpListeners();
   }
 
-  setCDPListeners() {
+  #setCdpListeners() {
     this.cdpClient.Page.on(
       'lifecycleEvent',
-      async (params: Protocol.Page.LifecycleEventEvent) => {
-        let map = undefined;
+      (params: Protocol.Page.LifecycleEventEvent) => {
+        let map: Map<
+          string,
+          Deferred<Protocol.Page.LifecycleEventEvent>
+        > | null = null;
         if (params.name === 'DOMContentLoaded') {
           map = this.#targetDeferres.Page.lifecycleEvent.DOMContentLoaded;
         }
@@ -118,7 +121,7 @@ export abstract class Context {
 
     this.cdpClient.Page.on(
       'navigatedWithinDocument',
-      async (params: Protocol.Page.NavigatedWithinDocumentEvent) => {
+      (params: Protocol.Page.NavigatedWithinDocumentEvent) => {
         if (params.frameId !== this.getContextId()) {
           return;
         }

--- a/src/bidiMapper/domains/context/context.ts
+++ b/src/bidiMapper/domains/context/context.ts
@@ -19,8 +19,22 @@ import { Protocol } from 'devtools-protocol';
 import { BrowsingContext, Script } from '../protocol/bidiProtocolTypes';
 import { NoSuchFrameException, UnknownErrorResponse } from '../protocol/error';
 import { CdpClient } from '../../../cdp';
+import { Deferred } from '../../utils/deferred';
 
 export abstract class Context {
+  readonly #targetDeferres = {
+    Page: {
+      navigatedWithinDocument: new Deferred(),
+      lifecycleEvent: {
+        DOMContentLoaded: new Map<
+          string,
+          Deferred<Protocol.Page.LifecycleEventEvent>
+        >(),
+        load: new Map<string, Deferred<Protocol.Page.LifecycleEventEvent>>(),
+      },
+    },
+  };
+
   static #contexts: Map<string, Context> = new Map();
   protected readonly cdpClient: CdpClient;
 
@@ -82,6 +96,36 @@ export abstract class Context {
     this.#parentId = parent;
     this.#sessionId = sessionId;
     this.cdpClient = cdpClient;
+
+    this.setCDPListeners();
+  }
+
+  setCDPListeners() {
+    this.cdpClient.Page.on(
+      'lifecycleEvent',
+      async (params: Protocol.Page.LifecycleEventEvent) => {
+        let map = undefined;
+        if (params.name === 'DOMContentLoaded') {
+          map = this.#targetDeferres.Page.lifecycleEvent.DOMContentLoaded;
+        }
+        if (params.name === 'load') {
+          map = this.#targetDeferres.Page.lifecycleEvent.load;
+        }
+
+        map?.get(params.loaderId)?.resolve(params);
+      }
+    );
+
+    this.cdpClient.Page.on(
+      'navigatedWithinDocument',
+      async (params: Protocol.Page.NavigatedWithinDocumentEvent) => {
+        if (params.frameId !== this.getContextId()) {
+          return;
+        }
+        this.#targetDeferres.Page.navigatedWithinDocument.resolve(params);
+        this.#targetDeferres.Page.navigatedWithinDocument = new Deferred();
+      }
+    );
   }
 
   abstract callFunction(
@@ -166,11 +210,11 @@ export abstract class Context {
       case 'interactive':
         // No `loaderId` means same-document navigation.
         if (cdpNavigateResult.loaderId === undefined) {
-          await this.waitNavigatedWithinDocument();
+          await this.#targetDeferres.Page.navigatedWithinDocument;
         } else {
-          await this.waitPageLifeCycleEvent(
-            'DOMContentLoaded',
-            cdpNavigateResult.loaderId!
+          await Context.#waitForDeferredWithKey(
+            cdpNavigateResult.loaderId,
+            this.#targetDeferres.Page.lifecycleEvent.DOMContentLoaded
           );
         }
         break;
@@ -178,11 +222,11 @@ export abstract class Context {
       case 'complete':
         // No `loaderId` means same-document navigation.
         if (cdpNavigateResult.loaderId === undefined) {
-          await this.waitNavigatedWithinDocument();
+          await this.#targetDeferres.Page.navigatedWithinDocument;
         } else {
-          await this.waitPageLifeCycleEvent(
-            'load',
-            cdpNavigateResult.loaderId!
+          await Context.#waitForDeferredWithKey(
+            cdpNavigateResult.loaderId,
+            this.#targetDeferres.Page.lifecycleEvent.load
           );
         }
         break;
@@ -199,43 +243,13 @@ export abstract class Context {
     };
   }
 
-  protected async waitPageLifeCycleEvent(eventName: string, loaderId: string) {
-    return new Promise<Protocol.Page.LifecycleEventEvent>((resolve) => {
-      const handleLifecycleEvent = async (
-        params: Protocol.Page.LifecycleEventEvent
-      ) => {
-        if (params.name !== eventName || params.loaderId !== loaderId) {
-          return;
-        }
-        this.cdpClient.Page.removeListener(
-          'lifecycleEvent',
-          handleLifecycleEvent
-        );
-        resolve(params);
-      };
-
-      this.cdpClient.Page.on('lifecycleEvent', handleLifecycleEvent);
-    });
-  }
-
-  protected async waitNavigatedWithinDocument() {
-    return new Promise<Protocol.Page.NavigatedWithinDocumentEvent>(
-      (resolve) => {
-        const handleLifecycleEvent = async (
-          params: Protocol.Page.NavigatedWithinDocumentEvent
-        ) => {
-          if (params.frameId !== this.getContextId()) {
-            return;
-          }
-          this.cdpClient.Page.removeListener(
-            'navigatedWithinDocument',
-            handleLifecycleEvent
-          );
-          resolve(params);
-        };
-
-        this.cdpClient.Page.on('navigatedWithinDocument', handleLifecycleEvent);
-      }
-    );
+  static async #waitForDeferredWithKey<T>(
+    key: string,
+    map: Map<string, Deferred<T>>
+  ): Promise<T> {
+    if (!map.has(key)) {
+      map.set(key, new Deferred<T>());
+    }
+    return map.get(key)!;
   }
 }

--- a/src/bidiMapper/domains/context/targetContext.ts
+++ b/src/bidiMapper/domains/context/targetContext.ts
@@ -23,6 +23,7 @@ import { IEventManager } from '../events/EventManager';
 import { LogManager } from '../log/logManager';
 import { ScriptEvaluator } from '../script/scriptEvaluator';
 import { Context } from './context';
+import { Deferred } from '../../utils/deferred';
 
 export class TargetContext extends Context {
   readonly #sessionId: string;
@@ -30,17 +31,7 @@ export class TargetContext extends Context {
   readonly #eventManager: IEventManager;
   readonly #scriptEvaluator: ScriptEvaluator;
 
-  // Delegate to resolve `#initialized`.
-  #markContextInitialized: () => void = () => {
-    throw Error('Context is not created yet.');
-  };
-
-  // `#initialized` is resolved when `#markContextInitialized` is called.
-  #initialized: Promise<void> = new Promise((resolve) => {
-    this.#markContextInitialized = () => {
-      resolve();
-    };
-  });
+  #initialized: Deferred<void> = new Deferred<void>();
 
   async waitInitialized(): Promise<void> {
     await this.#initialized;
@@ -145,6 +136,6 @@ export class TargetContext extends Context {
     });
 
     await this.cdpClient.Runtime.runIfWaitingForDebugger();
-    this.#markContextInitialized();
+    this.#initialized.resolve();
   }
 }

--- a/src/bidiMapper/utils/deferred.ts
+++ b/src/bidiMapper/utils/deferred.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC.
+ * Copyright 2022 Google LLC.
  * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/bidiMapper/utils/deferred.ts
+++ b/src/bidiMapper/utils/deferred.ts
@@ -28,23 +28,14 @@ export class Deferred<T> implements Promise<T> {
   }
 
   then<TResult1 = T, TResult2 = never>(
-    onFulfilled?:
-      | ((value: T) => TResult1 | PromiseLike<TResult1>)
-      | undefined
-      | null,
-    onRejected?:
-      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
-      | undefined
-      | null
+    onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
     return this.#promise.then(onFulfilled, onRejected);
   }
 
   catch<TResult = never>(
-    onRejected?:
-      | ((reason: any) => TResult | PromiseLike<TResult>)
-      | undefined
-      | null
+    onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
   ): Promise<T | TResult> {
     return this.#promise.catch(onRejected);
   }

--- a/src/bidiMapper/utils/deferred.ts
+++ b/src/bidiMapper/utils/deferred.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class Deferred<T> implements Promise<T> {
+  #resolve: (value: T) => void = () => {};
+  #reject: (value: T) => void = () => {};
+  #promise: Promise<T>;
+
+  constructor() {
+    this.#promise = new Promise((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    });
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onFulfilled?:
+      | ((value: T) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onRejected?:
+      | ((reason: any) => TResult2 | PromiseLike<TResult2>)
+      | undefined
+      | null
+  ): Promise<TResult1 | TResult2> {
+    return this.#promise.then(onFulfilled, onRejected);
+  }
+
+  catch<TResult = never>(
+    onRejected?:
+      | ((reason: any) => TResult | PromiseLike<TResult>)
+      | undefined
+      | null
+  ): Promise<T | TResult> {
+    return this.#promise.catch(onRejected);
+  }
+
+  public resolve(value: T) {
+    this.#resolve(value);
+  }
+
+  public reject(reason: any) {
+    this.#reject(reason);
+  }
+
+  finally(onFinally?: (() => void) | undefined | null): Promise<T> {
+    return this.#promise.finally(onFinally);
+  }
+
+  [Symbol.toStringTag]: string = 'Promise';
+}

--- a/src/cdp/cdpClient.ts
+++ b/src/cdp/cdpClient.ts
@@ -18,8 +18,8 @@
 import { EventEmitter } from 'events';
 import { CdpConnection } from './cdpConnection';
 
-import {domains as browserProtocolDomains} from 'devtools-protocol/json/browser_protocol_commands_only.json';
-import {domains as jsProtocolDomains} from 'devtools-protocol/json/js_protocol_commands_only.json';
+import { domains as browserProtocolDomains } from 'devtools-protocol/json/browser_protocol_commands_only.json';
+import { domains as jsProtocolDomains } from 'devtools-protocol/json/js_protocol_commands_only.json';
 import ProtocolProxyApi from 'devtools-protocol/types/protocol-proxy-api';
 import ProtocolMapping from 'devtools-protocol/types/protocol-mapping';
 

--- a/utils/filter_protocol_commands.js
+++ b/utils/filter_protocol_commands.js
@@ -9,11 +9,14 @@ function convertFile(filename) {
   for (const domain of data.domains) {
     domains.push({
       domain: domain.domain,
-      commands: domain.commands.map(c => c.name),
+      commands: domain.commands.map((c) => c.name),
     });
   }
 
-  fs.writeFileSync(filename.replace('.json', '_commands_only.json'), JSON.stringify({domains}));
+  fs.writeFileSync(
+    filename.replace('.json', '_commands_only.json'),
+    JSON.stringify({ domains })
+  );
 }
 
 convertFile('node_modules/devtools-protocol/json/browser_protocol.json');


### PR DESCRIPTION
Step 1 towards Out Of Process iFrames (OOPiF):
* Reformat with `prettier`
* Introduced `Deferred`
* Switch Context to Deferred, unties the waiter from the specific CDP session, and which make sit possible to transparently switch sessions.