### PR TITLE
Prototype channel mechanism (`script.MessageEvent`)

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -329,7 +329,8 @@ export class BrowsingContextImpl {
             ? params.context.name
             : undefined,
           this.#cdpTarget.cdpSessionId,
-          this.#cdpTarget.cdpClient
+          this.#cdpTarget.cdpClient,
+          this.#eventManager
         );
 
         if (params.context.auxData.isDefault) {

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -20,6 +20,7 @@ import {Protocol} from 'devtools-protocol';
 import {CommonDataTypes, Script} from '../../../protocol/protocol.js';
 import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 import {CdpClient} from '../../CdpConnection.js';
+import {IEventManager} from '../events/EventManager.js';
 
 import {SHARED_ID_DIVIDER, ScriptEvaluator} from './scriptEvaluator.js';
 import {RealmStorage} from './realmStorage.js';
@@ -35,6 +36,7 @@ export class Realm {
   readonly #origin: string;
   readonly #type: RealmType;
   readonly #cdpClient: CdpClient;
+  readonly #eventManager: IEventManager;
   readonly #scriptEvaluator: ScriptEvaluator;
 
   readonly sandbox?: string;
@@ -50,7 +52,8 @@ export class Realm {
     type: RealmType,
     sandbox: string | undefined,
     cdpSessionId: string,
-    cdpClient: CdpClient
+    cdpClient: CdpClient,
+    eventManager: IEventManager
   ) {
     this.#realmId = realmId;
     this.#browsingContextId = browsingContextId;
@@ -62,7 +65,8 @@ export class Realm {
     this.#cdpClient = cdpClient;
     this.#realmStorage = realmStorage;
     this.#browsingContextStorage = browsingContextStorage;
-    this.#scriptEvaluator = new ScriptEvaluator();
+    this.#eventManager = eventManager;
+    this.#scriptEvaluator = new ScriptEvaluator(this.#eventManager);
 
     this.#realmStorage.realmMap.set(this.#realmId, this);
   }

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -217,6 +217,8 @@ export namespace CommonDataTypes {
 
   // BrowsingContext = text;
   export const BrowsingContextSchema = zod.string();
+
+  export const MaxDepthSchema = zod.number().int().nonnegative().max(MAX_INT);
 }
 
 /** @see https://w3c.github.io/webdriver-bidi/#module-script */
@@ -306,7 +308,9 @@ export namespace Script {
 
   const ChannelPropertiesSchema = zod.object({
     channel: ChannelIdSchema,
-    maxDepth: zod.number().int().nonnegative().max(MAX_INT).optional(),
+    // TODO(#294): maxDepth: CommonDataTypes.MaxDepthSchema.optional(),
+    // See: https://github.com/w3c/webdriver-bidi/pull/361/files#r1141961142
+    maxDepth: zod.number().int().min(1).max(1).optional(),
     ownership: ResultOwnershipSchema.optional(),
   });
 
@@ -358,9 +362,7 @@ export namespace BrowsingContext {
   //   ?root: browsingContext.BrowsingContext,
   // }
   const GetTreeParametersSchema = zod.object({
-    // TODO(##294): maxDepth: zod.number().int().nonnegative().max(MAX_INT).optional(),
-    // See: https://github.com/w3c/webdriver-bidi/pull/361/files#r1141961142
-    maxDepth: zod.number().int().min(1).max(1).optional(),
+    maxDepth: CommonDataTypes.MaxDepthSchema.optional(),
     root: CommonDataTypes.BrowsingContextSchema.optional(),
   });
 

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -302,14 +302,29 @@ export namespace Script {
     return parseObject(params, DisownParametersSchema);
   }
 
+  const ChannelIdSchema = zod.string();
+
+  const ChannelPropertiesSchema = zod.object({
+    channel: ChannelIdSchema,
+    maxDepth: zod.number().int().nonnegative().max(MAX_INT).optional(),
+    ownership: ResultOwnershipSchema.optional(),
+  });
+
+  export const ChannelSchema = zod.object({
+    type: zod.literal('channel'),
+    value: ChannelPropertiesSchema,
+  });
+
   // ArgumentValue = (
   //   RemoteReference //
-  //   LocalValue
+  //   LocalValue //
+  //   script.Channel
   // );
   const ArgumentValueSchema = zod.union([
     CommonDataTypes.RemoteReferenceSchema,
     CommonDataTypes.SharedReferenceSchema,
     CommonDataTypes.LocalValueSchema,
+    Script.ChannelSchema,
   ]);
 
   // CallFunctionParameters = {
@@ -334,19 +349,6 @@ export namespace Script {
   ): ScriptTypes.CallFunctionParameters {
     return parseObject(params, CallFunctionParametersSchema);
   }
-
-  const ChannelIdSchema = zod.string();
-
-  const ChannelPropertiesSchema = zod.object({
-    channel: ChannelIdSchema,
-    maxDepth: zod.number().int().nonnegative().max(MAX_INT).optional(),
-    ownership: ResultOwnershipSchema.optional(),
-  });
-
-  export const ChannelSchema = zod.object({
-    type: zod.literal('channel'),
-    value: ChannelPropertiesSchema,
-  });
 }
 
 /** @see https://w3c.github.io/webdriver-bidi/#module-browsingContext */
@@ -356,7 +358,9 @@ export namespace BrowsingContext {
   //   ?root: browsingContext.BrowsingContext,
   // }
   const GetTreeParametersSchema = zod.object({
-    maxDepth: zod.number().int().nonnegative().max(MAX_INT).optional(),
+    // TODO(##294): maxDepth: zod.number().int().nonnegative().max(MAX_INT).optional(),
+    // See: https://github.com/w3c/webdriver-bidi/pull/361/files#r1141961142
+    maxDepth: zod.number().int().min(1).max(1).optional(),
     root: CommonDataTypes.BrowsingContextSchema.optional(),
   });
 

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -607,7 +607,8 @@ export namespace Script {
   export type ArgumentValue =
     | CommonDataTypes.RemoteReference
     | CommonDataTypes.SharedReference
-    | CommonDataTypes.LocalValue;
+    | CommonDataTypes.LocalValue
+    | Script.Channel;
 
   export type CallFunctionParameters = {
     functionDeclaration: string;
@@ -657,7 +658,7 @@ export namespace Script {
   };
 
   export type MessageParameters = {
-    channel: Channel;
+    channel: ChannelId;
     data: CommonDataTypes.RemoteValue;
     source: Source;
   };

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,0 +1,86 @@
+# Copyright 2023 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from anys import ANY_STR
+from test_helpers import execute_command, read_JSON_message, subscribe
+
+
+# TODO(#294): Implement E2E tests.
+@pytest.mark.asyncio
+async def test_channel(websocket, context_id):
+    await subscribe(websocket, "script.message")
+
+    # The channel was successfully created if there's no thrown exception.
+    await execute_command(
+        websocket,
+        {
+            "method": "script.callFunction",
+            "params": {
+                # A small delay is needed to avoid a race condition.
+                "functionDeclaration": """(binding) => {
+                    setTimeout(() => {
+                        binding('MY_MESSAGE1');
+                        binding('MY_MESSAGE2');
+                    }, 1);
+                }""",
+                "arguments": [{
+                    "type": "channel",
+                    "value": {
+                        "channel": "MY_CHANNEL",
+                        "ownership": "root",
+                    },
+                }],
+                "target": {
+                    "context": context_id
+                },
+                "awaitPromise": False,
+                "resultOwnership": "root"
+            }
+        })
+
+    resp = await read_JSON_message(websocket)
+
+    assert resp == {
+        "method": "script.message",
+        "params": {
+            "channel": "MY_CHANNEL",
+            "data": {
+                "type": "string",
+                "value": "MY_MESSAGE1"
+            },
+            "source": {
+                "context": context_id,
+                "realm": ANY_STR,
+            }
+        }
+    }
+
+    resp = await read_JSON_message(websocket)
+
+    assert resp == {
+        "method": "script.message",
+        "params": {
+            "channel": "MY_CHANNEL",
+            "data": {
+                "type": "string",
+                "value": "MY_MESSAGE2"
+            },
+            "source": {
+                "context": context_id,
+                "realm": ANY_STR,
+            }
+        }
+    }


### PR DESCRIPTION
Provide a way to communicate from scripts evaluated on the page side to
the BiDi client.

This is a safe (non-observable by the page script) analog of the `Runtime.addBinding` CDP command.

Prototype the mechanism using long-poll. Implementation details: http://go/webdriver-binding-implementation.

Reference: https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-callFunctionOn

Bug: https://github.com/GoogleChromeLabs/chromium-bidi/issues/294

## Aligning with spec:

- [x] BindingValue -> Channel
- [x] ScriptBindingCalledParams -> MessageParams

## Status

- [x] Introduce `Script.Message`: forked to https://github.com/GoogleChromeLabs/chromium-bidi/pull/541
- [x] Finish passing argument to the event in the deserialization method.
- [x] Rename `PROTO.binding` to channel to match spec.