### PR TITLE
Clear child browsing contexts on `Page.frameNavigated`

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -49,7 +49,7 @@ export class BrowsingContextImpl {
   #cdpClient: CdpClient;
   readonly #bidiServer: IBidiServer;
   #eventManager: IEventManager;
-  readonly #children: BrowsingContextImpl[] = [];
+  readonly #children: Map<string, BrowsingContextImpl> = new Map();
   #scriptEvaluator: ScriptEvaluator;
   // Default execution context is set with key `null`.
   readonly #sandboxToExecutionContextIdMap: Map<
@@ -178,7 +178,7 @@ export class BrowsingContextImpl {
   }
 
   get children(): BrowsingContextImpl[] {
-    return this.#children;
+    return Array.from(this.#children.values());
   }
 
   get url(): string {
@@ -186,7 +186,11 @@ export class BrowsingContextImpl {
   }
 
   addChild(child: BrowsingContextImpl): void {
-    this.#children.push(child);
+    this.#children.set(child.contextId, child);
+  }
+
+  removeChild(childContextId: string): void {
+    this.#children.delete(childContextId);
   }
 
   public serializeToBidiValue(

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -38,11 +38,10 @@ export class BrowsingContextProcessor {
     );
   }
 
-  async #removeChildrenContexts(context: BrowsingContextImpl): Promise<void> {
-    // Remove context's children.
-    for (let child of context.children) {
-      await this.#removeContext(child.contextId);
-    }
+  async #removeChildContexts(context: BrowsingContextImpl): Promise<void> {
+    await Promise.all(
+      context.children.map((child) => this.#removeContext(child.contextId))
+    );
   }
 
   async #removeContext(contextId: string): Promise<void> {
@@ -52,7 +51,7 @@ export class BrowsingContextProcessor {
     const context = BrowsingContextProcessor.#getKnownContext(contextId);
 
     // Remove context's children.
-    await this.#removeChildrenContexts(context);
+    await this.#removeChildContexts(context);
 
     // Remove context from the parent.
     if (context.parentId !== null) {
@@ -163,7 +162,7 @@ export class BrowsingContextProcessor {
         // At the point the page is initiated, all the nested iframes are
         // detached.
         // Remove context's children.
-        await this.#removeChildrenContexts(context);
+        await this.#removeChildContexts(context);
       }
     );
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -38,15 +38,21 @@ export class BrowsingContextProcessor {
     );
   }
 
+  async #removeChildrenContexts(context: BrowsingContextImpl): Promise<void> {
+    // Remove context's children.
+    for (let child of context.children) {
+      await this.#removeContext(child.contextId);
+    }
+  }
+
   async #removeContext(contextId: string): Promise<void> {
     if (!BrowsingContextProcessor.#hasKnownContext(contextId)) {
       return;
     }
     const context = BrowsingContextProcessor.#getKnownContext(contextId);
+
     // Remove context's children.
-    for (let child of context.children) {
-      await this.#removeContext(child.contextId);
-    }
+    await this.#removeChildrenContexts(context);
 
     // Remove context from the parent.
     if (context.parentId !== null) {
@@ -156,9 +162,8 @@ export class BrowsingContextProcessor {
         const context = BrowsingContextProcessor.#getKnownContext(contextId);
         // At the point the page is initiated, all the nested iframes are
         // detached.
-        for (let child of context.children) {
-          await this.#removeContext(child.contextId);
-        }
+        // Remove context's children.
+        await this.#removeChildrenContexts(context);
       }
     );
 

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -145,6 +145,103 @@ async def test_browsingContext_getTreeWithNestedCrossOriginContexts_contextsRetu
             "url": page_with_nested_iframe}]},
         result)
 
+# TODO(sadym): make offline.
+@pytest.mark.asyncio
+async def test_browsingContext_afterNavigation_getTreeWithNestedCrossOriginContexts_contextsReturned(
+      websocket, context_id):
+    nested_iframe = 'https://example.com/'
+    another_nested_iframe = 'https://example.org/'
+    page_with_nested_iframe = f'data:text/html,<h1>MAIN_PAGE</h1>' \
+                              f'<iframe src="{nested_iframe}" />'
+    another_page_with_nested_iframe = f'data:text/html,<h1>ANOTHER_MAIN_PAGE</h1>' \
+                              f'<iframe src="{another_nested_iframe}" />'
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": page_with_nested_iframe,
+            "wait": "complete",
+            "context": context_id}})
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": another_page_with_nested_iframe,
+            "wait": "complete",
+            "context": context_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": any_string,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": another_page_with_nested_iframe}]},
+        result)
+
+@pytest.mark.asyncio
+async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_contextsReturned(
+      websocket, context_id):
+    nested_iframe = 'data:text/html,<h2>IFRAME</h2>'
+    another_nested_iframe = 'data:text/html,<h2>ANOTHER_IFRAME</h2>'
+    page_with_nested_iframe = f'data:text/html,<h1>MAIN_PAGE</h1>' \
+                              f'<iframe src="{nested_iframe}" />'
+    another_page_with_nested_iframe = f'data:text/html,<h1>ANOTHER_MAIN_PAGE</h1>' \
+                              f'<iframe src="{another_nested_iframe}" />'
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": page_with_nested_iframe,
+            "wait": "complete",
+            "context": context_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": any_string,
+                "url": nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": page_with_nested_iframe}]},
+        result)
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": another_page_with_nested_iframe,
+            "wait": "complete",
+            "context": context_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": any_string,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": another_page_with_nested_iframe}]},
+        result)
+
 
 @pytest.mark.asyncio
 async def test_browsingContext_create_eventContextCreatedEmitted(

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -300,3 +300,85 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_navigated(
             "parent": any_string,
             "url": url_with_hash_2}]},
         result)
