### PR TITLE
Separate mapper tab from the mapper

### DIFF
--- a/.github/workflows/unit.js.yml
+++ b/.github/workflows/unit.js.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Verify mapper size
-        run: du -sh lib/iife/bidiMapper/mapper.js
+        run: du -sh lib/iife/mapperTab.js
       - name: Run unit tests
         run: npm run unit
 

--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -20,15 +20,11 @@ import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
 export default {
-  input: 'lib/cjs/bidiMapper/bidiMapper/mapper.js',
+  input: 'lib/cjs/bidiTab/bidiTab/bidiTab.js',
   output: {
-    file: 'lib/iife/bidiMapper/mapper.js',
+    file: 'lib/iife/mapperTab.js',
     sourcemap: true,
     format: 'iife',
   },
-  plugins: [
-    nodeResolve(),
-    commonjs(),
-    terser(),
-  ],
+  plugins: [nodeResolve(), commonjs(), terser()],
 };

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -491,9 +491,9 @@ export class BrowsingContextImpl {
   ): Promise<BrowsingContext.PROTO.FindElementResult> {
     await this.#targetDefers.targetUnblocked;
 
-    const functionDeclaration = String((resultsSelector: string) =>
-      document.querySelector(resultsSelector)
-    );
+    const functionDeclaration = `
+      (resultsSelector) => document.querySelector(resultsSelector)
+    `;
     const _arguments: Script.ArgumentValue[] = [
       {type: 'string', value: selector},
     ];

--- a/src/bidiServer/mapperReader.ts
+++ b/src/bidiServer/mapperReader.ts
@@ -20,7 +20,7 @@ import path from 'path';
 
 export default async function read(): Promise<string> {
   return await fs.readFile(
-    path.join(__dirname, '../../../iife/bidiMapper/mapper.js'),
+    path.join(__dirname, '../../../iife/mapperTab.js'),
     'utf8'
   );
 }

--- a/src/bidiServer/tsconfig.json
+++ b/src/bidiServer/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "../../lib/cjs/bidiServer"
-  },
+  }
 }

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -17,16 +17,16 @@
  * @license
  */
 
-import {CommandProcessor} from './commandProcessor';
+import {CommandProcessor} from '../bidiMapper/commandProcessor';
 
 import {CdpClient, CdpConnection} from '../cdp';
-import {BiDiMessageEntry, BidiServer} from './utils/bidiServer';
+import {BiDiMessageEntry, BidiServer} from '../bidiMapper/utils/bidiServer';
 import {ITransport} from '../utils/transport';
 
 import {log, LogType} from '../utils/log';
-import {EventManager} from './domains/events/EventManager';
-import {BrowsingContextStorage} from './domains/context/browsingContextStorage';
-import {MapperTabPage} from './utils/mapperTabPage';
+import {EventManager} from '../bidiMapper/domains/events/EventManager';
+import {BrowsingContextStorage} from '../bidiMapper/domains/context/browsingContextStorage';
+import {MapperTabPage} from './mapperTabPage';
 
 const logSystem = log(LogType.system);
 

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -14,7 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {LogType} from '../../utils/log';
+import {LogType} from '../utils/log';
+
+declare global {
+  interface Window {
+    MapperTabPage: MapperTabPage;
+  }
+}
 
 export class MapperTabPage {
   // HTML source code for the user-facing Mapper tab.
@@ -26,6 +32,7 @@ export class MapperTabPage {
     if (!globalThis.document?.documentElement) {
       return;
     }
+    window.MapperTabPage = MapperTabPage;
     window.document.documentElement.innerHTML = this.#mapperPageSource;
     // Create main log containers in proper order.
     this.#findOrCreateTypeLogContainer('System');

--- a/src/bidiTab/tsconfig.json
+++ b/src/bidiTab/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../../configs/tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["DOM", "ESNext"],
     "module": "CommonJS",
-    "outDir": "../../lib/cjs/bidiMapper",
+    "outDir": "../../lib/cjs/bidiTab",
     "declaration": true
-  },
+  }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,6 +3,7 @@
   "files": [],
   "references": [
     {"path": "bidiMapper/tsconfig.json"},
-    {"path": "bidiServer/tsconfig.json"}
+    {"path": "bidiServer/tsconfig.json"},
+    {"path": "bidiTab/tsconfig.json"}
   ]
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import {MapperTabPage} from '../bidiMapper/utils/mapperTabPage';
-
 export enum LogType {
   system = 'System',
   bidi = 'BiDi Messages',
@@ -29,6 +27,13 @@ export function log(logType: LogType): (...message: unknown[]) => void {
   return (...messages: any[]) => {
     console.log(logType, ...messages);
     // Add messages to the Mapper Tab Page, if exists.
-    MapperTabPage.log(logType, ...messages);
+    // Dynamic lookup to avoid circlular dependency.
+    if ('MapperTabPage' in globalThis) {
+      (
+        globalThis as unknown as {
+          MapperTabPage: {log: (...message: unknown[]) => void};
+        }
+      )['MapperTabPage'].log(logType, ...messages);
+    }
   };
 }


### PR DESCRIPTION
This PR separates the mapper tab from the mapper implementation. This allows compiling the mapper implementation without DOM APIs. As the next step we can turn bidiMapper/bidiTab/bidiServer into composite projects to reduce duplication in the build output.