### PR TITLE
Rename `warning` -> `warn`

### DIFF
--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -157,7 +157,7 @@ export class LogManager {
       return 'debug';
     }
     if (['warn', 'warning'].includes(consoleApiType)) {
-      return 'warning';
+      return 'warn';
     }
     return 'info';
   }

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -834,7 +834,7 @@ export namespace BrowsingContext {
 export namespace Log {
   export type LogEntry = GenericLogEntry | ConsoleLogEntry | JavascriptLogEntry;
   export type Event = LogEntryAddedEvent;
-  export type LogLevel = 'debug' | 'info' | 'warning' | 'error';
+  export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
   export type BaseLogEntry = {
     level: LogLevel;

--- a/tests/test_log_events.py
+++ b/tests/test_log_events.py
@@ -156,9 +156,8 @@ async def test_consoleWarn_levelAndMethodAreCorrect(websocket, context_id):
 
     # Assert method "error".
     assert event_response["method"] == "log.entryAdded"
-    # Method is `console.warn`, while the level is `warning`.
     assert event_response["params"]["method"] == "warn"
-    assert event_response["params"]["level"] == "warning"
+    assert event_response["params"]["level"] == "warn"
 
 
 @pytest.mark.asyncio

--- a/wpt-metadata/webdriver/tests/bidi/log/entry_added/console.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/log/entry_added/console.py.ini
@@ -1,3 +1,0 @@
-[console.py]
-  [test_level[warn-warn\]]
-    expected: FAIL


### PR DESCRIPTION
Align with [specification](https://github.com/w3c/webdriver-bidi/pull/259). 