### PR TITLE
Add `channel` to command

### DIFF
--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -173,6 +173,7 @@ export class CommandProcessor {
 
       const response = {
         id: command.id,
+        ...(command.channel !== undefined ? { channel: command.channel } : {}),
         ...result,
       };
 

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -35,6 +35,7 @@ export namespace Message {
     id: number;
     method: string;
     params: object;
+    channel?: string;
   };
 
   export type CommandRequest = { id: number } & (

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -25,7 +25,6 @@ import { ITransport } from '../utils/transport';
 
 import { log } from '../utils/log';
 import { EventManager } from './domains/events/EventManager';
-import { BrowsingContextProcessor } from './domains/context/browsingContextProcessor';
 import { BrowsingContextStorage } from './domains/context/browsingContextStorage';
 
 const logSystem = log('system');

--- a/tests/test_protocol_basics.py
+++ b/tests/test_protocol_basics.py
@@ -65,7 +65,25 @@ async def test_session_status(websocket):
     command = {"id": 5, "method": "session.status", "params": {}}
     await send_JSON_command(websocket, command)
     resp = await read_JSON_message(websocket)
-    assert resp == {"id": 5, "result": {"ready": False, "message": "already connected"}}
+    assert resp == {"id": 5,
+                    "result": {"ready": False, "message": "already connected"}}
+
+
+@pytest.mark.asyncio
+async def test_channel(websocket):
+    await send_JSON_command(websocket, {
+        "id": 5,
+        "method": "session.status",
+        "params": {},
+        "channel": "SOME_CHANNEL"
+    })
+    resp = await read_JSON_message(websocket)
+    assert resp == {
+        "id": 5,
+        "channel": "SOME_CHANNEL",
+        "result": {
+            "ready": False,
+            "message": "already connected"}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Extend BiDi+ command with an optional field `channel`. If set, the same `channel` is set in response.

Out of scope - respect `channel` in EventManager.