### PR TITLE
Synchronous exception text retrieval

### DIFF
--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -148,6 +148,7 @@ export class LogManager {
    *   //     "exceptionDetails": {
    *   //       "text": "Uncaught",
    *   //       "exception": {
+   *   //         "className":"Error"
    *   //         "description": "Error: cached_message\\n    at <anonymous>:1:16\\n...",
    *   //         "objectId": "-2282565827719730523.1.1",
    *   //         "preview": {
@@ -183,7 +184,7 @@ export class LogManager {
       )?.value;
 
     if (previewMessage !== undefined) {
-      return previewMessage;
+      return `${params.exceptionDetails.exception.className}: ${previewMessage}`;
     }
 
     if (realm === undefined) {

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -182,6 +182,7 @@ async def send_JSON_command(websocket, command):
         command_id = get_next_command_id()
         command["id"] = command_id
     await websocket.send(json.dumps(command))
+    return command["id"]
 
 
 async def read_JSON_message(websocket):

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import json
 import os
+
 import pytest
 import websockets
 
@@ -170,6 +170,14 @@ def any_timestamp(actual):
     # "2100-01-01 00:00:00" (4102441200000).
     assert 1577833200000 < actual < 4102441200000, \
         f"'{actual}' should be in epoch milliseconds format."
+
+
+def string_starting_with(prefix):
+    def _(actual):
+        assert actual.startswith(prefix), \
+            f'Actual "{actual}" should start with "{prefix}".'
+
+    return _
 
 
 # noinspection PyUnusedLocal

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -79,7 +79,12 @@ async def test_script_evaluateThrowingError_exceptionReturned(websocket,
     recursive_compare({
         "realm": any_string,
         "exceptionDetails": {
-            "text": "Error: foo",
+            "text": "Error: foo"
+                    "\n    at a (<anonymous>:1:26)"
+                    "\n    at b (<anonymous>:1:59)"
+                    "\n    at c (<anonymous>:2:14)"
+                    "\n    at <anonymous>:2:20"
+                    "\n    at <anonymous>:2:26",
             "columnNumber": 19,
             "lineNumber": 0,
             "exception": {

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -12,355 +12,407 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 
 from _helpers import *
 
 
 # Testing serialization.
-async def assertSerialization(websocket, context_id, js_str_object,
+async def assert_result_serialization(websocket, context_id, js_str_object,
       expected_serialized_object):
-    result = await execute_command(websocket, {
+    # Log events a serialized with "resultOwnership": "none".
+    # Remove `handle` if exists.
+    expected_serialized_object_without_handle = copy.deepcopy(
+        expected_serialized_object)
+    expected_serialized_object_without_handle.pop("handle", None)
+
+    await subscribe(websocket, "log.entryAdded")
+    command_id = await send_JSON_command(websocket, {
         "method": "script.evaluate",
         "params": {
-            "expression": f"({js_str_object})",
+            "expression": f"(()=>{{"
+                          f"console.log({js_str_object});"
+                          f"return {js_str_object}"
+                          f"}})()",
             "target": {"context": context_id},
             "awaitPromise": False,
             "resultOwnership": "root"
         }})
 
-    # Compare ignoring `handle`.
-    recursive_compare(expected_serialized_object, result["result"])
+    resp = await read_JSON_message(websocket)
+    assert resp["id"] == command_id
+    recursive_compare(expected_serialized_object, resp["result"]["result"])
+
+    resp = await read_JSON_message(websocket)
+    assert resp["method"] == "log.entryAdded"
+    recursive_compare(expected_serialized_object_without_handle,
+                      resp["params"]["args"][0])
 
 
-# Testing serialization.
-async def assertDeserializationAndSerialization(websocket, context_id,
+async def assert_callFunction_deserialization_serialization(websocket,
+      context_id,
       serialized_object,
       expected_serialized_object=None):
     if expected_serialized_object is None:
         expected_serialized_object = serialized_object
 
-    result = await execute_command(websocket, {
+    # Log events a serialized with "resultOwnership": "none".
+    expected_serialized_object_without_handle = copy.deepcopy(
+        expected_serialized_object)
+    expected_serialized_object_without_handle.pop("handle", None)
+
+    await subscribe(websocket, "log.entryAdded")
+    command_id = await send_JSON_command(websocket, {
         "method": "script.callFunction",
         "params": {
-            "functionDeclaration": "(arg)=>{return arg}",
+            "functionDeclaration": "(arg)=>{console.log(arg); return arg;}",
             "this": {
                 "type": "undefined"},
             "arguments": [serialized_object],
             "awaitPromise": False,
             "target": {"context": context_id},
             "resultOwnership": "root"}})
-    # Compare ignoring `handle`.
-    recursive_compare(expected_serialized_object, result["result"])
+
+    resp = await read_JSON_message(websocket)
+    assert resp["id"] == command_id
+    recursive_compare(expected_serialized_object, resp["result"]["result"])
+
+    resp = await read_JSON_message(websocket)
+    assert resp["method"] == "log.entryAdded"
+    recursive_compare(expected_serialized_object_without_handle,
+                      resp["params"]["args"][0])
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_undefined(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {"type": "undefined"})
+async def test_serialization_deserialization_undefined(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "undefined"})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_null(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {"type": "null"})
+async def test_serialization_deserialization_null(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {"type": "null"})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_string(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "string",
-        "value": "someStr"})
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "string",
-        "value": ""})
+async def test_serialization_deserialization_string(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "string",
+                                                                "value": "someStr"})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "string",
+                                                                "value": ""})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_number(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "number",
-        "value": 123})
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "number",
-        "value": 0.56})
+async def test_serialization_deserialization_number(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "number",
+                                                                "value": 123})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "number",
+                                                                "value": 0.56})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_specialNumber(websocket,
+async def test_serialization_deserialization_specialNumber(websocket,
       context_id):
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "number",
-        "value": "Infinity"})
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {
-                                                    "type": "number",
-                                                    "value": "+Infinity"
-                                                }, {
-                                                    "type": "number",
-                                                    "value": "Infinity"})
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "number",
-        "value": "-Infinity"})
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "number",
-        "value": "-0"})
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "number",
-        "value": "NaN"})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "number",
+                                                                "value": "Infinity"})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "number",
+                                                                "value": "+Infinity"
+                                                            }, {
+                                                                "type": "number",
+                                                                "value": "Infinity"})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "number",
+                                                                "value": "-Infinity"})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "number",
+                                                                "value": "-0"})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "number",
+                                                                "value": "NaN"})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_bool(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "boolean",
-        "value": True})
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "boolean",
-        "value": False})
+async def test_serialization_deserialization_bool(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "boolean",
+                                                                "value": True})
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "boolean",
+                                                                "value": False})
 
 
 @pytest.mark.asyncio
 async def test_serialization_function(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "function(){}", {
-                                  "type": "function",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "function(){}", {
+                                          "type": "function",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 async def test_serialization_promise(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "Promise.resolve(1)", {
-                                  "type": "promise",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "Promise.resolve(1)", {
+                                          "type": "promise",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 async def test_serialization_weakMap(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "new WeakMap()", {
-                                  "type": "weakmap",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "new WeakMap()", {
+                                          "type": "weakmap",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 async def test_serialization_weakSet(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "new WeakSet()", {
-                                  "type": "weakset",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "new WeakSet()", {
+                                          "type": "weakset",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 # Not specified yet.
 async def test_serialization_proxy(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "new Proxy({}, {})", {
-                                  "type": "proxy",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "new Proxy({}, {})", {
+                                          "type": "proxy",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 async def test_serialization_typedarray(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "new Int32Array()", {
-                                  "type": "typedarray",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "new Int32Array()", {
+                                          "type": "typedarray",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 async def test_serialization_object(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "{'foo': {'bar': 'baz'}, 'qux': 'quux'}", {
-                                  "type": "object",
-                                  "handle": any_string,
-                                  "value": [[
-                                      "foo", {
-                                          "type": "object"}], [
-                                      "qux", {
-                                          "type": "string",
-                                          "value": "quux"}]]})
+    await assert_result_serialization(websocket, context_id,
+                                      "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
+                                      {
+                                          "type": "object",
+                                          "handle": any_string,
+                                          "value": [[
+                                              "foo", {
+                                                  "type": "object"}], [
+                                              "qux", {
+                                                  "type": "string",
+                                                  "value": "quux"}]]})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_object(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {
-                                                    "type": "object",
-                                                    "value": [[
-                                                        "foo", {
-                                                            "type": "object",
-                                                            "value": []}
-                                                    ], [{
-                                                        "type": "string",
-                                                        "value": "qux"
-                                                    }, {
-                                                        "type": "string",
-                                                        "value": "quux"}]]},
-                                                {
-                                                    "type": "object",
-                                                    "handle": any_string,
-                                                    "value": [[
-                                                        "foo", {
-                                                            "type": "object"}
-                                                    ], [
-                                                        "qux", {
-                                                            "type": "string",
-                                                            "value": "quux"}]]})
+async def test_serialization_deserialization_object(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "object",
+                                                                "value": [[
+                                                                    "foo", {
+                                                                        "type": "object",
+                                                                        "value": []}
+                                                                ], [{
+                                                                    "type": "string",
+                                                                    "value": "qux"
+                                                                }, {
+                                                                    "type": "string",
+                                                                    "value": "quux"}]]},
+                                                            {
+                                                                "type": "object",
+                                                                "handle": any_string,
+                                                                "value": [[
+                                                                    "foo", {
+                                                                        "type": "object"}
+                                                                ], [
+                                                                    "qux", {
+                                                                        "type": "string",
+                                                                        "value": "quux"}]]})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_map(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {
-                                                    "type": "map",
-                                                    "value": [[
-                                                        "foo", {
-                                                            "type": "object",
-                                                            "value": []}
-                                                    ], [{
-                                                        "type": "string",
-                                                        "value": "qux"
-                                                    }, {
-                                                        "type": "string",
-                                                        "value": "quux"}]]},
-                                                {
-                                                    "type": "map",
-                                                    "handle": any_string,
-                                                    "value": [[
-                                                        "foo", {
-                                                            "type": "object"}
-                                                    ], [
-                                                        "qux", {
-                                                            "type": "string",
-                                                            "value": "quux"}]]})
+async def test_serialization_deserialization_map(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "map",
+                                                                "value": [[
+                                                                    "foo", {
+                                                                        "type": "object",
+                                                                        "value": []}
+                                                                ], [{
+                                                                    "type": "string",
+                                                                    "value": "qux"
+                                                                }, {
+                                                                    "type": "string",
+                                                                    "value": "quux"}]]},
+                                                            {
+                                                                "type": "map",
+                                                                "handle": any_string,
+                                                                "value": [[
+                                                                    "foo", {
+                                                                        "type": "object"}
+                                                                ], [
+                                                                    "qux", {
+                                                                        "type": "string",
+                                                                        "value": "quux"}]]})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_array(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {
-                                                    "type": "array",
-                                                    "value": [{
-                                                        "type": "number",
-                                                        "value": 1
-                                                    }, {
-                                                        "type": "string",
-                                                        "value": "a"
-                                                    }]}, {
-                                                    "type": "array",
-                                                    "handle": any_string,
-                                                    "value": [{
-                                                        "type": "number",
-                                                        "value": 1
-                                                    }, {
-                                                        "type": "string",
-                                                        "value": "a"
-                                                    }]}, )
+async def test_serialization_deserialization_array(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "array",
+                                                                "value": [{
+                                                                    "type": "number",
+                                                                    "value": 1
+                                                                }, {
+                                                                    "type": "string",
+                                                                    "value": "a"
+                                                                }]}, {
+                                                                "type": "array",
+                                                                "handle": any_string,
+                                                                "value": [{
+                                                                    "type": "number",
+                                                                    "value": 1
+                                                                }, {
+                                                                    "type": "string",
+                                                                    "value": "a"
+                                                                }]}, )
 
 
 @pytest.mark.asyncio
 async def test_serialization_array(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "[1, 'a', {foo: 'bar'}, [2,[3,4]]]", {
-                                  "type": "array",
-                                  "handle": any_string,
-                                  "value": [{
-                                      "type": "number",
-                                      "value": 1
-                                  }, {
-                                      "type": "string",
-                                      "value": "a"
-                                  }, {
-                                      "type": "object"
-                                  }, {
-                                      "type": "array"}]})
+    await assert_result_serialization(websocket, context_id,
+                                      "[1, 'a', {foo: 'bar'}, [2,[3,4]]]", {
+                                          "type": "array",
+                                          "handle": any_string,
+                                          "value": [{
+                                              "type": "number",
+                                              "value": 1
+                                          }, {
+                                              "type": "string",
+                                              "value": "a"
+                                          }, {
+                                              "type": "object"
+                                          }, {
+                                              "type": "array"}]})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_set(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {
-                                                    "type": "set",
-                                                    "value": [{
-                                                        "type": "number",
-                                                        "value": 1
-                                                    }, {
-                                                        "type": "string",
-                                                        "value": "a"
-                                                    }]}, {
-                                                    "type": "set",
-                                                    "handle": any_string,
-                                                    "value": [{
-                                                        "type": "number",
-                                                        "value": 1
-                                                    }, {
-                                                        "type": "string",
-                                                        "value": "a"
-                                                    }]}, )
+async def test_serialization_deserialization_set(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "set",
+                                                                "value": [{
+                                                                    "type": "number",
+                                                                    "value": 1
+                                                                }, {
+                                                                    "type": "string",
+                                                                    "value": "a"
+                                                                }]}, {
+                                                                "type": "set",
+                                                                "handle": any_string,
+                                                                "value": [{
+                                                                    "type": "number",
+                                                                    "value": 1
+                                                                }, {
+                                                                    "type": "string",
+                                                                    "value": "a"
+                                                                }]}, )
 
 
 @pytest.mark.asyncio
 async def test_serialization_set(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "new Set([1, 'a', {foo: 'bar'}, [2,[3,4]]])", {
-                                  "type": "set",
-                                  "handle": any_string,
-                                  "value": [{
-                                      "type": "number",
-                                      "value": 1
-                                  }, {
-                                      "type": "string",
-                                      "value": "a"
-                                  }, {
-                                      "type": "object"
-                                  }, {
-                                      "type": "array"}]})
+    await assert_result_serialization(websocket, context_id,
+                                      "new Set([1, 'a', {foo: 'bar'}, [2,[3,4]]])",
+                                      {
+                                          "type": "set",
+                                          "handle": any_string,
+                                          "value": [{
+                                              "type": "number",
+                                              "value": 1
+                                          }, {
+                                              "type": "string",
+                                              "value": "a"
+                                          }, {
+                                              "type": "object"
+                                          }, {
+                                              "type": "array"}]})
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_bigint(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id, {
-        "type": "bigint",
-        "value": "12345678901234567890"})
+async def test_serialization_deserialization_bigint(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id, {
+                                                                "type": "bigint",
+                                                                "value": "12345678901234567890"})
 
 
 @pytest.mark.asyncio
 async def test_serialization_symbol(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "Symbol('foo')", {
-                                  "type": "symbol",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "Symbol('foo')", {
+                                          "type": "symbol",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_regExp(websocket, context_id):
-    await assertDeserializationAndSerialization(websocket, context_id,
-                                                {
-                                                    "type": "regexp",
-                                                    "value": {
-                                                        "pattern": "ab+c",
-                                                        "flags": "i"
-                                                    }
-                                                }, {
-                                                    "type": "regexp",
-                                                    "handle": any_string,
-                                                    "value": {
-                                                        "pattern": "ab+c",
-                                                        "flags": "i"
-                                                    }
-                                                })
+async def test_serialization_deserialization_regExp(websocket, context_id):
+    await assert_callFunction_deserialization_serialization(websocket,
+                                                            context_id,
+                                                            {
+                                                                "type": "regexp",
+                                                                "value": {
+                                                                    "pattern": "ab+c",
+                                                                    "flags": "i"
+                                                                }
+                                                            }, {
+                                                                "type": "regexp",
+                                                                "handle": any_string,
+                                                                "value": {
+                                                                    "pattern": "ab+c",
+                                                                    "flags": "i"
+                                                                }
+                                                            })
 
 
 @pytest.mark.asyncio
-async def test_deserialization_serialization_date(websocket, context_id):
+async def test_serialization_deserialization_date(websocket, context_id):
     serialized_date = {
         "type": "date",
         "value": "2020-07-19T07:34:56.789+01:00"}
@@ -382,20 +434,20 @@ async def test_deserialization_serialization_date(websocket, context_id):
 
 @pytest.mark.asyncio
 async def test_serialization_windowProxy(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "this.window", {
-                                  "type": "window",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "this.window", {
+                                          "type": "window",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio
 async def test_serialization_error(websocket, context_id):
-    await assertSerialization(websocket, context_id,
-                              "new Error('Woops!')", {
-                                  "type": "error",
-                                  "handle": any_string
-                              })
+    await assert_result_serialization(websocket, context_id,
+                                      "new Error('Woops!')", {
+                                          "type": "error",
+                                          "handle": any_string
+                                      })
 
 
 @pytest.mark.asyncio

--- a/wpt-metadata/webdriver/tests/bidi/log/entry_added/event_buffer.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/log/entry_added/event_buffer.py.ini
@@ -1,0 +1,12 @@
+[event_buffer.py]
+  [test_console_log_cached_messages[javascript_error\]]
+    expected: FAIL
+
+  [test_console_log_cached_message_after_refresh[javascript_error\]]
+    expected: FAIL
+
+  [test_console_log_cached_messages[console_api_log\]]
+    expected: FAIL
+
+  [test_console_log_cached_message_after_refresh[console_api_log\]]
+    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/log/entry_added/javascript.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/log/entry_added/javascript.py.ini
@@ -1,0 +1,3 @@
+[javascript.py]
+  [test_types_and_values]
+    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/log/entry_added/stacktrace.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/log/entry_added/stacktrace.py.ini
@@ -1,0 +1,3 @@
+[stacktrace.py]
+  [test_javascript_entry_sync_callstack]
+    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/log/entry_added/subscription.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/log/entry_added/subscription.py.ini
@@ -1,0 +1,6 @@
+[subscription.py]
+  [test_subscribe_twice[javascript_error\]]
+    expected: FAIL
+
+  [test_subscribe_unsubscribe[javascript_error\]]
+    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/script/call_function/exception_details.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/script/call_function/exception_details.py.ini
@@ -1,0 +1,6 @@
+[exception_details.py]
+  [test_exception_details[null-expected1-True\]]
+    expected: FAIL
+
+  [test_exception_details[null-expected1-False\]]
+    expected: FAIL

--- a/wpt-metadata/webdriver/tests/bidi/script/evaluate/exception_details.py.ini
+++ b/wpt-metadata/webdriver/tests/bidi/script/evaluate/exception_details.py.ini
@@ -1,0 +1,6 @@
+[exception_details.py]
+  [test_exception_details[null-expected1-True\]]
+    expected: FAIL
+
+  [test_exception_details[null-expected1-False\]]
+    expected: FAIL


### PR DESCRIPTION
WPT log tests are racy and sometimes fail: [[1]](https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/3409317669/jobs/5670936087), [[2]](https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/3409460492). 

Log analysis showed the root cause is in the extra round-trip `realm.stringifyObject`. To avoid the race condition and make the CDP-BiDi event forwarding synchronous, some heuristic is implemented:
1. If exception has a description, use it. Date, Error with stacktrace, non-trivial objects.
2. If exception has value, use it. Primitives like number, string.
3. If exception has an objectId, use a CDP round-trip to make `toString` of it.
4. Return the whole exceptionDetails data if none of the above worked.

[BiDi Spec says](https://w3c.github.io/webdriver-bidi/#event-log-entryAdded) the `text` for non-primitives is implementation-defined.

WPT tests relies on the specific text format, and has to be updated.