### PR TITLE
Align `session.status` with spec

### DIFF
--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -77,7 +77,7 @@ export class CommandProcessor {
 
   // noinspection JSMethodCanBeStatic,JSUnusedLocalSymbols
   async #process_session_status(): Promise<Session.StatusResult> {
-    return { result: { ready: true, message: 'ready' } };
+    return { result: { ready: false, message: 'already connected' } };
   }
 
   async #process_session_subscribe(

--- a/tests/test_protocol_basics.py
+++ b/tests/test_protocol_basics.py
@@ -65,7 +65,7 @@ async def test_session_status(websocket):
     command = {"id": 5, "method": "session.status", "params": {}}
     await send_JSON_command(websocket, command)
     resp = await read_JSON_message(websocket)
-    assert resp == {"id": 5, "result": {"ready": True, "message": "ready"}}
+    assert resp == {"id": 5, "result": {"ready": False, "message": "ready"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_protocol_basics.py
+++ b/tests/test_protocol_basics.py
@@ -65,7 +65,7 @@ async def test_session_status(websocket):
     command = {"id": 5, "method": "session.status", "params": {}}
     await send_JSON_command(websocket, command)
     resp = await read_JSON_message(websocket)
-    assert resp == {"id": 5, "result": {"ready": False, "message": "ready"}}
+    assert resp == {"id": 5, "result": {"ready": False, "message": "already connected"}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
As we don't support creating additional sessions, the `ready` state should be `false`:
> The readiness state of a [remote end](https://w3c.github.io/webdriver/#dfn-remote-ends) indicates whether it is free to accept new connections.