### PR TITLE
Fix Hacker News `cross-browser.py` example

### DIFF
--- a/examples/app.html
+++ b/examples/app.html
@@ -1,1446 +1,178 @@
-<!DOCTYPE html>
-<!-- saved from https://news.ycombinator.com/ on 2022-04-27 -->
-<html lang="en" op="news">
-  <head>
-    <meta name="referrer" content="origin" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="rss" />
-    <title>Hacker News</title>
-  </head>
-  <body>
-    <center>
-      <table id="hnmain" border="0" cellpadding="0" cellspacing="0" width="85%" bgcolor="#f6f6ef">
-        <tr>
-          <td bgcolor="#ff6600">
-            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="padding: 2px">
-              <tr>
-                <td style="width: 18px; padding-right: 4px">
-                  <a href="https://news.ycombinator.com"><img src="y18.gif" width="18" height="18" style="border: 1px white solid" /></a>
-                </td>
-                <td style="line-height: 12pt; height: 10px">
-                  <span class="pagetop"
-                    ><b class="hnname"><a href="news">Hacker News</a></b> <a href="newest">new</a> | <a href="front">past</a> | <a href="newcomments">comments</a> | <a href="ask">ask</a> | <a href="show">show</a> | <a href="jobs">jobs</a> | <a href="submit">submit</a>
-                  </span>
-                </td>
-                <td style="text-align: right; padding-right: 4px">
-                  <span class="pagetop">
-                    <a href="login?goto=news">login</a>
-                  </span>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr id="pagespace" title="" style="height: 10px"></tr>
-        <tr>
-          <td>
-            <table border="0" cellpadding="0" cellspacing="0" class="itemlist">
-              <tr class="athing" id="31178506">
-                <td align="right" valign="top" class="title"><span class="rank">1.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31178506" href="vote?id=31178506&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://shkspr.mobi/blog/2021/10/no-you-cant-save-30-per-year-by-switching-off-your-standby-devices/" class="titlelink">No, you can’t save £30 per year by switching off your “standby” devices</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=shkspr.mobi"><span class="sitestr">shkspr.mobi</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31178506">41 points</span> by <a href="user?id=tosh" class="hnuser">tosh</a> <span class="age" title="2022-04-27T11:09:50"><a href="item?id=31178506">1 hour ago</a></span> <span id="unv_31178506"></span> | <a href="hide?id=31178506&amp;goto=news">hide</a> | <a href="item?id=31178506">29&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31178022">
-                <td align="right" valign="top" class="title"><span class="rank">2.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31178022" href="vote?id=31178022&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://news.mit.edu/2022/low-power-thin-loudspeaker-0426" class="titlelink">MIT researchers develop a paper thin loudspeaker</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=news.mit.edu"><span class="sitestr">news.mit.edu</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31178022">103 points</span> by <a href="user?id=go_prodev" class="hnuser">go_prodev</a> <span class="age" title="2022-04-27T09:34:39"><a href="item?id=31178022">2 hours ago</a></span> <span id="unv_31178022"></span> | <a href="hide?id=31178022&amp;goto=news">hide</a> | <a href="item?id=31178022">56&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176828">
-                <td align="right" valign="top" class="title"><span class="rank">3.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176828" href="vote?id=31176828&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://asuprep.asu.edu/khan-world-school/" class="titlelink">Khan Academy launches Khan World School online high school</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=asu.edu"><span class="sitestr">asu.edu</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176828">226 points</span> by <a href="user?id=webmaven" class="hnuser">webmaven</a> <span class="age" title="2022-04-27T06:02:24"><a href="item?id=31176828">6 hours ago</a></span> <span id="unv_31176828"></span> | <a href="hide?id=31176828&amp;goto=news">hide</a> | <a href="item?id=31176828">124&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176138">
-                <td align="right" valign="top" class="title"><span class="rank">4.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176138" href="vote?id=31176138&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.ctrl.blog/entry/selinux-unmanageable.html" class="titlelink">SELinux is unmanageable; just turn it off if it gets in your way</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=ctrl.blog"><span class="sitestr">ctrl.blog</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176138">310 points</span> by <a href="user?id=HyphenSam" class="hnuser">HyphenSam</a> <span class="age" title="2022-04-27T04:00:36"><a href="item?id=31176138">8 hours ago</a></span> <span id="unv_31176138"></span> | <a href="hide?id=31176138&amp;goto=news">hide</a> | <a href="item?id=31176138">235&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31177454">
-                <td align="right" valign="top" class="title"><span class="rank">5.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31177454" href="vote?id=31177454&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://arxiv.org/abs/2204.10920" class="titlelink">Statistical Analysis shows Echos process voice to serve ads</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31177454">107 points</span> by <a href="user?id=BeniBoy" class="hnuser">BeniBoy</a> <span class="age" title="2022-04-27T07:56:15"><a href="item?id=31177454">4 hours ago</a></span> <span id="unv_31177454"></span> | <a href="hide?id=31177454&amp;goto=news">hide</a> | <a href="item?id=31177454">55&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31177098">
-                <td align="right" valign="top" class="title"><span class="rank">6.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31177098" href="vote?id=31177098&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://git.videolan.org/?p=ffmpeg.git;a=commit;h=0008c159562b877700cd9b7c96f941de4ee69af5" class="titlelink">FFmpeg now supports JPEG XL</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=videolan.org"><span class="sitestr">videolan.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31177098">105 points</span> by <a href="user?id=867-5309" class="hnuser">867-5309</a> <span class="age" title="2022-04-27T06:59:35"><a href="item?id=31177098">5 hours ago</a></span> <span id="unv_31177098"></span> | <a href="hide?id=31177098&amp;goto=news">hide</a> | <a href="item?id=31177098">26&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31178817">
-                <td align="right" valign="top" class="title"><span class="rank">7.</span></td>
-                <td></td>
-                <td class="title">
-                  <a href="https://www.ycombinator.com/companies/playhouse/jobs/s9TaYfC-founding-full-stack-engineer" class="titlelink" rel="nofollow">Playhouse (YC S21) Is Hiring a Founding Full-Stack Engineer</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=ycombinator.com"><span class="sitestr">ycombinator.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="age" title="2022-04-27T12:00:04"><a href="item?id=31178817">16 minutes ago</a></span> | <a href="hide?id=31178817&amp;goto=news">hide</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31178737">
-                <td align="right" valign="top" class="title"><span class="rank">8.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31178737" href="vote?id=31178737&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://github.com/rabbibotton/clog/blob/main/LEARN.md" class="titlelink" rel="nofollow">Tutorial Series to learn Common Lisp quickly</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=github.com/rabbibotton"><span class="sitestr">github.com/rabbibotton</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31178737">8 points</span> by <a href="user?id=oumua_don17" class="hnuser">oumua_don17</a> <span class="age" title="2022-04-27T11:48:32"><a href="item?id=31178737">28 minutes ago</a></span> <span id="unv_31178737"></span> | <a href="hide?id=31178737&amp;goto=news">hide</a> | <a href="item?id=31178737">discuss</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31177474">
-                <td align="right" valign="top" class="title"><span class="rank">9.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31177474" href="vote?id=31177474&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://serokell.io/blog/haskell-typeclasses" class="titlelink">Introduction to Haskell Typeclasses</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=serokell.io"><span class="sitestr">serokell.io</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31177474">41 points</span> by <a href="user?id=ingve" class="hnuser">ingve</a> <span class="age" title="2022-04-27T07:59:49"><a href="item?id=31177474">4 hours ago</a></span> <span id="unv_31177474"></span> | <a href="hide?id=31177474&amp;goto=news">hide</a> | <a href="item?id=31177474">1&nbsp;comment</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31175291">
-                <td align="right" valign="top" class="title"><span class="rank">10.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31175291" href="vote?id=31175291&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://textsynth.com/playground.html" class="titlelink">Textsynth: Bellard's free GPT-NeoX-20B, GPT-J playground and paid API</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=textsynth.com"><span class="sitestr">textsynth.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31175291">208 points</span> by <a href="user?id=crazypython" class="hnuser">crazypython</a> <span class="age" title="2022-04-27T01:42:45"><a href="item?id=31175291">10 hours ago</a></span> <span id="unv_31175291"></span> | <a href="hide?id=31175291&amp;goto=news">hide</a> | <a href="item?id=31175291">108&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31166274">
-                <td align="right" valign="top" class="title"><span class="rank">11.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31166274" href="vote?id=31166274&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://nautil.us/what-lurks-in-a-drowned-forest-in-alabama-16508/" class="titlelink">What Lurks in a Drowned Forest in Alabama?</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=nautil.us"><span class="sitestr">nautil.us</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31166274">20 points</span> by <a href="user?id=dnetesn" class="hnuser">dnetesn</a> <span class="age" title="2022-04-26T11:47:21"><a href="item?id=31166274">2 hours ago</a></span> <span id="unv_31166274"></span> | <a href="hide?id=31166274&amp;goto=news">hide</a> | <a href="item?id=31166274">1&nbsp;comment</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176910">
-                <td align="right" valign="top" class="title"><span class="rank">12.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176910" href="vote?id=31176910&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.pzuraq.com/blog/four-eras-of-javascript-frameworks" class="titlelink">Four Eras of JavaScript Frameworks</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=pzuraq.com"><span class="sitestr">pzuraq.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176910">120 points</span> by <a href="user?id=RafelMri" class="hnuser">RafelMri</a> <span class="age" title="2022-04-27T06:21:47"><a href="item?id=31176910">5 hours ago</a></span> <span id="unv_31176910"></span> | <a href="hide?id=31176910&amp;goto=news">hide</a> | <a href="item?id=31176910">105&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31168052">
-                <td align="right" valign="top" class="title"><span class="rank">13.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31168052" href="vote?id=31168052&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://xakcop.com/post/re-2.4ghz/" class="titlelink">Reversing a 2.4GHz Remote Control</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=xakcop.com"><span class="sitestr">xakcop.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31168052">84 points</span> by <a href="user?id=ggerganov" class="hnuser">ggerganov</a> <span class="age" title="2022-04-26T14:40:21"><a href="item?id=31168052">7 hours ago</a></span> <span id="unv_31168052"></span> | <a href="hide?id=31168052&amp;goto=news">hide</a> | <a href="item?id=31168052">22&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176054">
-                <td align="right" valign="top" class="title"><span class="rank">14.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176054" href="vote?id=31176054&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://docs.datasette.io/en/stable/ecosystem.html" class="titlelink">The Datasette Ecosystem</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=datasette.io"><span class="sitestr">datasette.io</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176054">111 points</span> by <a href="user?id=Tomte" class="hnuser">Tomte</a> <span class="age" title="2022-04-27T03:43:29"><a href="item?id=31176054">8 hours ago</a></span> <span id="unv_31176054"></span> | <a href="hide?id=31176054&amp;goto=news">hide</a> | <a href="item?id=31176054">12&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176458">
-                <td align="right" valign="top" class="title"><span class="rank">15.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176458" href="vote?id=31176458&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.innovationaus.com/uber-concedes-deception-prepares-for-26m-accc-spanking/" class="titlelink">Uber concedes deception, prepares for $26m ACCC spanking</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=innovationaus.com"><span class="sitestr">innovationaus.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176458">104 points</span> by <a href="user?id=smcleod" class="hnuser">smcleod</a> <span class="age" title="2022-04-27T04:52:48"><a href="item?id=31176458">7 hours ago</a></span> <span id="unv_31176458"></span> | <a href="hide?id=31176458&amp;goto=news">hide</a> | <a href="item?id=31176458">86&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154039">
-                <td align="right" valign="top" class="title"><span class="rank">16.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154039" href="vote?id=31154039&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.instantdb.dev/essays/datalogjs" class="titlelink">Datalog in JavaScript</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=instantdb.dev"><span class="sitestr">instantdb.dev</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154039">46 points</span> by <a href="user?id=stopachka" class="hnuser">stopachka</a> <span class="age" title="2022-04-25T13:13:19"><a href="item?id=31154039">5 hours ago</a></span> <span id="unv_31154039"></span> | <a href="hide?id=31154039&amp;goto=news">hide</a> | <a href="item?id=31154039">9&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154567">
-                <td align="right" valign="top" class="title"><span class="rank">17.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154567" href="vote?id=31154567&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://lists.sh" class="titlelink">Show HN: Lists.sh – A Microblog for Lists</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=lists.sh"><span class="sitestr">lists.sh</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154567">191 points</span> by <a href="user?id=qudat" class="hnuser">qudat</a> <span class="age" title="2022-04-25T13:44:02"><a href="item?id=31154567">11 hours ago</a></span> <span id="unv_31154567"></span> | <a href="hide?id=31154567&amp;goto=news">hide</a> | <a href="item?id=31154567">39&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31158654">
-                <td align="right" valign="top" class="title"><span class="rank">18.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31158654" href="vote?id=31158654&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.theguardian.com/books/2022/apr/18/stalins-architect-by-deyan-sudjic-review-a-momumental-life" class="titlelink">Stalin’s Architect by Deyan Sudjic review – a monumental life</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=theguardian.com"><span class="sitestr">theguardian.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31158654">6 points</span> by <a href="user?id=Caiero" class="hnuser">Caiero</a> <span class="age" title="2022-04-25T18:16:22"><a href="item?id=31158654">1 hour ago</a></span> <span id="unv_31158654"></span> | <a href="hide?id=31158654&amp;goto=news">hide</a> | <a href="item?id=31158654">1&nbsp;comment</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31175472">
-                <td align="right" valign="top" class="title"><span class="rank">19.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31175472" href="vote?id=31175472&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://arxiv.org/abs/2204.11918" class="titlelink">Google Scanned Objects: A High-Quality Dataset of 3D Scanned Household Items</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31175472">108 points</span> by <a href="user?id=lnyan" class="hnuser">lnyan</a> <span class="age" title="2022-04-27T02:10:59"><a href="item?id=31175472">10 hours ago</a></span> <span id="unv_31175472"></span> | <a href="hide?id=31175472&amp;goto=news">hide</a> | <a href="item?id=31175472">17&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31173484">
-                <td align="right" valign="top" class="title"><span class="rank">20.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31173484" href="vote?id=31173484&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://cbea.ms/git-commit/" class="titlelink">How to write a Git commit message (2014)</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=cbea.ms"><span class="sitestr">cbea.ms</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31173484">225 points</span> by <a href="user?id=baristaGeek" class="hnuser">baristaGeek</a> <span class="age" title="2022-04-26T21:35:44"><a href="item?id=31173484">14 hours ago</a></span> <span id="unv_31173484"></span> | <a href="hide?id=31173484&amp;goto=news">hide</a> | <a href="item?id=31173484">138&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31166079">
-                <td align="right" valign="top" class="title"><span class="rank">21.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31166079" href="vote?id=31166079&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.cockroachlabs.com/blog/brief-history-high-availability/" class="titlelink">A Brief History of High Availability</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=cockroachlabs.com"><span class="sitestr">cockroachlabs.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31166079">18 points</span> by <a href="user?id=EntICOnc" class="hnuser">EntICOnc</a> <span class="age" title="2022-04-26T11:21:41"><a href="item?id=31166079">3 hours ago</a></span> <span id="unv_31166079"></span> | <a href="hide?id=31166079&amp;goto=news">hide</a> | <a href="item?id=31166079">2&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154522">
-                <td align="right" valign="top" class="title"><span class="rank">22.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154522" href="vote?id=31154522&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.washingtonpost.com/video-games/esports/2022/04/19/esports-age-retirement/" class="titlelink">Esports stars have shorter careers than NFL players</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=washingtonpost.com"><span class="sitestr">washingtonpost.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154522">125 points</span> by <a href="user?id=danso" class="hnuser">danso</a> <span class="age" title="2022-04-25T13:42:25"><a href="item?id=31154522">13 hours ago</a></span> <span id="unv_31154522"></span> | <a href="hide?id=31154522&amp;goto=news">hide</a> | <a href="item?id=31154522">121&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31169193">
-                <td align="right" valign="top" class="title"><span class="rank">23.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31169193" href="vote?id=31169193&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.baseten.co/" class="titlelink">Show HN: Baseten – Build ML-powered applications</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=baseten.co"><span class="sitestr">baseten.co</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31169193">59 points</span> by <a href="user?id=philipkiely" class="hnuser">philipkiely</a> <span class="age" title="2022-04-26T16:05:37"><a href="item?id=31169193">6 hours ago</a></span> <span id="unv_31169193"></span> | <a href="hide?id=31169193&amp;goto=news">hide</a> | <a href="item?id=31169193">5&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31164769">
-                <td align="right" valign="top" class="title"><span class="rank">24.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31164769" href="vote?id=31164769&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://blog.concannon.tech/tech-talk/tbd54566975/" class="titlelink">What’s Behind the Naming of TBD54566975?</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=concannon.tech"><span class="sitestr">concannon.tech</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31164769">62 points</span> by <a href="user?id=alexrustic" class="hnuser">alexrustic</a> <span class="age" title="2022-04-26T06:57:45"><a href="item?id=31164769">9 hours ago</a></span> <span id="unv_31164769"></span> | <a href="hide?id=31164769&amp;goto=news">hide</a> | <a href="item?id=31164769">34&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31169774">
-                <td align="right" valign="top" class="title"><span class="rank">25.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31169774" href="vote?id=31169774&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.bloomberg.com/news/articles/2022-04-26/forever-21-parent-authentic-brands-sues-bolt-startup" class="titlelink">Payment startup Bolt sued by its most prominent customer</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=bloomberg.com"><span class="sitestr">bloomberg.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31169774">149 points</span> by <a href="user?id=babelfish" class="hnuser">babelfish</a> <span class="age" title="2022-04-26T16:48:09"><a href="item?id=31169774">15 hours ago</a></span> <span id="unv_31169774"></span> | <a href="hide?id=31169774&amp;goto=news">hide</a> | <a href="item?id=31169774">79&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31168646">
-                <td align="right" valign="top" class="title"><span class="rank">26.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31168646" href="vote?id=31168646&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://macos8.app/" class="titlelink">Infinite Mac</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=macos8.app"><span class="sitestr">macos8.app</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31168646">945 points</span> by <a href="user?id=bookofjoe" class="hnuser">bookofjoe</a> <span class="age" title="2022-04-26T15:25:15"><a href="item?id=31168646">20 hours ago</a></span> <span id="unv_31168646"></span> | <a href="hide?id=31168646&amp;goto=news">hide</a> | <a href="item?id=31168646">301&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31172653">
-                <td align="right" valign="top" class="title"><span class="rank">27.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31172653" href="vote?id=31172653&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://datastation.multiprocess.io/blog/2022-04-26-event-handler-attributes.html" class="titlelink">HTML event handler attributes: down the rabbit hole</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=multiprocess.io"><span class="sitestr">multiprocess.io</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31172653">32 points</span> by <a href="user?id=eatonphil" class="hnuser">eatonphil</a> <span class="age" title="2022-04-26T20:20:26"><a href="item?id=31172653">7 hours ago</a></span> <span id="unv_31172653"></span> | <a href="hide?id=31172653&amp;goto=news">hide</a> | <a href="item?id=31172653">24&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31167322">
-                <td align="right" valign="top" class="title"><span class="rank">28.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31167322" href="vote?id=31167322&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://aneesh.mataroa.blog/blog/vectorization-in-olap-databases/" class="titlelink">Vectorization in OLAP Databases</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=mataroa.blog"><span class="sitestr">mataroa.blog</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31167322">15 points</span> by <a href="user?id=alterneesh" class="hnuser">alterneesh</a> <span class="age" title="2022-04-26T13:38:45"><a href="item?id=31167322">4 hours ago</a></span> <span id="unv_31167322"></span> | <a href="hide?id=31167322&amp;goto=news">hide</a> | <a href="item?id=31167322">discuss</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154607">
-                <td align="right" valign="top" class="title"><span class="rank">29.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154607" href="vote?id=31154607&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://aperiodical.com/2022/03/now-im-calculating-with-constructive-reals/" class="titlelink">Now I’m calculating with constructive reals</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=aperiodical.com"><span class="sitestr">aperiodical.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154607">101 points</span> by <a href="user?id=ColinWright" class="hnuser">ColinWright</a> <span class="age" title="2022-04-25T13:46:29"><a href="item?id=31154607">13 hours ago</a></span> <span id="unv_31154607"></span> | <a href="hide?id=31154607&amp;goto=news">hide</a> | <a href="item?id=31154607">56&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31153702">
-                <td align="right" valign="top" class="title"><span class="rank">30.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31153702" href="vote?id=31153702&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://arxiv.org/abs/1505.07375" class="titlelink">The Mysteries of Lisp (2015)</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31153702">90 points</span> by <a href="user?id=wslh" class="hnuser">wslh</a> <span class="age" title="2022-04-25T12:49:48"><a href="item?id=31153702">12 hours ago</a></span> <span id="unv_31153702"></span> | <a href="hide?id=31153702&amp;goto=news">hide</a> | <a href="item?id=31153702">17&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="morespace" style="height: 10px"></tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="title"><a href="news?p=2" class="morelink" rel="next">More</a></td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <img src="s.gif" height="10" width="0" />
-            <table width="100%" cellspacing="0" cellpadding="1">
-              <tr>
-                <td bgcolor="#ff6600"></td>
-              </tr>
-            </table>
-            <br />
-            <center><a href="https://www.ycombinator.com/apply/"> Applications are open for YC Summer 2022 </a></center>
-            <br />
-            <center>
-              <span class="yclinks"><a href="newsguidelines.html">Guidelines</a> | <a href="newsfaq.html">FAQ</a> | <a href="lists">Lists</a> | <a href="https://github.com/HackerNews/API">API</a> | <a href="security.html">Security</a> | <a href="http://www.ycombinator.com/legal/">Legal</a> | <a href="http://www.ycombinator.com/apply/">Apply to YC</a> | <a href="mailto:hn@ycombinator.com">Contact</a></span
-              ><br /><br />
-              <form method="get" action="//hn.algolia.com/">Search: <input type="text" name="q" value="" size="17" autocorrect="off" spellcheck="false" autocapitalize="off" autocomplete="false" /></form>
-            </center>
-          </td>
-        </tr>
-      </table>
-    </center>
-  </body>
-</html>
-<html lang="en" op="news">
-  <head>
-    <meta name="referrer" content="origin" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="news.css?PRlO1GADx7BbjOd7JFET" />
-    <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="rss" />
-    <title>Hacker News</title>
-  </head>
-  <body>
-    <center>
-      <table id="hnmain" border="0" cellpadding="0" cellspacing="0" width="85%" bgcolor="#f6f6ef">
-        <tr>
-          <td bgcolor="#ff6600">
-            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="padding: 2px">
-              <tr>
-                <td style="width: 18px; padding-right: 4px">
-                  <a href="https://news.ycombinator.com"><img src="y18.gif" width="18" height="18" style="border: 1px white solid" /></a>
-                </td>
-                <td style="line-height: 12pt; height: 10px">
-                  <span class="pagetop"
-                    ><b class="hnname"><a href="news">Hacker News</a></b> <a href="newest">new</a> | <a href="front">past</a> | <a href="newcomments">comments</a> | <a href="ask">ask</a> | <a href="show">show</a> | <a href="jobs">jobs</a> | <a href="submit">submit</a>
-                  </span>
-                </td>
-                <td style="text-align: right; padding-right: 4px">
-                  <span class="pagetop">
-                    <a href="login?goto=news">login</a>
-                  </span>
-                </td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr id="pagespace" title="" style="height: 10px"></tr>
-        <tr>
-          <td>
-            <table border="0" cellpadding="0" cellspacing="0" class="itemlist">
-              <tr class="athing" id="31178506">
-                <td align="right" valign="top" class="title"><span class="rank">1.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31178506" href="vote?id=31178506&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://shkspr.mobi/blog/2021/10/no-you-cant-save-30-per-year-by-switching-off-your-standby-devices/" class="titlelink">No, you can’t save £30 per year by switching off your “standby” devices</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=shkspr.mobi"><span class="sitestr">shkspr.mobi</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31178506">41 points</span> by <a href="user?id=tosh" class="hnuser">tosh</a> <span class="age" title="2022-04-27T11:09:50"><a href="item?id=31178506">1 hour ago</a></span> <span id="unv_31178506"></span> | <a href="hide?id=31178506&amp;goto=news">hide</a> | <a href="item?id=31178506">29&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31178022">
-                <td align="right" valign="top" class="title"><span class="rank">2.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31178022" href="vote?id=31178022&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://news.mit.edu/2022/low-power-thin-loudspeaker-0426" class="titlelink">MIT researchers develop a paper thin loudspeaker</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=news.mit.edu"><span class="sitestr">news.mit.edu</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31178022">103 points</span> by <a href="user?id=go_prodev" class="hnuser">go_prodev</a> <span class="age" title="2022-04-27T09:34:39"><a href="item?id=31178022">2 hours ago</a></span> <span id="unv_31178022"></span> | <a href="hide?id=31178022&amp;goto=news">hide</a> | <a href="item?id=31178022">56&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176828">
-                <td align="right" valign="top" class="title"><span class="rank">3.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176828" href="vote?id=31176828&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://asuprep.asu.edu/khan-world-school/" class="titlelink">Khan Academy launches Khan World School online high school</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=asu.edu"><span class="sitestr">asu.edu</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176828">226 points</span> by <a href="user?id=webmaven" class="hnuser">webmaven</a> <span class="age" title="2022-04-27T06:02:24"><a href="item?id=31176828">6 hours ago</a></span> <span id="unv_31176828"></span> | <a href="hide?id=31176828&amp;goto=news">hide</a> | <a href="item?id=31176828">124&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176138">
-                <td align="right" valign="top" class="title"><span class="rank">4.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176138" href="vote?id=31176138&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.ctrl.blog/entry/selinux-unmanageable.html" class="titlelink">SELinux is unmanageable; just turn it off if it gets in your way</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=ctrl.blog"><span class="sitestr">ctrl.blog</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176138">310 points</span> by <a href="user?id=HyphenSam" class="hnuser">HyphenSam</a> <span class="age" title="2022-04-27T04:00:36"><a href="item?id=31176138">8 hours ago</a></span> <span id="unv_31176138"></span> | <a href="hide?id=31176138&amp;goto=news">hide</a> | <a href="item?id=31176138">235&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31177454">
-                <td align="right" valign="top" class="title"><span class="rank">5.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31177454" href="vote?id=31177454&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://arxiv.org/abs/2204.10920" class="titlelink">Statistical Analysis shows Echos process voice to serve ads</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31177454">107 points</span> by <a href="user?id=BeniBoy" class="hnuser">BeniBoy</a> <span class="age" title="2022-04-27T07:56:15"><a href="item?id=31177454">4 hours ago</a></span> <span id="unv_31177454"></span> | <a href="hide?id=31177454&amp;goto=news">hide</a> | <a href="item?id=31177454">55&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31177098">
-                <td align="right" valign="top" class="title"><span class="rank">6.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31177098" href="vote?id=31177098&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://git.videolan.org/?p=ffmpeg.git;a=commit;h=0008c159562b877700cd9b7c96f941de4ee69af5" class="titlelink">FFmpeg now supports JPEG XL</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=videolan.org"><span class="sitestr">videolan.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31177098">105 points</span> by <a href="user?id=867-5309" class="hnuser">867-5309</a> <span class="age" title="2022-04-27T06:59:35"><a href="item?id=31177098">5 hours ago</a></span> <span id="unv_31177098"></span> | <a href="hide?id=31177098&amp;goto=news">hide</a> | <a href="item?id=31177098">26&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31178817">
-                <td align="right" valign="top" class="title"><span class="rank">7.</span></td>
-                <td></td>
-                <td class="title">
-                  <a href="https://www.ycombinator.com/companies/playhouse/jobs/s9TaYfC-founding-full-stack-engineer" class="titlelink" rel="nofollow">Playhouse (YC S21) Is Hiring a Founding Full-Stack Engineer</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=ycombinator.com"><span class="sitestr">ycombinator.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="age" title="2022-04-27T12:00:04"><a href="item?id=31178817">16 minutes ago</a></span> | <a href="hide?id=31178817&amp;goto=news">hide</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31178737">
-                <td align="right" valign="top" class="title"><span class="rank">8.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31178737" href="vote?id=31178737&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://github.com/rabbibotton/clog/blob/main/LEARN.md" class="titlelink" rel="nofollow">Tutorial Series to learn Common Lisp quickly</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=github.com/rabbibotton"><span class="sitestr">github.com/rabbibotton</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31178737">8 points</span> by <a href="user?id=oumua_don17" class="hnuser">oumua_don17</a> <span class="age" title="2022-04-27T11:48:32"><a href="item?id=31178737">28 minutes ago</a></span> <span id="unv_31178737"></span> | <a href="hide?id=31178737&amp;goto=news">hide</a> | <a href="item?id=31178737">discuss</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31177474">
-                <td align="right" valign="top" class="title"><span class="rank">9.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31177474" href="vote?id=31177474&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://serokell.io/blog/haskell-typeclasses" class="titlelink">Introduction to Haskell Typeclasses</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=serokell.io"><span class="sitestr">serokell.io</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31177474">41 points</span> by <a href="user?id=ingve" class="hnuser">ingve</a> <span class="age" title="2022-04-27T07:59:49"><a href="item?id=31177474">4 hours ago</a></span> <span id="unv_31177474"></span> | <a href="hide?id=31177474&amp;goto=news">hide</a> | <a href="item?id=31177474">1&nbsp;comment</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31175291">
-                <td align="right" valign="top" class="title"><span class="rank">10.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31175291" href="vote?id=31175291&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://textsynth.com/playground.html" class="titlelink">Textsynth: Bellard's free GPT-NeoX-20B, GPT-J playground and paid API</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=textsynth.com"><span class="sitestr">textsynth.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31175291">208 points</span> by <a href="user?id=crazypython" class="hnuser">crazypython</a> <span class="age" title="2022-04-27T01:42:45"><a href="item?id=31175291">10 hours ago</a></span> <span id="unv_31175291"></span> | <a href="hide?id=31175291&amp;goto=news">hide</a> | <a href="item?id=31175291">108&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31166274">
-                <td align="right" valign="top" class="title"><span class="rank">11.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31166274" href="vote?id=31166274&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://nautil.us/what-lurks-in-a-drowned-forest-in-alabama-16508/" class="titlelink">What Lurks in a Drowned Forest in Alabama?</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=nautil.us"><span class="sitestr">nautil.us</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31166274">20 points</span> by <a href="user?id=dnetesn" class="hnuser">dnetesn</a> <span class="age" title="2022-04-26T11:47:21"><a href="item?id=31166274">2 hours ago</a></span> <span id="unv_31166274"></span> | <a href="hide?id=31166274&amp;goto=news">hide</a> | <a href="item?id=31166274">1&nbsp;comment</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176910">
-                <td align="right" valign="top" class="title"><span class="rank">12.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176910" href="vote?id=31176910&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.pzuraq.com/blog/four-eras-of-javascript-frameworks" class="titlelink">Four Eras of JavaScript Frameworks</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=pzuraq.com"><span class="sitestr">pzuraq.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176910">120 points</span> by <a href="user?id=RafelMri" class="hnuser">RafelMri</a> <span class="age" title="2022-04-27T06:21:47"><a href="item?id=31176910">5 hours ago</a></span> <span id="unv_31176910"></span> | <a href="hide?id=31176910&amp;goto=news">hide</a> | <a href="item?id=31176910">105&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31168052">
-                <td align="right" valign="top" class="title"><span class="rank">13.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31168052" href="vote?id=31168052&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://xakcop.com/post/re-2.4ghz/" class="titlelink">Reversing a 2.4GHz Remote Control</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=xakcop.com"><span class="sitestr">xakcop.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31168052">84 points</span> by <a href="user?id=ggerganov" class="hnuser">ggerganov</a> <span class="age" title="2022-04-26T14:40:21"><a href="item?id=31168052">7 hours ago</a></span> <span id="unv_31168052"></span> | <a href="hide?id=31168052&amp;goto=news">hide</a> | <a href="item?id=31168052">22&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176054">
-                <td align="right" valign="top" class="title"><span class="rank">14.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176054" href="vote?id=31176054&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://docs.datasette.io/en/stable/ecosystem.html" class="titlelink">The Datasette Ecosystem</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=datasette.io"><span class="sitestr">datasette.io</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176054">111 points</span> by <a href="user?id=Tomte" class="hnuser">Tomte</a> <span class="age" title="2022-04-27T03:43:29"><a href="item?id=31176054">8 hours ago</a></span> <span id="unv_31176054"></span> | <a href="hide?id=31176054&amp;goto=news">hide</a> | <a href="item?id=31176054">12&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31176458">
-                <td align="right" valign="top" class="title"><span class="rank">15.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31176458" href="vote?id=31176458&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.innovationaus.com/uber-concedes-deception-prepares-for-26m-accc-spanking/" class="titlelink">Uber concedes deception, prepares for $26m ACCC spanking</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=innovationaus.com"><span class="sitestr">innovationaus.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31176458">104 points</span> by <a href="user?id=smcleod" class="hnuser">smcleod</a> <span class="age" title="2022-04-27T04:52:48"><a href="item?id=31176458">7 hours ago</a></span> <span id="unv_31176458"></span> | <a href="hide?id=31176458&amp;goto=news">hide</a> | <a href="item?id=31176458">86&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154039">
-                <td align="right" valign="top" class="title"><span class="rank">16.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154039" href="vote?id=31154039&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.instantdb.dev/essays/datalogjs" class="titlelink">Datalog in JavaScript</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=instantdb.dev"><span class="sitestr">instantdb.dev</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154039">46 points</span> by <a href="user?id=stopachka" class="hnuser">stopachka</a> <span class="age" title="2022-04-25T13:13:19"><a href="item?id=31154039">5 hours ago</a></span> <span id="unv_31154039"></span> | <a href="hide?id=31154039&amp;goto=news">hide</a> | <a href="item?id=31154039">9&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154567">
-                <td align="right" valign="top" class="title"><span class="rank">17.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154567" href="vote?id=31154567&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://lists.sh" class="titlelink">Show HN: Lists.sh – A Microblog for Lists</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=lists.sh"><span class="sitestr">lists.sh</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154567">191 points</span> by <a href="user?id=qudat" class="hnuser">qudat</a> <span class="age" title="2022-04-25T13:44:02"><a href="item?id=31154567">11 hours ago</a></span> <span id="unv_31154567"></span> | <a href="hide?id=31154567&amp;goto=news">hide</a> | <a href="item?id=31154567">39&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31158654">
-                <td align="right" valign="top" class="title"><span class="rank">18.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31158654" href="vote?id=31158654&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.theguardian.com/books/2022/apr/18/stalins-architect-by-deyan-sudjic-review-a-momumental-life" class="titlelink">Stalin’s Architect by Deyan Sudjic review – a monumental life</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=theguardian.com"><span class="sitestr">theguardian.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31158654">6 points</span> by <a href="user?id=Caiero" class="hnuser">Caiero</a> <span class="age" title="2022-04-25T18:16:22"><a href="item?id=31158654">1 hour ago</a></span> <span id="unv_31158654"></span> | <a href="hide?id=31158654&amp;goto=news">hide</a> | <a href="item?id=31158654">1&nbsp;comment</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31175472">
-                <td align="right" valign="top" class="title"><span class="rank">19.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31175472" href="vote?id=31175472&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://arxiv.org/abs/2204.11918" class="titlelink">Google Scanned Objects: A High-Quality Dataset of 3D Scanned Household Items</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31175472">108 points</span> by <a href="user?id=lnyan" class="hnuser">lnyan</a> <span class="age" title="2022-04-27T02:10:59"><a href="item?id=31175472">10 hours ago</a></span> <span id="unv_31175472"></span> | <a href="hide?id=31175472&amp;goto=news">hide</a> | <a href="item?id=31175472">17&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31173484">
-                <td align="right" valign="top" class="title"><span class="rank">20.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31173484" href="vote?id=31173484&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://cbea.ms/git-commit/" class="titlelink">How to write a Git commit message (2014)</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=cbea.ms"><span class="sitestr">cbea.ms</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31173484">225 points</span> by <a href="user?id=baristaGeek" class="hnuser">baristaGeek</a> <span class="age" title="2022-04-26T21:35:44"><a href="item?id=31173484">14 hours ago</a></span> <span id="unv_31173484"></span> | <a href="hide?id=31173484&amp;goto=news">hide</a> | <a href="item?id=31173484">138&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31166079">
-                <td align="right" valign="top" class="title"><span class="rank">21.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31166079" href="vote?id=31166079&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.cockroachlabs.com/blog/brief-history-high-availability/" class="titlelink">A Brief History of High Availability</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=cockroachlabs.com"><span class="sitestr">cockroachlabs.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31166079">18 points</span> by <a href="user?id=EntICOnc" class="hnuser">EntICOnc</a> <span class="age" title="2022-04-26T11:21:41"><a href="item?id=31166079">3 hours ago</a></span> <span id="unv_31166079"></span> | <a href="hide?id=31166079&amp;goto=news">hide</a> | <a href="item?id=31166079">2&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154522">
-                <td align="right" valign="top" class="title"><span class="rank">22.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154522" href="vote?id=31154522&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.washingtonpost.com/video-games/esports/2022/04/19/esports-age-retirement/" class="titlelink">Esports stars have shorter careers than NFL players</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=washingtonpost.com"><span class="sitestr">washingtonpost.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154522">125 points</span> by <a href="user?id=danso" class="hnuser">danso</a> <span class="age" title="2022-04-25T13:42:25"><a href="item?id=31154522">13 hours ago</a></span> <span id="unv_31154522"></span> | <a href="hide?id=31154522&amp;goto=news">hide</a> | <a href="item?id=31154522">121&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31169193">
-                <td align="right" valign="top" class="title"><span class="rank">23.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31169193" href="vote?id=31169193&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.baseten.co/" class="titlelink">Show HN: Baseten – Build ML-powered applications</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=baseten.co"><span class="sitestr">baseten.co</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31169193">59 points</span> by <a href="user?id=philipkiely" class="hnuser">philipkiely</a> <span class="age" title="2022-04-26T16:05:37"><a href="item?id=31169193">6 hours ago</a></span> <span id="unv_31169193"></span> | <a href="hide?id=31169193&amp;goto=news">hide</a> | <a href="item?id=31169193">5&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31164769">
-                <td align="right" valign="top" class="title"><span class="rank">24.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31164769" href="vote?id=31164769&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://blog.concannon.tech/tech-talk/tbd54566975/" class="titlelink">What’s Behind the Naming of TBD54566975?</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=concannon.tech"><span class="sitestr">concannon.tech</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31164769">62 points</span> by <a href="user?id=alexrustic" class="hnuser">alexrustic</a> <span class="age" title="2022-04-26T06:57:45"><a href="item?id=31164769">9 hours ago</a></span> <span id="unv_31164769"></span> | <a href="hide?id=31164769&amp;goto=news">hide</a> | <a href="item?id=31164769">34&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31169774">
-                <td align="right" valign="top" class="title"><span class="rank">25.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31169774" href="vote?id=31169774&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://www.bloomberg.com/news/articles/2022-04-26/forever-21-parent-authentic-brands-sues-bolt-startup" class="titlelink">Payment startup Bolt sued by its most prominent customer</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=bloomberg.com"><span class="sitestr">bloomberg.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31169774">149 points</span> by <a href="user?id=babelfish" class="hnuser">babelfish</a> <span class="age" title="2022-04-26T16:48:09"><a href="item?id=31169774">15 hours ago</a></span> <span id="unv_31169774"></span> | <a href="hide?id=31169774&amp;goto=news">hide</a> | <a href="item?id=31169774">79&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31168646">
-                <td align="right" valign="top" class="title"><span class="rank">26.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31168646" href="vote?id=31168646&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://macos8.app/" class="titlelink">Infinite Mac</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=macos8.app"><span class="sitestr">macos8.app</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31168646">945 points</span> by <a href="user?id=bookofjoe" class="hnuser">bookofjoe</a> <span class="age" title="2022-04-26T15:25:15"><a href="item?id=31168646">20 hours ago</a></span> <span id="unv_31168646"></span> | <a href="hide?id=31168646&amp;goto=news">hide</a> | <a href="item?id=31168646">301&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31172653">
-                <td align="right" valign="top" class="title"><span class="rank">27.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31172653" href="vote?id=31172653&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://datastation.multiprocess.io/blog/2022-04-26-event-handler-attributes.html" class="titlelink">HTML event handler attributes: down the rabbit hole</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=multiprocess.io"><span class="sitestr">multiprocess.io</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31172653">32 points</span> by <a href="user?id=eatonphil" class="hnuser">eatonphil</a> <span class="age" title="2022-04-26T20:20:26"><a href="item?id=31172653">7 hours ago</a></span> <span id="unv_31172653"></span> | <a href="hide?id=31172653&amp;goto=news">hide</a> | <a href="item?id=31172653">24&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31167322">
-                <td align="right" valign="top" class="title"><span class="rank">28.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31167322" href="vote?id=31167322&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://aneesh.mataroa.blog/blog/vectorization-in-olap-databases/" class="titlelink">Vectorization in OLAP Databases</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=mataroa.blog"><span class="sitestr">mataroa.blog</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31167322">15 points</span> by <a href="user?id=alterneesh" class="hnuser">alterneesh</a> <span class="age" title="2022-04-26T13:38:45"><a href="item?id=31167322">4 hours ago</a></span> <span id="unv_31167322"></span> | <a href="hide?id=31167322&amp;goto=news">hide</a> | <a href="item?id=31167322">discuss</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31154607">
-                <td align="right" valign="top" class="title"><span class="rank">29.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31154607" href="vote?id=31154607&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://aperiodical.com/2022/03/now-im-calculating-with-constructive-reals/" class="titlelink">Now I’m calculating with constructive reals</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=aperiodical.com"><span class="sitestr">aperiodical.com</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31154607">101 points</span> by <a href="user?id=ColinWright" class="hnuser">ColinWright</a> <span class="age" title="2022-04-25T13:46:29"><a href="item?id=31154607">13 hours ago</a></span> <span id="unv_31154607"></span> | <a href="hide?id=31154607&amp;goto=news">hide</a> | <a href="item?id=31154607">56&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="athing" id="31153702">
-                <td align="right" valign="top" class="title"><span class="rank">30.</span></td>
-                <td valign="top" class="votelinks">
-                  <center>
-                    <a id="up_31153702" href="vote?id=31153702&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a>
-                  </center>
-                </td>
-                <td class="title">
-                  <a href="https://arxiv.org/abs/1505.07375" class="titlelink">The Mysteries of Lisp (2015)</a
-                  ><span class="sitebit comhead">
-                    (<a href="from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a
-                    >)</span
-                  >
-                </td>
-              </tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="subtext">
-                  <span class="score" id="score_31153702">90 points</span> by <a href="user?id=wslh" class="hnuser">wslh</a> <span class="age" title="2022-04-25T12:49:48"><a href="item?id=31153702">12 hours ago</a></span> <span id="unv_31153702"></span> | <a href="hide?id=31153702&amp;goto=news">hide</a> | <a href="item?id=31153702">17&nbsp;comments</a>
-                </td>
-              </tr>
-              <tr class="spacer" style="height: 5px"></tr>
-              <tr class="morespace" style="height: 10px"></tr>
-              <tr>
-                <td colspan="2"></td>
-                <td class="title"><a href="news?p=2" class="morelink" rel="next">More</a></td>
-              </tr>
-            </table>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <img src="s.gif" height="10" width="0" />
-            <table width="100%" cellspacing="0" cellpadding="1">
-              <tr>
-                <td bgcolor="#ff6600"></td>
-              </tr>
-            </table>
-            <br />
-            <center><a href="https://www.ycombinator.com/apply/"> Applications are open for YC Summer 2022 </a></center>
-            <br />
-            <center>
-              <span class="yclinks"><a href="newsguidelines.html">Guidelines</a> | <a href="newsfaq.html">FAQ</a> | <a href="lists">Lists</a> | <a href="https://github.com/HackerNews/API">API</a> | <a href="security.html">Security</a> | <a href="http://www.ycombinator.com/legal/">Legal</a> | <a href="http://www.ycombinator.com/apply/">Apply to YC</a> | <a href="mailto:hn@ycombinator.com">Contact</a></span
-              ><br /><br />
-              <form method="get" action="//hn.algolia.com/">Search: <input type="text" name="q" value="" size="17" autocorrect="off" spellcheck="false" autocapitalize="off" autocomplete="false" /></form>
-            </center>
-          </td>
-        </tr>
-      </table>
-    </center>
-  </body>
-</html>
+<!-- saved from url=https://news.ycombinator.com/ on 2022-11-16 -->
+<html lang="en" op="news" class=" gootftcahue idc0_344"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="referrer" content="origin"><meta name="viewport" content="width=device-width, initial-scale=1.0"><link rel="stylesheet" type="text/css" href="./app_files/news.css">
+        <link rel="shortcut icon" href="https://news.ycombinator.com/favicon.ico">
+          <link rel="alternate" type="application/rss+xml" title="RSS" href="https://news.ycombinator.com/rss">
+        <title>Hacker News</title></head><body class="vsc-initialized"><center><table id="hnmain" border="0" cellpadding="0" cellspacing="0" width="85%" bgcolor="#f6f6ef">
+        <tbody><tr><td bgcolor="#ff6600"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="padding:2px"><tbody><tr><td style="width:18px;padding-right:4px"><a href="https://news.ycombinator.com/"><img src="./app_files/y18.gif" width="18" height="18" style="border:1px white solid;"></a></td>
+                  <td style="line-height:12pt; height:10px;"><span class="pagetop"><b class="hnname"><a href="https://news.ycombinator.com/news">Hacker News</a></b>
+                            <a href="https://news.ycombinator.com/newest">new</a> | <a href="https://news.ycombinator.com/front">past</a> | <a href="https://news.ycombinator.com/newcomments">comments</a> | <a href="https://news.ycombinator.com/ask">ask</a> | <a href="https://news.ycombinator.com/show">show</a> | <a href="https://news.ycombinator.com/jobs">jobs</a> | <a href="https://news.ycombinator.com/submit">submit</a>            </span></td><td style="text-align:right;padding-right:4px;"><span class="pagetop">
+                              <a href="https://news.ycombinator.com/login?goto=news">login</a>
+                          </span></td>
+              </tr></tbody></table></td></tr>
+<tr id="pagespace" title="" style="height:10px"></tr><tr><td><table border="0" cellpadding="0" cellspacing="0">
+            <tbody><tr class="athing" id="33623201">
+      <td align="right" valign="top" class="title"><span class="rank">1.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623201" href="https://news.ycombinator.com/vote?id=33623201&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.notion.so/ai">Introducing Notion AI</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=notion.so"><span class="sitestr">notion.so</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623201">55 points</span> by <a href="https://news.ycombinator.com/user?id=antouank" class="hnuser">antouank</a> <span class="age" title="2022-11-16T14:11:57"><a href="https://news.ycombinator.com/item?id=33623201">55 minutes ago</a></span> <span id="unv_33623201"></span> | <a href="https://news.ycombinator.com/hide?id=33623201&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623201">47&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33621566">
+      <td align="right" valign="top" class="title"><span class="rank">2.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33621566" href="https://news.ycombinator.com/vote?id=33621566&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://os.mbed.com/docs/mbed-os/v6.15/apis/LoRa-tutorial.html">Building a Private Lora Network</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=mbed.com"><span class="sitestr">mbed.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33621566">117 points</span> by <a href="https://news.ycombinator.com/user?id=Tomte" class="hnuser">Tomte</a> <span class="age" title="2022-11-16T11:34:07"><a href="https://news.ycombinator.com/item?id=33621566">3 hours ago</a></span> <span id="unv_33621566"></span> | <a href="https://news.ycombinator.com/hide?id=33621566&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33621566">49&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33623697">
+      <td align="right" valign="top" class="title"><span class="rank">3.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623697" href="https://news.ycombinator.com/vote?id=33623697&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://github.com/nabaz-io/nabaz">Show HN: I built a tool to get instant test results (250ms)</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com/nabaz-io"><span class="sitestr">github.com/nabaz-io</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623697">16 points</span> by <a href="https://news.ycombinator.com/user?id=yuvalsteuer" class="hnuser">yuvalsteuer</a> <span class="age" title="2022-11-16T14:39:59"><a href="https://news.ycombinator.com/item?id=33623697">27 minutes ago</a></span> <span id="unv_33623697"></span> | <a href="https://news.ycombinator.com/hide?id=33623697&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623697">10&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33620439">
+      <td align="right" valign="top" class="title"><span class="rank">4.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33620439" href="https://news.ycombinator.com/vote?id=33620439&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://jrsinclair.com/articles/2022/whats-so-great-about-functional-programming-anyway/">What’s so great about functional programming anyway?</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=jrsinclair.com"><span class="sitestr">jrsinclair.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33620439">197 points</span> by <a href="https://news.ycombinator.com/user?id=redbell" class="hnuser">redbell</a> <span class="age" title="2022-11-16T08:34:15"><a href="https://news.ycombinator.com/item?id=33620439">6 hours ago</a></span> <span id="unv_33620439"></span> | <a href="https://news.ycombinator.com/hide?id=33620439&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33620439">216&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33608004">
+      <td align="right" valign="top" class="title"><span class="rank">5.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33608004" href="https://news.ycombinator.com/vote?id=33608004&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="http://blog.computationalcomplexity.org/2022/11/who-first-thought-of-notion-of.html">Computational Complexity: Who first thought of the notion of Polynomial Time?</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=computationalcomplexity.org"><span class="sitestr">computationalcomplexity.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33608004">17 points</span> by <a href="https://news.ycombinator.com/user?id=furcyd" class="hnuser">furcyd</a> <span class="age" title="2022-11-15T11:45:02"><a href="https://news.ycombinator.com/item?id=33608004">1 hour ago</a></span> <span id="unv_33608004"></span> | <a href="https://news.ycombinator.com/hide?id=33608004&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33608004">discuss</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33622825">
+      <td align="right" valign="top" class="title"><span class="rank">6.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33622825" href="https://news.ycombinator.com/vote?id=33622825&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.theguardian.com/world/2022/nov/15/hand-of-irulegi-ancient-spanish-artefact-rewrites-history-of-basque-language">Hand of Irulegi: ancient artefact could help trace origins of Basque language</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=theguardian.com"><span class="sitestr">theguardian.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33622825">18 points</span> by <a href="https://news.ycombinator.com/user?id=benbreen" class="hnuser">benbreen</a> <span class="age" title="2022-11-16T13:50:24"><a href="https://news.ycombinator.com/item?id=33622825">1 hour ago</a></span> <span id="unv_33622825"></span> | <a href="https://news.ycombinator.com/hide?id=33622825&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33622825">7&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33624032">
+      <td align="right" valign="top" class="title"><span class="rank">7.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33624032" href="https://news.ycombinator.com/vote?id=33624032&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.frontiersin.org/articles/10.3389/fpsyg.2015.01100/full" rel="nofollow">Psychological and Psychiatric Terms to Avoid</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=frontiersin.org"><span class="sitestr">frontiersin.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33624032">4 points</span> by <a href="https://news.ycombinator.com/user?id=limbicsystem" class="hnuser">limbicsystem</a> <span class="age" title="2022-11-16T14:56:20"><a href="https://news.ycombinator.com/item?id=33624032">11 minutes ago</a></span> <span id="unv_33624032"></span> | <a href="https://news.ycombinator.com/hide?id=33624032&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33624032">discuss</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33622329">
+      <td align="right" valign="top" class="title"><span class="rank">8.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33622329" href="https://news.ycombinator.com/vote?id=33622329&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.coindesk.com/business/2022/11/16/genesis-crypto-lending-unit-is-halting-customer-withdrawals-in-wake-of-ftx-collapse/">Genesis' Crypto-Lending Unit Is Suspending Withdrawals in Wake of FTX Collapse</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=coindesk.com"><span class="sitestr">coindesk.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33622329">67 points</span> by <a href="https://news.ycombinator.com/user?id=VagueMag" class="hnuser">VagueMag</a> <span class="age" title="2022-11-16T13:06:28"><a href="https://news.ycombinator.com/item?id=33622329">2 hours ago</a></span> <span id="unv_33622329"></span> | <a href="https://news.ycombinator.com/hide?id=33622329&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33622329">39&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33620427">
+      <td align="right" valign="top" class="title"><span class="rank">9.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33620427" href="https://news.ycombinator.com/vote?id=33620427&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://github.com/enso-org/enso">Enso: Hybrid visual and textual functional programming</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com/enso-org"><span class="sitestr">github.com/enso-org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33620427">41 points</span> by <a href="https://news.ycombinator.com/user?id=ivanche" class="hnuser">ivanche</a> <span class="age" title="2022-11-16T08:30:55"><a href="https://news.ycombinator.com/item?id=33620427">4 hours ago</a></span> <span id="unv_33620427"></span> | <a href="https://news.ycombinator.com/hide?id=33620427&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33620427">9&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33621562">
+      <td align="right" valign="top" class="title"><span class="rank">10.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33621562" href="https://news.ycombinator.com/vote?id=33621562&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://twitter.com/pnikosis/status/1592823543498436611">Tesla has used space characters in internal emails to identify leaks</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=twitter.com/pnikosis"><span class="sitestr">twitter.com/pnikosis</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33621562">159 points</span> by <a href="https://news.ycombinator.com/user?id=BerislavLopac" class="hnuser">BerislavLopac</a> <span class="age" title="2022-11-16T11:33:28"><a href="https://news.ycombinator.com/item?id=33621562">3 hours ago</a></span> <span id="unv_33621562"></span> | <a href="https://news.ycombinator.com/hide?id=33621562&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33621562">165&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33622295">
+      <td align="right" valign="top" class="title"><span class="rank">11.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33622295" href="https://news.ycombinator.com/vote?id=33622295&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://news.ycombinator.com/item?id=33622295">Ask HN: Anyone go through Montessori education until age 12 (end of gr 6)?</a></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33622295">53 points</span> by <a href="https://news.ycombinator.com/user?id=boringg" class="hnuser">boringg</a> <span class="age" title="2022-11-16T13:03:16"><a href="https://news.ycombinator.com/item?id=33622295">2 hours ago</a></span> <span id="unv_33622295"></span> | <a href="https://news.ycombinator.com/hide?id=33622295&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33622295">51&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33621795">
+      <td align="right" valign="top" class="title"><span class="rank">12.</span></td>      <td><img src="./app_files/s.gif" height="1" width="14"></td>       <td class="title"><span class="titleline"><a href="https://jobs.lever.co/givecampus/44af3199-546a-404a-95fd-a097ef37e915" rel="nofollow">GiveCampus (YC S15) Is Hiring senior engineers to support schools</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=lever.co"><span class="sitestr">lever.co</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext">
+        <span class="age" title="2022-11-16T12:00:51"><a href="https://news.ycombinator.com/item?id=33621795">3 hours ago</a></span> | <a href="https://news.ycombinator.com/hide?id=33621795&amp;goto=news">hide</a>      </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33623013">
+      <td align="right" valign="top" class="title"><span class="rank">13.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623013" href="https://news.ycombinator.com/vote?id=33623013&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.npr.org/sections/money/2022/11/15/1136039542/these-companies-ran-an-experiment-pay-workers-their-full-salary-to-work-fewer-da">Companies ran an experiment: Pay workers their full salary to work fewer days</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=npr.org"><span class="sitestr">npr.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623013">25 points</span> by <a href="https://news.ycombinator.com/user?id=akeck" class="hnuser">akeck</a> <span class="age" title="2022-11-16T14:02:07"><a href="https://news.ycombinator.com/item?id=33623013">1 hour ago</a></span> <span id="unv_33623013"></span> | <a href="https://news.ycombinator.com/hide?id=33623013&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623013">9&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33623645">
+      <td align="right" valign="top" class="title"><span class="rank">14.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623645" href="https://news.ycombinator.com/vote?id=33623645&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://arxiv.org/abs/2211.07082" rel="nofollow">Learning Latent Part-Whole Hierarchies for Point Clouds</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=arxiv.org"><span class="sitestr">arxiv.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623645">3 points</span> by <a href="https://news.ycombinator.com/user?id=PaulHoule" class="hnuser">PaulHoule</a> <span class="age" title="2022-11-16T14:36:51"><a href="https://news.ycombinator.com/item?id=33623645">30 minutes ago</a></span> <span id="unv_33623645"></span> | <a href="https://news.ycombinator.com/hide?id=33623645&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623645">discuss</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33619650">
+      <td align="right" valign="top" class="title"><span class="rank">15.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33619650" href="https://news.ycombinator.com/vote?id=33619650&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://news.ycombinator.com/item?id=33619650">Ask HN: Alternative ways to make money with coding and system skills?</a></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33619650">248 points</span> by <a href="https://news.ycombinator.com/user?id=tayo42" class="hnuser">tayo42</a> <span class="age" title="2022-11-16T06:33:18"><a href="https://news.ycombinator.com/item?id=33619650">8 hours ago</a></span> <span id="unv_33619650"></span> | <a href="https://news.ycombinator.com/hide?id=33619650&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33619650">128&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33621591">
+      <td align="right" valign="top" class="title"><span class="rank">16.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33621591" href="https://news.ycombinator.com/vote?id=33621591&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.nature.com/articles/d41586-022-03693-6">Overhyping hydrogen as a fuel risks endangering net-zero goals</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=nature.com"><span class="sitestr">nature.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33621591">72 points</span> by <a href="https://news.ycombinator.com/user?id=samizdis" class="hnuser">samizdis</a> <span class="age" title="2022-11-16T11:36:43"><a href="https://news.ycombinator.com/item?id=33621591">3 hours ago</a></span> <span id="unv_33621591"></span> | <a href="https://news.ycombinator.com/hide?id=33621591&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33621591">109&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33616593">
+      <td align="right" valign="top" class="title"><span class="rank">17.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33616593" href="https://news.ycombinator.com/vote?id=33616593&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="http://blog.archive.org/2022/11/15/digital-books-wear-out-faster-than-physical-books/">Digital books wear out faster than physical books</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=archive.org"><span class="sitestr">archive.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33616593">671 points</span> by <a href="https://news.ycombinator.com/user?id=Amorymeltzer" class="hnuser">Amorymeltzer</a> <span class="age" title="2022-11-15T23:18:16"><a href="https://news.ycombinator.com/item?id=33616593">15 hours ago</a></span> <span id="unv_33616593"></span> | <a href="https://news.ycombinator.com/hide?id=33616593&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33616593">360&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33622639">
+      <td align="right" valign="top" class="title"><span class="rank">18.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33622639" href="https://news.ycombinator.com/vote?id=33622639&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://finance.yahoo.com/video/evs-least-reliable-vehicle-type-214225842.html">EVs are the least reliable vehicle type: Consumer Reports</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=yahoo.com"><span class="sitestr">yahoo.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33622639">80 points</span> by <a href="https://news.ycombinator.com/user?id=Markoff" class="hnuser">Markoff</a> <span class="age" title="2022-11-16T13:35:36"><a href="https://news.ycombinator.com/item?id=33622639">1 hour ago</a></span> <span id="unv_33622639"></span> | <a href="https://news.ycombinator.com/hide?id=33622639&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33622639">113&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33623195">
+      <td align="right" valign="top" class="title"><span class="rank">19.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623195" href="https://news.ycombinator.com/vote?id=33623195&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.csail.mit.edu/news/solving-brain-dynamics-gives-rise-flexible-machine-learning-models" rel="nofollow">Solving brain dynamics gives rise to flexible machine learning models</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=csail.mit.edu"><span class="sitestr">csail.mit.edu</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623195">3 points</span> by <a href="https://news.ycombinator.com/user?id=tchalla" class="hnuser">tchalla</a> <span class="age" title="2022-11-16T14:11:38"><a href="https://news.ycombinator.com/item?id=33623195">56 minutes ago</a></span> <span id="unv_33623195"></span> | <a href="https://news.ycombinator.com/hide?id=33623195&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623195">discuss</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33619463">
+      <td align="right" valign="top" class="title"><span class="rank">20.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33619463" href="https://news.ycombinator.com/vote?id=33619463&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.bbc.com/news/business-63631877">Amazon staff laid off as tech giants cut costs, according to LinkedIn posts</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=bbc.com"><span class="sitestr">bbc.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33619463">50 points</span> by <a href="https://news.ycombinator.com/user?id=djha-skin" class="hnuser">djha-skin</a> <span class="age" title="2022-11-16T06:03:10"><a href="https://news.ycombinator.com/item?id=33619463">9 hours ago</a></span> <span id="unv_33619463"></span> | <a href="https://news.ycombinator.com/hide?id=33619463&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33619463">15&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33620692">
+      <td align="right" valign="top" class="title"><span class="rank">21.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33620692" href="https://news.ycombinator.com/vote?id=33620692&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://discuss.python.org/t/python-3-12-0-alpha-2-released/21087">Python 3.12.0 is to remove long-deprecated items</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=python.org"><span class="sitestr">python.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33620692">126 points</span> by <a href="https://news.ycombinator.com/user?id=BerislavLopac" class="hnuser">BerislavLopac</a> <span class="age" title="2022-11-16T09:30:12"><a href="https://news.ycombinator.com/item?id=33620692">5 hours ago</a></span> <span id="unv_33620692"></span> | <a href="https://news.ycombinator.com/hide?id=33620692&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33620692">105&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33623632">
+      <td align="right" valign="top" class="title"><span class="rank">22.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623632" href="https://news.ycombinator.com/vote?id=33623632&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://github.com/microsoft/WSL/releases/tag/1.0.0" rel="nofollow">Windows Subsystem For Linux a.k.a. WSL 1.0.0 released</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=github.com/microsoft"><span class="sitestr">github.com/microsoft</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623632">5 points</span> by <a href="https://news.ycombinator.com/user?id=CoolCold" class="hnuser">CoolCold</a> <span class="age" title="2022-11-16T14:36:13"><a href="https://news.ycombinator.com/item?id=33623632">31 minutes ago</a></span> <span id="unv_33623632"></span> | <a href="https://news.ycombinator.com/hide?id=33623632&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623632">1&nbsp;comment</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33592191">
+      <td align="right" valign="top" class="title"><span class="rank">23.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33592191" href="https://news.ycombinator.com/vote?id=33592191&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="http://bitsavers.informatik.uni-stuttgart.de/pdf/borland/turbo_assembler/Turbo_Assembler_Version_5_Users_Guide.pdf">Borland Turbo Assembler Version 5 User's Guide (1996) [pdf]</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=uni-stuttgart.de"><span class="sitestr">uni-stuttgart.de</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33592191">91 points</span> by <a href="https://news.ycombinator.com/user?id=ibobev" class="hnuser">ibobev</a> <span class="age" title="2022-11-14T10:27:21"><a href="https://news.ycombinator.com/item?id=33592191">11 hours ago</a></span> <span id="unv_33592191"></span> | <a href="https://news.ycombinator.com/hide?id=33592191&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33592191">40&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33617762">
+      <td align="right" valign="top" class="title"><span class="rank">24.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33617762" href="https://news.ycombinator.com/vote?id=33617762&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.bbc.com/travel/article/20221114-pakistans-lost-city-of-40000-people">Pakistan's lost city of 40k people</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=bbc.com"><span class="sitestr">bbc.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33617762">156 points</span> by <a href="https://news.ycombinator.com/user?id=pseudolus" class="hnuser">pseudolus</a> <span class="age" title="2022-11-16T01:39:11"><a href="https://news.ycombinator.com/item?id=33617762">13 hours ago</a></span> <span id="unv_33617762"></span> | <a href="https://news.ycombinator.com/hide?id=33617762&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33617762">52&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33623402">
+      <td align="right" valign="top" class="title"><span class="rank">25.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33623402" href="https://news.ycombinator.com/vote?id=33623402&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://evernote.com/blog/evernote-next-move-joining-bending-spoons/">Evernote to be acquired by Bending Spoons</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=evernote.com"><span class="sitestr">evernote.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33623402">16 points</span> by <a href="https://news.ycombinator.com/user?id=taldo" class="hnuser">taldo</a> <span class="age" title="2022-11-16T14:23:31"><a href="https://news.ycombinator.com/item?id=33623402">44 minutes ago</a></span> <span id="unv_33623402"></span> | <a href="https://news.ycombinator.com/hide?id=33623402&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33623402">discuss</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33620933">
+      <td align="right" valign="top" class="title"><span class="rank">26.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33620933" href="https://news.ycombinator.com/vote?id=33620933&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="http://leapsecond.com/java/gpsclock.htm">GPS does not account for leap seconds (2002)</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=leapsecond.com"><span class="sitestr">leapsecond.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33620933">49 points</span> by <a href="https://news.ycombinator.com/user?id=uncertainrhymes" class="hnuser">uncertainrhymes</a> <span class="age" title="2022-11-16T10:13:08"><a href="https://news.ycombinator.com/item?id=33620933">4 hours ago</a></span> <span id="unv_33620933"></span> | <a href="https://news.ycombinator.com/hide?id=33620933&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33620933">43&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33622313">
+      <td align="right" valign="top" class="title"><span class="rank">27.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33622313" href="https://news.ycombinator.com/vote?id=33622313&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.economist.com/finance-and-economics/2022/11/15/even-a-global-recession-may-not-crush-inflation" rel="nofollow">Even a global recession may not crush inflation</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=economist.com"><span class="sitestr">economist.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33622313">4 points</span> by <a href="https://news.ycombinator.com/user?id=mfiguiere" class="hnuser">mfiguiere</a> <span class="age" title="2022-11-16T13:05:11"><a href="https://news.ycombinator.com/item?id=33622313">2 hours ago</a></span> <span id="unv_33622313"></span> | <a href="https://news.ycombinator.com/hide?id=33622313&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33622313">1&nbsp;comment</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33604654">
+      <td align="right" valign="top" class="title"><span class="rank">28.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33604654" href="https://news.ycombinator.com/vote?id=33604654&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://phys.org/news/2022-11-cesium-atmosphere-hot-white-dwarf.html">Cesium detected in the atmosphere of a hot white dwarf</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=phys.org"><span class="sitestr">phys.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33604654">43 points</span> by <a href="https://news.ycombinator.com/user?id=wglb" class="hnuser">wglb</a> <span class="age" title="2022-11-15T02:53:12"><a href="https://news.ycombinator.com/item?id=33604654">8 hours ago</a></span> <span id="unv_33604654"></span> | <a href="https://news.ycombinator.com/hide?id=33604654&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33604654">11&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33615473">
+      <td align="right" valign="top" class="title"><span class="rank">29.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33615473" href="https://news.ycombinator.com/vote?id=33615473&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://www.pnas.org/doi/10.1073/pnas.2120668119">Relational diversity in social portfolios predicts well-being</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=pnas.org"><span class="sitestr">pnas.org</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33615473">12 points</span> by <a href="https://news.ycombinator.com/user?id=herodotus" class="hnuser">herodotus</a> <span class="age" title="2022-11-15T21:45:49"><a href="https://news.ycombinator.com/item?id=33615473">3 hours ago</a></span> <span id="unv_33615473"></span> | <a href="https://news.ycombinator.com/hide?id=33615473&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33615473">discuss</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+                <tr class="athing" id="33612410">
+      <td align="right" valign="top" class="title"><span class="rank">30.</span></td>      <td valign="top" class="votelinks"><center><a id="up_33612410" href="https://news.ycombinator.com/vote?id=33612410&amp;how=up&amp;goto=news"><div class="votearrow" title="upvote"></div></a></center></td><td class="title"><span class="titleline"><a href="https://engineering.fb.com/2022/11/15/open-source/sapling-source-control-scalable/">Sapling: A new source control system with Git-compatible client</a><span class="sitebit comhead"> (<a href="https://news.ycombinator.com/from?site=fb.com"><span class="sitestr">fb.com</span></a>)</span></span></td></tr><tr><td colspan="2"></td><td class="subtext"><span class="subline">
+          <span class="score" id="score_33612410">829 points</span> by <a href="https://news.ycombinator.com/user?id=bolinfest" class="hnuser">bolinfest</a> <span class="age" title="2022-11-15T17:39:14"><a href="https://news.ycombinator.com/item?id=33612410">21 hours ago</a></span> <span id="unv_33612410"></span> | <a href="https://news.ycombinator.com/hide?id=33612410&amp;goto=news">hide</a> | <a href="https://news.ycombinator.com/item?id=33612410">429&nbsp;comments</a>        </span>
+              </td></tr>
+      <tr class="spacer" style="height:5px"></tr>
+            <tr class="morespace" style="height:10px"></tr><tr><td colspan="2"></td>
+      <td class="title"><a href="https://news.ycombinator.com/news?p=2" class="morelink" rel="next">More</a></td>    </tr>
+  </tbody></table>
+</td></tr>
+<tr><td><img src="./app_files/s.gif" height="10" width="0"><table width="100%" cellspacing="0" cellpadding="1"><tbody><tr><td bgcolor="#ff6600"></td></tr></tbody></table><br><center><span class="yclinks"><a href="https://news.ycombinator.com/newsguidelines.html">Guidelines</a>
+        | <a href="https://news.ycombinator.com/newsfaq.html">FAQ</a>
+        | <a href="https://news.ycombinator.com/lists">Lists</a>
+        | <a href="https://github.com/HackerNews/API">API</a>
+        | <a href="https://news.ycombinator.com/security.html">Security</a>
+        | <a href="http://www.ycombinator.com/legal/">Legal</a>
+        | <a href="http://www.ycombinator.com/apply/">Apply to YC</a>
+        | <a href="mailto:hn@ycombinator.com">Contact</a></span><br><br><form method="get" action="https://hn.algolia.com/">Search:
+          <input type="text" name="q" value="" size="17" autocorrect="off" spellcheck="false" autocapitalize="off" autocomplete="false"></form>
+            </center></td></tr>
+      </tbody></table></center>
+      <script type="text/javascript" src="./app_files/hn.js"></script>
+</body></html>

