### PR TITLE
Fix `BrowsingContext` WPT tests

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -251,6 +251,11 @@ export class BrowsingContextImpl {
           this.#targetDefers.documentInitialized.resolve();
         }
 
+        if (params.name === 'commit') {
+          this.#loaderId = params.loaderId;
+          return;
+        }
+
         if (params.loaderId !== this.#loaderId) {
           return;
         }

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -264,6 +264,7 @@ export class BrowsingContextImpl {
               new BrowsingContext.DomContentLoadedEvent({
                 context: this.contextId,
                 navigation: this.#loaderId,
+                url: this.#url,
               }),
               this.contextId
             );
@@ -275,6 +276,7 @@ export class BrowsingContextImpl {
               new LoadEvent({
                 context: this.contextId,
                 navigation: this.#loaderId,
+                url: this.#url,
               }),
               this.contextId
             );

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -655,8 +655,7 @@ export namespace BrowsingContext {
   export type NavigationInfo = {
     context: CommonDataTypes.BrowsingContext;
     navigation: Navigation | null;
-    // TODO: implement or remove from specification.
-    // url: string;
+    url: string;
   };
 
   export class ContextCreatedEvent extends EventResponseClass<BrowsingContext.Info> {

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -317,7 +317,8 @@ async def test_browsingContext_navigateWaitNone_navigated(websocket,
         "method": "browsingContext.load",
         "params": {
             "context": context_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Wait for `browsingContext.domContentLoaded` event.
     resp = await read_JSON_message(websocket)
@@ -325,7 +326,8 @@ async def test_browsingContext_navigateWaitNone_navigated(websocket,
         "method": "browsingContext.domContentLoaded",
         "params": {
             "context": context_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
 
 @pytest.mark.asyncio
@@ -351,7 +353,8 @@ async def test_browsingContext_navigateWaitInteractive_navigated(websocket,
         "method": "browsingContext.load",
         "params": {
             "context": context_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Wait for `browsingContext.domContentLoaded` event.
     resp = await read_JSON_message(websocket)
@@ -359,7 +362,8 @@ async def test_browsingContext_navigateWaitInteractive_navigated(websocket,
         "method": "browsingContext.domContentLoaded",
         "params": {
             "context": context_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>", }}
 
     # Assert command done.
     resp = await read_JSON_message(websocket)
@@ -393,7 +397,8 @@ async def test_browsingContext_navigateWaitComplete_navigated(websocket,
         "method": "browsingContext.load",
         "params": {
             "context": context_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Assert command done.
     resp = await read_JSON_message(websocket)
@@ -409,7 +414,8 @@ async def test_browsingContext_navigateWaitComplete_navigated(websocket,
         "method": "browsingContext.domContentLoaded",
         "params": {
             "context": context_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -171,10 +171,8 @@ async def test_browsingContext_create_eventContextCreatedEmitted(
                 await read_JSON_message(websocket)]
 
     messages.sort(key=lambda x: x["method"] if "method" in x else "")
-    command_result = messages[0]
-    context_created_event = messages[1]
-    dom_content_loaded_event = messages[2]
-    load_event = messages[3]
+    [command_result, context_created_event, dom_content_loaded_event,
+     load_event] = messages
 
     new_context_id = command_result['result']['context']
 

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -72,7 +72,8 @@ async def test_nestedBrowsingContext_navigateWaitNone_navigated(websocket, ifram
         "method": "browsingContext.load",
         "params": {
             "context": iframe_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Wait for `browsingContext.domContentLoaded` event.
     resp = await read_JSON_message(websocket)
@@ -80,7 +81,8 @@ async def test_nestedBrowsingContext_navigateWaitNone_navigated(websocket, ifram
         "method": "browsingContext.domContentLoaded",
         "params": {
             "context": iframe_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
 
 @pytest.mark.asyncio
@@ -105,7 +107,8 @@ async def test_nestedBrowsingContext_navigateWaitInteractive_navigated(websocket
         "method": "browsingContext.load",
         "params": {
             "context": iframe_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Wait for `browsingContext.domContentLoaded` event.
     resp = await read_JSON_message(websocket)
@@ -113,7 +116,8 @@ async def test_nestedBrowsingContext_navigateWaitInteractive_navigated(websocket
         "method": "browsingContext.domContentLoaded",
         "params": {
             "context": iframe_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Assert command done.
     resp = await read_JSON_message(websocket)
@@ -146,7 +150,8 @@ async def test_nestedBrowsingContext_navigateWaitComplete_navigated(websocket, i
         "method": "browsingContext.load",
         "params": {
             "context": iframe_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
     # Assert command done.
     resp = await read_JSON_message(websocket)
@@ -162,7 +167,8 @@ async def test_nestedBrowsingContext_navigateWaitComplete_navigated(websocket, i
         "method": "browsingContext.domContentLoaded",
         "params": {
             "context": iframe_id,
-            "navigation": navigation_id}}
+            "navigation": navigation_id,
+            "url": "data:text/html,<h2>test</h2>"}}
 
 
 @pytest.mark.asyncio

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
@@ -1,2 +1,6 @@
 [load.py]
-  expected: TIMEOUT
+  [test_subscribe]
+    expected: FAIL
+
+  [test_iframe]
+    expected: FAIL


### PR DESCRIPTION
* Add `url` to `browsingContext.load` and `browsingContext.domContentLoaded`.
* Raise loading events for initial `about:blank` loading.
* Other failures should be fixed by https://github.com/web-platform-tests/wpt/pull/35848.