### PR TITLE
Add output.name to rollup config to resolve warning

### DIFF
--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -22,6 +22,7 @@ import commonjs from '@rollup/plugin-commonjs';
 export default {
   input: 'lib/cjs/bidiTab/bidiTab.js',
   output: {
+    name: 'mapperTab',
     file: 'lib/iife/mapperTab.js',
     sourcemap: true,
     format: 'iife',


### PR DESCRIPTION
> (!) If you do not supply "output.name", you may not be able to access
> the exports of an IIFE bundle.

Tested: `npm run build` does not produce a warning