+
+
+# TODO(sadym): make offline.
+@pytest.mark.asyncio
+async def test_nestedBrowsingContext_afterNavigation_getTreeWithNestedCrossOriginContexts_contextsReturned(
+      websocket, iframe_id):
+    nested_iframe = 'https://example.com/'
+    another_nested_iframe = 'https://example.org/'
+    page_with_nested_iframe = f'data:text/html,<h1>MAIN_PAGE</h1>' \
+                              f'<iframe src="{nested_iframe}" />'
+    another_page_with_nested_iframe = f'data:text/html,<h1>ANOTHER_MAIN_PAGE</h1>' \
+                                      f'<iframe src="{another_nested_iframe}" />'
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": page_with_nested_iframe,
+            "wait": "complete",
+            "context": iframe_id}})
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": another_page_with_nested_iframe,
+            "wait": "complete",
+            "context": iframe_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {"root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "children": [{
+                "context": any_string,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": any_string,
+            "url": another_page_with_nested_iframe}]},
+        result)
+
+
+@pytest.mark.asyncio
+async def test_nestedBrowsingContext_afterNavigation_getTreeWithNestedContexts_contextsReturned(
+      websocket, iframe_id):
+    nested_iframe = 'data:text/html,<h2>IFRAME</h2>'
+    another_nested_iframe = 'data:text/html,<h2>ANOTHER_IFRAME</h2>'
+    page_with_nested_iframe = f'data:text/html,<h1>MAIN_PAGE</h1>' \
+                              f'<iframe src="{nested_iframe}" />'
+    another_page_with_nested_iframe = f'data:text/html,<h1>ANOTHER_MAIN_PAGE</h1>' \
+                                      f'<iframe src="{another_nested_iframe}" />'
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": page_with_nested_iframe,
+            "wait": "complete",
+            "context": iframe_id}})
+
+    await execute_command(websocket, {
+        "method": "browsingContext.navigate",
+        "params": {
+            "url": another_page_with_nested_iframe,
+            "wait": "complete",
+            "context": iframe_id}})
+
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {"root": iframe_id}})
+
+    recursive_compare({
+        "contexts": [{
+            "context": iframe_id,
+            "url": another_page_with_nested_iframe,
+            "children": [{
+                "context": any_string,
+                "url": another_nested_iframe,
+                "children": []}],
+            "parent": any_string}]},
+        result)

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
@@ -1,12 +1,2 @@
 [load.py]
-  [test_subscribe]
-    disabled: TRUE
-
-  [test_iframe]
-    disabled: TRUE
-
-  [test_subscribe]
-    disabled: TRUE
-
-  [test_new_context]
-    disabled: TRUE
+  disabled: due to https://github.com/web-platform-tests/wpt/issues/35846

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
@@ -1,9 +1,3 @@
 [load.py]
   [test_subscribe]
     expected: FAIL
-
-  [test_iframe]
-    expected: FAIL
-
-  [test_new_context[tab\]]
-    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
@@ -4,3 +4,6 @@
 
   [test_iframe]
     expected: FAIL
+
+  [test_new_context[tab\]]
+    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
@@ -1,3 +1,12 @@
 [load.py]
   [test_subscribe]
-    expected: FAIL
+    disabled: TRUE
+
+  [test_iframe]
+    disabled: TRUE
+
+  [test_subscribe]
+    disabled: TRUE
+
+  [test_new_context]
+    disabled: TRUE


### PR DESCRIPTION
Addressing the issue https://crbug.com/chromedriver/4204.
Whenever the page is navigated, the child browsing contexts should be removed.

WPT test `webdriver/tests/bidi/browsing_context/load/load.py` was disabled due to instability: https://github.com/web-platform-tests/wpt/issues/35846