### PR TITLE
Destroy realms when a BrowsingContext is destroyed

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -153,6 +153,10 @@ export class BrowsingContextImpl {
   public async delete() {
     await this.#removeChildContexts();
 
+    Realm.findRealms({browsingContextId: this.contextId}).forEach((realm) =>
+      realm.delete()
+    );
+
     // Remove context from the parent.
     if (this.parentId !== null) {
       const parent = BrowsingContextStorage.getKnownContext(this.parentId);

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -968,6 +968,23 @@ async def test_scriptGetRealms(websocket, context_id):
             }])
         }, result)
 
+    # Assert closing browsing context destroys its realms.
+    await execute_command(websocket, {
+        "method": "browsingContext.close",
+        "params": {
+            "context": context_id
+        }})
+
+    result = await execute_command(websocket, {
+        "method": "script.getRealms",
+        "params": {}
+    })
+
+    # Assert no more realms existed.
+    recursive_compare({
+        "realms": []
+    }, result)
+
 
 @pytest.mark.asyncio
 async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):


### PR DESCRIPTION
This should fix the [get_realm](https://wpt.fyi/results/webdriver/tests/bidi/script/get_realms/get_realms.py?label=experimental&label=master&aligned&view=subtest) WPT tests.