### PR TITLE
Non-racy serialization with message queue

### DIFF
--- a/src/bidiMapper/commandProcessor.ts
+++ b/src/bidiMapper/commandProcessor.ts
@@ -24,7 +24,7 @@ import {
   Session,
 } from './domains/protocol/bidiProtocolTypes';
 import {CdpConnection} from '../cdp';
-import {IBidiServer} from './utils/bidiServer';
+import {BiDiMessageEntry, IBidiServer} from './utils/bidiServer';
 import {IEventManager} from './domains/events/EventManager';
 import {
   ErrorResponseClass,
@@ -185,22 +185,28 @@ export class CommandProcessor {
         ...result,
       };
 
-      await this.#bidiServer.sendMessage(response, command.channel ?? null);
+      await this.#bidiServer.sendMessage(
+        BiDiMessageEntry.createResolved(response, command.channel ?? null)
+      );
     } catch (e) {
       if (e instanceof ErrorResponseClass) {
         const errorResponse = e as ErrorResponseClass;
 
         await this.#bidiServer.sendMessage(
-          errorResponse.toErrorResponse(command.id),
-          command.channel ?? null
+          BiDiMessageEntry.createResolved(
+            errorResponse.toErrorResponse(command.id),
+            command.channel ?? null
+          )
         );
       } else {
         const error = e as Error;
         console.error(error);
 
         await this.#bidiServer.sendMessage(
-          new UnknownException(error.message).toErrorResponse(command.id),
-          command.channel ?? null
+          BiDiMessageEntry.createResolved(
+            new UnknownException(error.message).toErrorResponse(command.id),
+            command.channel ?? null
+          )
         );
       }
     }

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -105,7 +105,7 @@ export class BrowsingContextImpl {
     );
     context.#targetDefers.targetUnblocked.resolve();
 
