### PR TITLE
Wait for the initial tab to be loaded

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -32,7 +32,7 @@ const logContext = log('context');
 export class BrowsingContextProcessor {
   static #contexts: Map<string, BrowsingContextImpl> = new Map();
 
-  static #getTopLevelContexts(): BrowsingContextImpl[] {
+  static getTopLevelContexts(): BrowsingContextImpl[] {
     return Array.from(BrowsingContextProcessor.#contexts.values()).filter(
       (c) => c.parentId === null
     );
@@ -257,7 +257,7 @@ export class BrowsingContextProcessor {
   ): Promise<BrowsingContext.GetTreeResult> {
     const resultContexts =
       params.root === undefined
-        ? BrowsingContextProcessor.#getTopLevelContexts()
+        ? BrowsingContextProcessor.getTopLevelContexts()
         : [BrowsingContextProcessor.#getKnownContext(params.root)];
 
     return {

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -25,6 +25,7 @@ import { ITransport } from '../utils/transport';
 
 import { log } from '../utils/log';
 import { EventManager } from './domains/events/EventManager';
+import { BrowsingContextProcessor } from './domains/context/browsingContextProcessor';
 
 const logSystem = log('system');
 
@@ -155,4 +156,8 @@ async function _prepareCdp(cdpClient: CdpClient) {
     waitForDebuggerOnStart: true,
     flatten: true,
   });
+
+  await Promise.all(
+    BrowsingContextProcessor.getTopLevelContexts().map((c) => c.awaitLoaded())
+  );
 }

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -36,20 +36,12 @@ async def websocket():
         yield connection
 
 
-# noinspection PyUnusedFunction
 @pytest.fixture
 async def context_id(websocket):
-    # Note: there can be a race condition between initially created context's
-    # events and following subscription commands. Sometimes subscribe is called
-    # before the initial context emitted `browsingContext.contextCreated`,
-    # `browsingContext.domContentLoaded`, or `browsingContext.load` events,
-    # which makes events verification way harder. Navigation command guarantees
-    # there will be no follow-up events, as it uses `interactive` flag.
-    # TODO: find a way to avoid mentioned race condition properly.
-
-    open_context_id = await get_open_context_id(websocket)
-    await goto_url(websocket, open_context_id, "about:blank")
-    return open_context_id
+    result = await execute_command(websocket, {
+        "method": "browsingContext.getTree",
+        "params": {}})
+    return result["contexts"][0]["context"]
 
 
 @pytest.fixture
@@ -135,14 +127,6 @@ def any_timestamp(expected):
 # noinspection PyUnusedLocal
 def any_value(expected):
     return
-
-
-# Returns an id of an open context.
-async def get_open_context_id(websocket):
-    result = await execute_command(websocket, {
-        "method": "browsingContext.getTree",
-        "params": {}})
-    return result["contexts"][0]["context"]
 
 
 async def send_JSON_command(websocket, command):

--- a/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/browsing_context/load/load.py.ini
@@ -1,2 +1,0 @@
-[load.py]
-  disabled: due to https://github.com/web-platform-tests/wpt/issues/35846


### PR DESCRIPTION
To prevent the `browsingContext.load` event for the initial tab form being unexpectedly emitted after the initialization complete, wait for the initial targets to be fully loaded.
* Wait for initial tab to be fully loaded before finishing launching.
* Added e2e test.