### PR TITLE
Log CDP commands

### DIFF
--- a/src/bidiMapper/mapper.ts
+++ b/src/bidiMapper/mapper.ts
@@ -106,7 +106,7 @@ function _createCdpConnection() {
     }
   }
 
-  return new CdpConnection(new WindowCdpTransport());
+  return new CdpConnection(new WindowCdpTransport(), log(LogType.cdp));
 }
 
 function _createBidiServer() {

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -29,34 +29,41 @@ interface CdpCallbacks {
  * Manages a CdpClient instance for each active CDP session.
  */
 export class CdpConnection {
-  private _browserCdpClient: CdpClient;
-  private _sessionCdpClients: Map<string, CdpClient> = new Map();
-  private _commandCallbacks: Map<number, CdpCallbacks> = new Map();
-  private _nextId: number;
+  readonly #transport: ITransport;
+  readonly #browserCdpClient: CdpClient;
+  readonly #sessionCdpClients: Map<string, CdpClient> = new Map();
+  readonly #commandCallbacks: Map<number, CdpCallbacks> = new Map();
+  readonly #log: (...message: unknown[]) => void;
 
-  constructor(private _transport: ITransport) {
-    this._nextId = 0;
-    this._transport.setOnMessage(this._onMessage);
-    this._browserCdpClient = createClient(this, null);
+  #nextId: number = 0;
+
+  constructor(
+    transport: ITransport,
+    logCdp: (...message: unknown[]) => void = () => {}
+  ) {
+    this.#transport = transport;
+    this.#log = logCdp;
+    this.#transport.setOnMessage(this._onMessage);
+    this.#browserCdpClient = createClient(this, null);
   }
 
   /**
    * Close the connection to the browser.
    */
   close() {
-    this._transport.close();
-    for (const [_id, {reject}] of this._commandCallbacks) {
+    this.#transport.close();
+    for (const [_id, {reject}] of this.#commandCallbacks) {
       reject(new Error('Disconnected'));
     }
-    this._commandCallbacks.clear();
-    this._sessionCdpClients.clear();
+    this.#commandCallbacks.clear();
+    this.#sessionCdpClients.clear();
   }
 
   /**
    * @returns The CdpClient object attached to the root browser session.
    */
   browserClient(): CdpClient {
-    return this._browserCdpClient;
+    return this.#browserCdpClient;
   }
 
   /**
@@ -65,7 +72,7 @@ export class CdpConnection {
    * @returns The CdpClient object attached to the given session, or null if the session is not attached.
    */
   getCdpClient(sessionId: string): CdpClient {
-    const cdpClient = this._sessionCdpClients.get(sessionId);
+    const cdpClient = this.#sessionCdpClients.get(sessionId);
     if (!cdpClient) {
       throw new Error('Unknown CDP session ID');
     }
@@ -78,37 +85,40 @@ export class CdpConnection {
     sessionId: string | null
   ): Promise<object> {
     return new Promise((resolve, reject) => {
-      const id = this._nextId++;
-      this._commandCallbacks.set(id, {resolve, reject});
+      const id = this.#nextId++;
+      this.#commandCallbacks.set(id, {resolve, reject});
       let messageObj: CdpMessage = {id, method, params};
       if (sessionId) {
         messageObj.sessionId = sessionId;
       }
 
       const messageStr = JSON.stringify(messageObj);
-      this._transport.sendMessage(messageStr);
+      this.#transport.sendMessage(messageStr);
+      this.#log('sent > ' + messageStr);
     });
   }
 
   private _onMessage = async (message: string) => {
+    this.#log('received < ' + message);
+
     const parsed = JSON.parse(message);
 
     // Update client map if a session is attached or detached.
     // Listen for these events on every session.
     if (parsed.method === 'Target.attachedToTarget') {
       const {sessionId} = parsed.params;
-      this._sessionCdpClients.set(sessionId, createClient(this, sessionId));
+      this.#sessionCdpClients.set(sessionId, createClient(this, sessionId));
     } else if (parsed.method === 'Target.detachedFromTarget') {
       const {sessionId} = parsed.params;
-      const client = this._sessionCdpClients.get(sessionId);
+      const client = this.#sessionCdpClients.get(sessionId);
       if (client) {
-        this._sessionCdpClients.delete(sessionId);
+        this.#sessionCdpClients.delete(sessionId);
       }
     }
 
     if (parsed.id !== undefined) {
       // Handle command response.
-      const callbacks = this._commandCallbacks.get(parsed.id);
+      const callbacks = this.#commandCallbacks.get(parsed.id);
       if (callbacks) {
         if (parsed.result) {
           callbacks.resolve(parsed.result);
@@ -118,8 +128,8 @@ export class CdpConnection {
       }
     } else if (parsed.method) {
       const client = parsed.sessionId
-        ? this._sessionCdpClients.get(parsed.sessionId)
-        : this._browserCdpClient;
+        ? this.#sessionCdpClients.get(parsed.sessionId)
+        : this.#browserCdpClient;
       if (client) {
         client._onCdpEvent(parsed.method, parsed.params || {});
       }


### PR DESCRIPTION
It is useful to have the CDP logs of the Mapper, but from the other side, CDP log of the server is too noisy.  This PR allows providing a custom log for `CdpConnection`, which is used both in the Mapper and in the server.

Example output:
```
 bidiMapper:log   'BiDi Messages',
  bidiMapper:log   'received < {"method": "PROTO.browsingContext.findElement", "params": {"selector": "body > div", "context": "50D4E0F9CC72E109250C8EA8E20242F7"}, "id": 4}'
  bidiMapper:log ] +3ms
  bidiMapper:log consoleAPICalled log [
  bidiMapper:log   'CDP',
  bidiMapper:log   'sent > {"id":10,"method":"Runtime.callFunctionOn","params":{"functionDeclaration":"(...args)=>{ return _callFunction((\\ne=>document.querySelector(e)\\n), args);\\n      function _callFunction(f, args) {\\n        const deserializedThis = args.shift();\\n        const deserializedArgs = args;\\n        return f.apply(deserializedThis, deserializedArgs);\\n      }}","awaitPromise":true,"arguments":[{"unserializableValue":"undefined"},{"value":"body > div"}],"generateWebDriverValue":true,"executionContextId":2},"sessionId":"7BF0B9D0753B5CE2F6BBF7C9DFE7B3B8"}'
  bidiMapper:log ] +2ms
  bidiMapper:log consoleAPICalled log [
  bidiMapper:log   'CDP',
  bidiMapper:log   'received < {"id":10,"result":{"result":{"type":"object","subtype":"node","className":"HTMLDivElement","description":"div","webDriverValue":{"type":"node","value":{"nodeType":1,"nodeValue":"","nodeName":"","localName":"div","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":2,"attributes":{"some_attr_name":"some_attr_value"},"children":[{"type":"node","value":{"nodeType":3,"nodeValue":"some text","nodeName":"some text"}},{"type":"node","value":{"nodeType":1,"nodeValue":"","nodeName":"","localName":"h2","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":1,"attributes":{}}}]}},"objectId":"-7246785575299807082.2.1"}},"sessionId":"7BF0B9D0753B5CE2F6BBF7C9DFE7B3B8"}'
  bidiMapper:log ] +12ms
  bidiMapper:log consoleAPICalled log [
  bidiMapper:log   'BiDi Messages',
  bidiMapper:log   'sent > {"id":4,"result":{"result":{"type":"node","value":{"nodeType":1,"nodeValue":"","nodeName":"","localName":"div","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":2,"attributes":{"some_attr_name":"some_attr_value"},"children":[{"type":"node","value":{"nodeType":3,"nodeValue":"some text","nodeName":"some text"}},{"type":"node","value":{"nodeType":1,"nodeValue":"","nodeName":"","localName":"h2","namespaceURI":"http://www.w3.org/1999/xhtml","childNodeCount":1,"attributes":{}}}]},"handle":"-7246785575299807082.2.1"},"realm":"-5556634247619071416.-6394433750996909965"}}'
  bidiMapper:log ] +0ms
```