--- a/examples/cross-browser.py
+++ b/examples/cross-browser.py
@@ -123,7 +123,7 @@ async def main():
     # Puppeteer:
     # await page.goto('https://news.ycombinator.com/');
     # https://github.com/puppeteer/puppeteer/blob/4c3caaa3f99f0c31333a749ec50f56180507a374/examples/cross-browser.js#L34
-    # To avoid the network dependency in this test, we use a local, static copy.
+    # To avoid network dependency in this test, use a local (static) copy.
     pageUrl = f'file://{Path(__file__).parent.resolve()}/app.html'
     await run_and_wait_command({
         "id": 1001,
@@ -139,7 +139,7 @@ async def main():
     # https://github.com/puppeteer/puppeteer/blob/4c3caaa3f99f0c31333a749ec50f56180507a374/examples/cross-browser.js#L37
     results_selector = {
         "type": "string",
-        "value": ".titlelink"}
+        "value": ".titleline > a"}
 
     # `script.callFunction` is not implemented by Firefox yet:
     # https://bugzilla.mozilla.org/show_bug.cgi?id=1750541


### PR DESCRIPTION
The previous selector is broken as of ~2 months ago, c.f. https://news.ycombinator.com/item?id=33027700

Changed from:

    <a class="titlelink"></a>

To:

    <span class="titleline">
    <a></a>
    </span>