-    await eventManager.sendEvent(
+    await eventManager.registerEvent(
       new BrowsingContext.ContextCreatedEvent(context.serializeToBidiValue()),
       context.contextId
     );
@@ -134,7 +134,7 @@ export class BrowsingContextImpl {
     // noinspection ES6MissingAwait
     context.#unblockAttachedTarget();
 
-    await eventManager.sendEvent(
+    await eventManager.registerEvent(
       new BrowsingContext.ContextCreatedEvent(context.serializeToBidiValue()),
       context.contextId
     );
@@ -163,7 +163,7 @@ export class BrowsingContextImpl {
       parent.#children.delete(this.contextId);
     }
 
-    await this.#eventManager.sendEvent(
+    await this.#eventManager.registerEvent(
       new BrowsingContext.ContextDestroyedEvent(this.serializeToBidiValue()),
       this.contextId
     );
@@ -322,7 +322,7 @@ export class BrowsingContextImpl {
             this.#targetDefers.Page.lifecycleEvent.DOMContentLoaded.resolve(
               params
             );
-            await this.#eventManager.sendEvent(
+            await this.#eventManager.registerEvent(
               new BrowsingContext.DomContentLoadedEvent({
                 context: this.contextId,
                 navigation: this.#loaderId,
@@ -334,7 +334,7 @@ export class BrowsingContextImpl {
 
           case 'load':
             this.#targetDefers.Page.lifecycleEvent.load.resolve(params);
-            await this.#eventManager.sendEvent(
+            await this.#eventManager.registerEvent(
               new LoadEvent({
                 context: this.contextId,
                 navigation: this.#loaderId,

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -73,7 +73,7 @@ export class BrowsingContextProcessor {
     this.#setTargetEventListeners(sessionCdpClient);
 
     sessionCdpClient.on('event', async (method, params) => {
-      await this.#eventManager.sendEvent(
+      await this.#eventManager.registerEvent(
         {
           method: 'cdp.eventReceived',
           params: {

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -16,7 +16,7 @@
  */
 
 import {CommonDataTypes, Message} from '../protocol/bidiProtocolTypes';
-import {IBidiServer} from '../../utils/bidiServer';
+import {BiDiMessageEntry, IBidiServer} from '../../utils/bidiServer';
 import {SubscriptionManager} from './SubscriptionManager';
 import {IdWrapper} from '../../../utils/idWrapper';
 import {Buffer} from '../../../utils/buffer';
@@ -122,7 +122,9 @@ export class EventManager implements IEventManager {
     this.#bufferEvent(eventWrapper);
     // Send events to channels in the subscription priority.
     for (const channel of sortedChannels) {
-      await this.#bidiServer.sendMessage(event, channel);
+      await this.#bidiServer.sendMessage(
+        BiDiMessageEntry.createResolved(event, channel)
+      );
       this.#markEventSent(eventWrapper, channel);
     }
   }
@@ -148,7 +150,9 @@ export class EventManager implements IEventManager {
           channel
         )) {
           // The order of the events is important.
-          await this.#bidiServer.sendMessage(eventWrapper.event, channel);
+          await this.#bidiServer.sendMessage(
+            BiDiMessageEntry.createResolved(eventWrapper.event, channel)
+          );
           this.#markEventSent(eventWrapper, channel);
         }
       }

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -24,10 +24,10 @@ import {BrowsingContextStorage} from '../context/browsingContextStorage';
 
 class EventWrapper extends IdWrapper {
   readonly #contextId: CommonDataTypes.BrowsingContext | null;
-  readonly #event: Message.EventMessage;
+  readonly #event: Promise<Message.EventMessage>;
 
   constructor(
-    event: Message.EventMessage,
+    event: Promise<Message.EventMessage>,
     contextId: CommonDataTypes.BrowsingContext | null
   ) {
     super();
@@ -39,15 +39,21 @@ class EventWrapper extends IdWrapper {
     return this.#contextId;
   }
 
-  get event(): Message.EventMessage {
+  get event(): Promise<Message.EventMessage> {
     return this.#event;
   }
 }
 
 export interface IEventManager {
-  sendEvent(
+  registerEvent(
     event: Message.EventMessage,
     contextId: CommonDataTypes.BrowsingContext | null
+  ): Promise<void>;
+
+  registerPromiseEvent(
+    event: Promise<Message.EventMessage>,
+    contextId: CommonDataTypes.BrowsingContext | null,
+    eventName: string
   ): Promise<void>;
 
   subscribe(
@@ -109,23 +115,35 @@ export class EventManager implements IEventManager {
     return JSON.stringify({eventName, browsingContext, channel});
   }
 
-  async sendEvent(
+  async registerEvent(
     event: Message.EventMessage,
     contextId: CommonDataTypes.BrowsingContext | null
+  ): Promise<void> {
+    await this.registerPromiseEvent(
+      Promise.resolve(event),
+      contextId,
+      event.method
+    );
+  }
+
+  async registerPromiseEvent(
+    event: Promise<Message.EventMessage>,
+    contextId: CommonDataTypes.BrowsingContext | null,
+    eventName: string
   ): Promise<void> {
     const eventWrapper = new EventWrapper(event, contextId);
     const sortedChannels =
       this.#subscriptionManager.getChannelsSubscribedToEvent(
-        event.method,
+        eventName,
         contextId
       );
-    this.#bufferEvent(eventWrapper);
+    this.#bufferEvent(eventWrapper, eventName);
     // Send events to channels in the subscription priority.
     for (const channel of sortedChannels) {
       await this.#bidiServer.sendMessage(
-        BiDiMessageEntry.createResolved(event, channel)
+        BiDiMessageEntry.createFromPromise(event, channel)
       );
-      this.#markEventSent(eventWrapper, channel);
+      this.#markEventSent(eventWrapper, channel, eventName);
     }
   }
 
@@ -151,9 +169,9 @@ export class EventManager implements IEventManager {
         )) {
           // The order of the events is important.
           await this.#bidiServer.sendMessage(
-            BiDiMessageEntry.createResolved(eventWrapper.event, channel)
+            BiDiMessageEntry.createFromPromise(eventWrapper.event, channel)
           );
-          this.#markEventSent(eventWrapper, channel);
+          this.#markEventSent(eventWrapper, channel, eventName);
         }
       }
     }
@@ -174,8 +192,7 @@ export class EventManager implements IEventManager {
   /**
    * If the event is buffer-able, put it in the buffer.
    */
-  #bufferEvent(eventWrapper: EventWrapper) {
-    const eventName = eventWrapper.event.method;
+  #bufferEvent(eventWrapper: EventWrapper, eventName: string) {
     if (!EventManager.#eventBufferLength.has(eventName)) {
       // Do nothing if the event is no buffer-able.
       return;
@@ -203,8 +220,11 @@ export class EventManager implements IEventManager {
   /**
    * If the event is buffer-able, mark it as sent to the given contextId and channel.
    */
-  #markEventSent(eventWrapper: EventWrapper, channel: string | null) {
-    const eventName = eventWrapper.event.method;
+  #markEventSent(
+    eventWrapper: EventWrapper,
+    channel: string | null,
+    eventName: string
+  ) {
     if (!EventManager.#eventBufferLength.has(eventName)) {
       // Do nothing if the event is no buffer-able.
       return;

--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -85,7 +85,7 @@ export class LogManager {
                 })
               );
 
-        await this.#eventManager.sendEvent(
+        await this.#eventManager.registerEvent(
           new Log.LogEntryAddedEvent({
             level: LogManager.#getLogLevel(params.type),
             source: {
@@ -129,7 +129,7 @@ export class LogManager {
           );
         })();
 
-        await this.#eventManager.sendEvent(
+        await this.#eventManager.registerEvent(
           new Log.LogEntryAddedEvent({
             level: 'error',
             source: {

--- a/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
+++ b/src/bidiMapper/domains/protocol/bidiProtocolTypes.ts
@@ -46,7 +46,10 @@ function parseObject<T extends ZodType>(obj: unknown, schema: T): zod.infer<T> {
 }
 
 export namespace Message {
-  export type OutgoingMessage = CommandResponse | EventMessage;
+  export type OutgoingMessage =
+    | CommandResponse
+    | EventMessage
+    | {launched: true};
 
   export type RawCommandRequest = {
     id: number;

--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -20,7 +20,7 @@
 import {CommandProcessor} from './commandProcessor';
 
 import {CdpClient, CdpConnection} from '../cdp';
-import {BidiServer} from './utils/bidiServer';
+import {BiDiMessageEntry, BidiServer} from './utils/bidiServer';
 import {ITransport} from '../utils/transport';
 
 import {log, LogType} from '../utils/log';
@@ -73,7 +73,9 @@ const _waitSelfTargetIdPromise = _waitSelfTargetId();
 
   logSystem('launched');
 
-  bidiServer.sendMessage({launched: true}, null);
+  bidiServer.sendMessage(
+    BiDiMessageEntry.createResolved({launched: true}, null)
+  );
 })();
 
 function _createCdpConnection() {

--- a/src/bidiMapper/utils/bidiServer.ts
+++ b/src/bidiMapper/utils/bidiServer.ts
@@ -21,6 +21,7 @@ import {EventEmitter} from 'events';
 import {ITransport} from '../../utils/transport';
 import {Message} from '../domains/protocol/bidiProtocolTypes';
 import {ProcessingQueue} from '../../utils/processingQueue';
+import ErrorCode = Message.ErrorCode;
 
 const logBidi = log(LogType.bidi);
 
@@ -30,10 +31,7 @@ export interface IBidiServer {
     handler: (messageObj: Message.RawCommandRequest) => void
   ): void;
 
-  sendMessage: (
-    messageObj: Message.OutgoingMessage,
-    channel: string | null
-  ) => Promise<void>;
+  sendMessage: (message: Promise<BiDiMessageEntry>) => void;
 
   close(): void;
 }
@@ -49,6 +47,13 @@ export class BiDiMessageEntry {
   constructor(message: Message.OutgoingMessage, channel: string | null) {
     this.#message = message;
     this.#channel = channel;
+  }
+
+  static createResolved(
+    message: Message.OutgoingMessage,
+    channel: string | null
+  ): Promise<BiDiMessageEntry> {
+    return Promise.resolve(new BiDiMessageEntry(message, channel));
   }
 
   get message(): Message.OutgoingMessage {
@@ -98,10 +103,9 @@ export class BidiServer extends EventEmitter implements IBidiServer {
   /**
    * Sends BiDi message.
    */
-  async sendMessage(messageObj: any, channel: string | null): Promise<void> {
-    this.#messageQueue.add(
-      Promise.resolve(new BiDiMessageEntry(messageObj, channel))
-    );
+  sendMessage(messageEntry: Promise<BiDiMessageEntry>): void {
+    // messageEntry.then((m) => this.#sendMessage(m));
+    this.#messageQueue.add(messageEntry);
   }
 
   close(): void {
@@ -113,7 +117,7 @@ export class BidiServer extends EventEmitter implements IBidiServer {
 
     let messageObj;
     try {
-      messageObj = this.#parseBidiMessage(messageStr);
+      messageObj = BidiServer.#parseBidiMessage(messageStr);
     } catch (e: any) {
       // Transport-level error does not provide channel.
       this.#respondWithError(messageStr, 'invalid argument', e.message, null);
@@ -124,19 +128,19 @@ export class BidiServer extends EventEmitter implements IBidiServer {
 
   #respondWithError(
     plainCommandData: string,
-    errorCode: string,
+    errorCode: ErrorCode,
     errorMessage: string,
     channel: string | null
   ) {
-    const errorResponse = this.#getErrorResponse(
+    const errorResponse = BidiServer.#getErrorResponse(
       plainCommandData,
       errorCode,
       errorMessage
     );
-    this.sendMessage(errorResponse, channel);
+    this.sendMessage(BiDiMessageEntry.createResolved(errorResponse, channel));
   }
 
-  #getJsonType(value: any) {
+  static #getJsonType(value: any) {
     if (value === null) {
       return 'null';
     }
@@ -146,17 +150,20 @@ export class BidiServer extends EventEmitter implements IBidiServer {
     return typeof value;
   }
 
-  #getErrorResponse(
+  static #getErrorResponse(
     messageStr: string,
-    errorCode: string,
+    errorCode: ErrorCode,
     errorMessage: string
-  ) {
+  ): Message.OutgoingMessage {
     // TODO: this is bizarre per spec. We reparse the payload and
     // extract the ID, regardless of what kind of value it was.
     let messageId = undefined;
     try {
       const messageObj = JSON.parse(messageStr);
-      if (this.#getJsonType(messageObj) === 'object' && 'id' in messageObj) {
+      if (
+        BidiServer.#getJsonType(messageObj) === 'object' &&
+        'id' in messageObj
+      ) {
         messageId = messageObj.id;
       }
     } catch {}
@@ -169,7 +176,7 @@ export class BidiServer extends EventEmitter implements IBidiServer {
     };
   }
 
-  #parseBidiMessage(messageStr: string): Message.RawCommandRequest {
+  static #parseBidiMessage(messageStr: string): Message.RawCommandRequest {
     let messageObj: any;
     try {
       messageObj = JSON.parse(messageStr);
@@ -177,7 +184,7 @@ export class BidiServer extends EventEmitter implements IBidiServer {
       throw new Error('Cannot parse data as JSON');
     }
 
-    const parsedType = this.#getJsonType(messageObj);
+    const parsedType = BidiServer.#getJsonType(messageObj);
     if (parsedType !== 'object') {
       throw new Error(`Expected JSON object but got ${parsedType}`);
     }
@@ -185,26 +192,26 @@ export class BidiServer extends EventEmitter implements IBidiServer {
     // Extract amd validate id, method and params.
     const {id, method, params} = messageObj;
 
-    const idType = this.#getJsonType(id);
+    const idType = BidiServer.#getJsonType(id);
     if (idType !== 'number' || !Number.isInteger(id) || id < 0) {
       // TODO: should uint64_t be the upper limit?
       // https://tools.ietf.org/html/rfc7049#section-2.1
       throw new Error(`Expected unsigned integer but got ${idType}`);
     }
 
-    const methodType = this.#getJsonType(method);
+    const methodType = BidiServer.#getJsonType(method);
     if (methodType !== 'string') {
       throw new Error(`Expected string method but got ${methodType}`);
     }
 
-    const paramsType = this.#getJsonType(params);
+    const paramsType = BidiServer.#getJsonType(params);
     if (paramsType !== 'object') {
       throw new Error(`Expected object params but got ${paramsType}`);
     }
 
     let channel = messageObj.channel;
     if (channel !== undefined) {
-      const channelType = this.#getJsonType(channel);
+      const channelType = BidiServer.#getJsonType(channel);
       if (channelType !== 'string') {
         throw new Error(`Expected string channel but got ${channelType}`);
       }

--- a/src/bidiMapper/utils/bidiServer.ts
+++ b/src/bidiMapper/utils/bidiServer.ts
@@ -49,6 +49,15 @@ export class BiDiMessageEntry {
     this.#channel = channel;
   }
 
+  static createFromPromise(
+    messagePromise: Promise<Message.OutgoingMessage>,
+    channel: string | null
+  ): Promise<BiDiMessageEntry> {
+    return messagePromise.then(
+      (message) => new BiDiMessageEntry(message, channel)
+    );
+  }
+
   static createResolved(
     message: Message.OutgoingMessage,
     channel: string | null

--- a/src/utils/processingQueue.spec.ts
+++ b/src/utils/processingQueue.spec.ts
@@ -18,8 +18,8 @@
 import * as chai from 'chai';
 
 import * as sinon from 'sinon';
-import { ProcessingQueue } from './processingQueue';
-import { Deferred } from '../bidiMapper/utils/deferred';
+import {ProcessingQueue} from './processingQueue';
+import {Deferred} from '../bidiMapper/utils/deferred';
 
 const expect = chai.expect;
 

--- a/src/utils/processingQueue.spec.ts
+++ b/src/utils/processingQueue.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2022 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as chai from 'chai';
+
+import * as sinon from 'sinon';
+import { ProcessingQueue } from './processingQueue';
+import { Deferred } from '../bidiMapper/utils/deferred';
+
+const expect = chai.expect;
+
+describe('test ProcessingQueue', () => {
+  it('should wait and call processor in order', async () => {
+    const processor = sinon.stub().returns(Promise.resolve());
+    const buffer = new ProcessingQueue<number>(processor);
+    const deferred1 = new Deferred<number>();
+    const deferred2 = new Deferred<number>();
+    const deferred3 = new Deferred<number>();
+
+    buffer.add(deferred1);
+    await wait(1);
+    sinon.assert.notCalled(processor);
+
+    buffer.add(deferred2);
+    buffer.add(deferred3);
+    await wait(1);
+    sinon.assert.notCalled(processor);
+
+    deferred3.resolve(3);
+    deferred2.resolve(2);
+    await wait(1);
+    sinon.assert.notCalled(processor);
+
+    deferred1.resolve(1);
+    await wait(1);
+
+    const processedValues = processor.getCalls().map((c) => c.firstArg);
+    expect(processedValues).to.deep.equal([1, 2, 3]);
+  });
+  it('rejects should not stop processing', async () => {
+    const processor = sinon.stub().returns(Promise.reject('Processor reject'));
+    const _catch = sinon.spy();
+    const buffer = new ProcessingQueue<number>(processor, _catch);
+    const deferred1 = new Deferred<number>();
+    const deferred2 = new Deferred<number>();
+
+    buffer.add(deferred1);
+    buffer.add(deferred2);
+    // await wait(1);
+
+    deferred1.reject(1);
+    deferred2.resolve(2);
+    await wait(1);
+
+    // Assert processor was called with successful value.
+    sinon.assert.calledOnceWithExactly(processor, 2);
+
+    // Assert `_catch` was called for waiting entry and processor call.
+    const processedValues = _catch.getCalls().map((c) => c.firstArg);
+    expect(processedValues).to.deep.equal([1, 'Processor reject']);
+  });
+});
+
+function wait(timeout: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -53,7 +53,7 @@ export class ProcessingQueue<T> {
         await entryPromise
           .then((entry) => this.#processor(entry))
           .catch((e) => {
-            logSystem('Event was not processed! ' + e);
+            logSystem('Event was not processed:' + e);
             this.#catch(e);
           })
           .finally();

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -1,3 +1,5 @@
+import {log, LogType} from './log';
+
 /**
  * Copyright 2022 Google LLC.
  * Copyright (c) Microsoft Corporation.
@@ -14,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+const logSystem = log(LogType.system);
 
 export class ProcessingQueue<T> {
   readonly #queue: Promise<T>[] = [];
@@ -48,8 +52,10 @@ export class ProcessingQueue<T> {
       if (entryPromise !== undefined) {
         await entryPromise
           .then((entry) => this.#processor(entry))
-          .catch((e) => this.#catch(e))
-          // Continue processing queue.
+          .catch((e) => {
+            logSystem('Event was not processed! ' + e);
+            this.#catch(e);
+          })
           .finally();
       }
     }

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -54,6 +54,6 @@ export class ProcessingQueue<T> {
       }
     }
 
-    this.#isProcessing = true;
+    this.#isProcessing = false;
   }
 }

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2022 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class ProcessingQueue<T> {
+  readonly #queue: Promise<T>[] = [];
+  readonly #processor: (arg: T) => Promise<void>;
+  readonly #catch: (error: unknown) => Promise<void>;
+
+  // Flag to keep only 1 active processor.
+  #isProcessing = false;
+
+  constructor(
+    processor: (arg: T) => Promise<void>,
+    _catch: (error: unknown) => Promise<void> = () => Promise.resolve()
+  ) {
+    this.#catch = _catch;
+    this.#processor = processor;
+  }
+
+  add(entry: Promise<T>) {
+    this.#queue.push(entry);
+    // No need in waiting. Just initialise processor if needed.
+    // noinspection JSIgnoredPromiseFromCall
+    this.#processIfNeeded();
+  }
+
+  async #processIfNeeded() {
+    if (this.#isProcessing) {
+      return;
+    }
+    this.#isProcessing = true;
+    while (this.#queue.length > 0) {
+      const entryPromise = this.#queue.shift();
+      if (entryPromise !== undefined) {
+        await entryPromise
+          .then((entry) => this.#processor(entry))
+          .catch((e) => this.#catch(e))
+          // Continue processing queue.
+          .finally();
+      }
+    }
+
+    this.#isProcessing = true;
+  }
+}

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import json
 import os
+
 import pytest
 import websockets
 
@@ -182,6 +182,7 @@ async def send_JSON_command(websocket, command):
         command_id = get_next_command_id()
         command["id"] = command_id
     await websocket.send(json.dumps(command))
+    return command["id"]
 
 
 async def read_JSON_message(websocket):

--- a/tests/test_log_events.py
+++ b/tests/test_log_events.py
@@ -302,3 +302,99 @@ async def test_buffer_bufferedEventsReturned(websocket, context_id):
     # Wait for subscription command to finish.
     resp = await read_JSON_message(websocket)
     assert resp["id"] == 16
+
+
+@pytest.mark.asyncio
+async def test_runtimeException_emitted(websocket, context_id):
+    error_message = "SOME_ERROR_MESSAGE"
+
+    await subscribe(websocket, "log.entryAdded")
+
+    # Throw JS page error and get expected error message text.
+    command_id = await send_JSON_command(websocket, {
+        "method": "script.evaluate",
+        "params": {
+            "expression": f"""
+                const script = document.createElement("script");
+                script.append(document.createTextNode(
+                    '(() => {{ throw new Error("{error_message}") }})()'
+                ));
+                document.body.append(script);""",
+            "target": {"context": context_id},
+            "awaitPromise": True}})
+
+    # Assert event was emitted before the command is finished.
+    resp = await read_JSON_message(websocket)
+    recursive_compare({
+        "method": "log.entryAdded",
+        "params": {
+            "level": "error",
+            "source": {
+                "realm": any_string,
+                "context": any_string},
+            "text": f"Error: {error_message}",
+            "timestamp": any_timestamp,
+            "stackTrace": any_value,
+            "type": "javascript"}},
+        resp)
+
+    # Assert evaluate command is finished after event emitted.
+    resp = await read_JSON_message(websocket)
+    recursive_compare({
+        "id": command_id,
+        "result": {
+            'realm': any_string,
+            'result': any_value}},
+        resp)
+
+
+@pytest.mark.asyncio
+async def test_runtimeException_buffered(websocket, context_id):
+    error_message = "SOME_ERROR_MESSAGE"
+    # Throw JS page error and get expected error message text.
+    command_id = await send_JSON_command(websocket, {
+        "method": "script.evaluate",
+        "params": {
+            "expression": f"""
+                const script = document.createElement("script");
+                script.append(document.createTextNode(
+                    '(() => {{ throw new Error("{error_message}") }})()'
+                ));
+                document.body.append(script);""",
+            "target": {"context": context_id},
+            "awaitPromise": True}})
+
+    # Assert evaluate command is finished.
+    resp = await read_JSON_message(websocket)
+    recursive_compare({
+        "id": command_id,
+        "result": any_value},
+        resp)
+
+    # Subscribe to events with buffer.
+    subscribe_command_id = await send_JSON_command(websocket, {
+        "method": "session.subscribe",
+        "params": {
+            "events": ["log.entryAdded"]}})
+
+    # Assert event was emitted.
+    resp = await read_JSON_message(websocket)
+    recursive_compare({
+        "method": "log.entryAdded",
+        "params": {
+            "level": "error",
+            "source": {
+                "realm": any_string,
+                "context": any_string},
+            "text": f"Error: {error_message}",
+            "timestamp": any_timestamp,
+            "stackTrace": any_value,
+            "type": "javascript"}},
+        resp)
+
+    # Assert subscribe command is finished.
+    resp = await read_JSON_message(websocket)
+    recursive_compare({
+        "id": subscribe_command_id,
+        "result": {}},
+        resp)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -118,331 +118,240 @@ async def assert_callFunction_deserialization_serialization(websocket,
 
 
 @pytest.mark.asyncio
-async def test_serialization_deserialization_undefined(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "undefined"})
+@pytest.mark.parametrize("serialized", [
+    {
+        "type": "undefined"
+    }, {
+        "type": "string",
+        "value": "someStr"
+    },
+    {
+        "type": "string",
+        "value": ""
+    }, {
+        "type": "number",
+        "value": 123
+    }, {
+        "type": "number",
+        "value": 0.56
+    }, {
+        "type": "number",
+        "value": "Infinity"
+    }, {
+        "type": "number",
+        "value": "-Infinity"
+    }, {
+        "type": "number",
+        "value": "-0"
+    }, {
+        "type": "number",
+        "value": "NaN"
+    }, {
+        "type": "boolean",
+        "value": True
+    }, {
+        "type": "boolean",
+        "value": False
+    }, {
+        "type": "bigint",
+        "value": "12345678901234567890"
+    }])
+async def test_serialization_deserialization(websocket, context_id,
+      serialized):
+    await assert_callFunction_deserialization_serialization(
+        websocket, context_id, serialized)
 
 
 @pytest.mark.asyncio
-async def test_serialization_deserialization_null(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {"type": "null"})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_string(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "string",
-                                                                "value": "someStr"})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "string",
-                                                                "value": ""})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_number(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "number",
-                                                                "value": 123})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "number",
-                                                                "value": 0.56})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_specialNumber(websocket,
-      context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "number",
-                                                                "value": "Infinity"})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "number",
-                                                                "value": "+Infinity"
-                                                            }, {
-                                                                "type": "number",
-                                                                "value": "Infinity"})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "number",
-                                                                "value": "-Infinity"})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "number",
-                                                                "value": "-0"})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "number",
-                                                                "value": "NaN"})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_bool(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "boolean",
-                                                                "value": True})
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "boolean",
-                                                                "value": False})
-
-
-@pytest.mark.asyncio
-async def test_serialization_function(websocket, context_id):
+@pytest.mark.parametrize("jsString, excepted_serialized", [
+    (
+          "function(){}",
+          {
+              "type": "function",
+              "handle": any_string
+          }
+    ), (
+          "Promise.resolve(1)", {
+              "type": "promise",
+              "handle": any_string
+          }
+    ), (
+          "new WeakMap()", {
+              "type": "weakmap",
+              "handle": any_string
+          }
+    ), (
+          "new WeakSet()", {
+              "type": "weakset",
+              "handle": any_string
+          }
+    ), (
+          "new Proxy({}, {})", {
+              "type": "proxy",
+              "handle": any_string
+          }
+    ), (
+          "new Int32Array()", {
+              "type": "typedarray",
+              "handle": any_string
+          }
+    ), (
+          "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
+          {
+              "type": "object",
+              "handle": any_string,
+              "value": [[
+                  "foo", {
+                      "type": "object"}], [
+                  "qux", {
+                      "type": "string",
+                      "value": "quux"}]]}
+    ), (
+          "[1, 'a', {foo: 'bar'}, [2,[3,4]]]", {
+              "type": "array",
+              "handle": any_string,
+              "value": [{
+                  "type": "number",
+                  "value": 1
+              }, {
+                  "type": "string",
+                  "value": "a"
+              }, {
+                  "type": "object"
+              }, {
+                  "type": "array"}]}
+    ), (
+          "new Set([1, 'a', {foo: 'bar'}, [2,[3,4]]])",
+          {
+              "type": "set",
+              "handle": any_string,
+              "value": [{
+                  "type": "number",
+                  "value": 1
+              }, {
+                  "type": "string",
+                  "value": "a"
+              }, {
+                  "type": "object"
+              }, {
+                  "type": "array"}]}
+    ), (
+          "Symbol('foo')", {
+              "type": "symbol",
+              "handle": any_string
+          }), (
+          "this.window", {
+              "type": "window",
+              "handle": any_string
+          }
+    ), (
+          "new Error('Woops!')", {
+              "type": "error",
+              "handle": any_string
+          })])
+async def test_serialization_function(websocket, context_id, jsString,
+      excepted_serialized):
     await assert_serialization(websocket, context_id,
-                               "function(){}", {
-                                   "type": "function",
-                                   "handle": any_string
-                               })
+                               jsString, excepted_serialized)
 
 
 @pytest.mark.asyncio
-async def test_serialization_promise(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "Promise.resolve(1)", {
-                                   "type": "promise",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-async def test_serialization_weakMap(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "new WeakMap()", {
-                                   "type": "weakmap",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-async def test_serialization_weakSet(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "new WeakSet()", {
-                                   "type": "weakset",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-# Not specified yet.
-async def test_serialization_proxy(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "new Proxy({}, {})", {
-                                   "type": "proxy",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-async def test_serialization_typedarray(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "new Int32Array()", {
-                                   "type": "typedarray",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-async def test_serialization_object(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "{'foo': {'bar': 'baz'}, 'qux': 'quux'}",
-                               {
-                                   "type": "object",
-                                   "handle": any_string,
-                                   "value": [[
-                                       "foo", {
-                                           "type": "object"}], [
-                                       "qux", {
-                                           "type": "string",
-                                           "value": "quux"}]]})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_object(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "object",
-                                                                "value": [[
-                                                                    "foo", {
-                                                                        "type": "object",
-                                                                        "value": []}
-                                                                ], [{
-                                                                    "type": "string",
-                                                                    "value": "qux"
-                                                                }, {
-                                                                    "type": "string",
-                                                                    "value": "quux"}]]},
-                                                            {
-                                                                "type": "object",
-                                                                "handle": any_string,
-                                                                "value": [[
-                                                                    "foo", {
-                                                                        "type": "object"}
-                                                                ], [
-                                                                    "qux", {
-                                                                        "type": "string",
-                                                                        "value": "quux"}]]})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_map(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "map",
-                                                                "value": [[
-                                                                    "foo", {
-                                                                        "type": "object",
-                                                                        "value": []}
-                                                                ], [{
-                                                                    "type": "string",
-                                                                    "value": "qux"
-                                                                }, {
-                                                                    "type": "string",
-                                                                    "value": "quux"}]]},
-                                                            {
-                                                                "type": "map",
-                                                                "handle": any_string,
-                                                                "value": [[
-                                                                    "foo", {
-                                                                        "type": "object"}
-                                                                ], [
-                                                                    "qux", {
-                                                                        "type": "string",
-                                                                        "value": "quux"}]]})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_array(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "array",
-                                                                "value": [{
-                                                                    "type": "number",
-                                                                    "value": 1
-                                                                }, {
-                                                                    "type": "string",
-                                                                    "value": "a"
-                                                                }]}, {
-                                                                "type": "array",
-                                                                "handle": any_string,
-                                                                "value": [{
-                                                                    "type": "number",
-                                                                    "value": 1
-                                                                }, {
-                                                                    "type": "string",
-                                                                    "value": "a"
-                                                                }]}, )
-
-
-@pytest.mark.asyncio
-async def test_serialization_array(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "[1, 'a', {foo: 'bar'}, [2,[3,4]]]", {
-                                   "type": "array",
-                                   "handle": any_string,
-                                   "value": [{
-                                       "type": "number",
-                                       "value": 1
-                                   }, {
-                                       "type": "string",
-                                       "value": "a"
-                                   }, {
-                                       "type": "object"
-                                   }, {
-                                       "type": "array"}]})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_set(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "set",
-                                                                "value": [{
-                                                                    "type": "number",
-                                                                    "value": 1.23
-                                                                }, {
-                                                                    "type": "string",
-                                                                    "value": "a"
-                                                                }]}, {
-                                                                "type": "set",
-                                                                "handle": any_string,
-                                                                "value": [{
-                                                                    "type": "number",
-                                                                    "value": 1.23
-                                                                }, {
-                                                                    "type": "string",
-                                                                    "value": "a"
-                                                                }]}, )
-
-
-@pytest.mark.asyncio
-async def test_serialization_set(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "new Set([1, 'a', {foo: 'bar'}, [2,[3,4]]])",
-                               {
-                                   "type": "set",
-                                   "handle": any_string,
-                                   "value": [{
-                                       "type": "number",
-                                       "value": 1
-                                   }, {
-                                       "type": "string",
-                                       "value": "a"
-                                   }, {
-                                       "type": "object"
-                                   }, {
-                                       "type": "array"}]})
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_bigint(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id, {
-                                                                "type": "bigint",
-                                                                "value": "12345678901234567890"})
-
-
-@pytest.mark.asyncio
-async def test_serialization_symbol(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "Symbol('foo')", {
-                                   "type": "symbol",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-async def test_serialization_deserialization_regExp(websocket, context_id):
-    await assert_callFunction_deserialization_serialization(websocket,
-                                                            context_id,
-                                                            {
-                                                                "type": "regexp",
-                                                                "value": {
-                                                                    "pattern": "ab+c",
-                                                                    "flags": "i"
-                                                                }
-                                                            }, {
-                                                                "type": "regexp",
-                                                                "handle": any_string,
-                                                                "value": {
-                                                                    "pattern": "ab+c",
-                                                                    "flags": "i"
-                                                                }
-                                                            })
+@pytest.mark.parametrize("serialized, excepted_re_serialized", [
+    ({
+         "type": "object",
+         "value": [[
+             "foo", {
+                 "type": "object",
+                 "value": []}
+         ], [{
+             "type": "string",
+             "value": "qux"
+         }, {
+             "type": "string",
+             "value": "quux"}]]
+     }, {
+         "type": "object",
+         "handle": any_string,
+         "value": [[
+             "foo", {
+                 "type": "object"}
+         ], [
+             "qux", {
+                 "type": "string",
+                 "value": "quux"}]]}
+    ), ({
+            "type": "map",
+            "value": [[
+                "foo", {
+                    "type": "object",
+                    "value": []}
+            ], [{
+                "type": "string",
+                "value": "qux"
+            }, {
+                "type": "string",
+                "value": "quux"}]]
+        }, {
+            "type": "map",
+            "handle": any_string,
+            "value": [[
+                "foo", {
+                    "type": "object"}
+            ], [
+                "qux", {
+                    "type": "string",
+                    "value": "quux"}]]}
+    ), ({
+            "type": "array",
+            "value": [{
+                "type": "number",
+                "value": 1
+            }, {
+                "type": "string",
+                "value": "a"}]
+        }, {
+            "type": "array",
+            "handle": any_string,
+            "value": [{
+                "type": "number",
+                "value": 1
+            }, {
+                "type": "string",
+                "value": "a"}]}
+    ), ({
+            "type": "set",
+            "value": [{
+                "type": "number",
+                "value": 1.23
+            }, {
+                "type": "string",
+                "value": "a"}]
+        }, {
+            "type": "set",
+            "handle": any_string,
+            "value": [{
+                "type": "number",
+                "value": 1.23
+            }, {
+                "type": "string",
+                "value": "a"
+            }]}
+    ), ({
+            "type": "regexp",
+            "value": {
+                "pattern": "ab+c",
+                "flags": "i"}
+        }, {
+            "type": "regexp",
+            "handle": any_string,
+            "value": {
+                "pattern": "ab+c",
+                "flags": "i"
+            }})])
+async def test_serialization_deserialization_complex(websocket, context_id,
+      serialized, excepted_re_serialized):
+    await assert_callFunction_deserialization_serialization(
+        websocket, context_id, serialized, excepted_re_serialized)
 
 
 @pytest.mark.asyncio
@@ -464,24 +373,6 @@ async def test_serialization_deserialization_date(websocket, context_id):
     assert result["result"] == {
         "type": "date",
         "value": "2020-07-19T06:34:56.789Z"}
-
-
-@pytest.mark.asyncio
-async def test_serialization_windowProxy(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "this.window", {
-                                   "type": "window",
-                                   "handle": any_string
-                               })
-
-
-@pytest.mark.asyncio
-async def test_serialization_error(websocket, context_id):
-    await assert_serialization(websocket, context_id,
-                               "new Error('Woops!')", {
-                                   "type": "error",
-                                   "handle": any_string
-                               })
 
 
 @pytest.mark.asyncio

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -141,7 +141,7 @@ async def test_subscribeToOneChannel_eventReceivedWithProperChannel(
         "params": {
             "events": ["log.entryAdded"]}})
 
-    await execute_command(websocket, {
+    await send_JSON_command(websocket, {
         "method": "script.evaluate",
         "params": {
             "expression": "console.log('SOME_MESSAGE')",
@@ -190,7 +190,7 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
             "cointext": context_id
         }})
 
-    await execute_command(websocket, {
+    await send_JSON_command(websocket, {
         "method": "script.evaluate",
         "channel": "SOME_OTHER_CHANNEL",
         "params": {


### PR DESCRIPTION
Implementation of the "processing queue with promises": http://go/webdriver-non-racy-serialization-proposal.

To provide serialization of the events, additional CDP call is required. When such a call is done, the order of the events can be changed. This PR implements `ProcessingQueue`, which allows adding Promises instead of the real values, and guarantee the order of the messages are kept.

The promise queue is for consoleAPI events.

Extended e2e tests to cover result, exception and log serialization.