### PR TITLE
eslint: add no-extraneous-class rule and fix BrowsingContextStorage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,9 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'import', 'mocha'],
   extends: ['plugin:prettier/recommended'],
-  rules: {},
+  rules: {
+    '@typescript-eslint/no-extraneous-class': 'warn',
+  },
   overrides: [
     {
       files: ['*.ts'],

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "server-no-build": "node lib/cjs/bidiServer/index.js",
     "server": "npm run build && npm run server-no-build --",
     "test": "npm run build && npm run unit",
-    "unit": "cross-env TS_NODE_PROJECT='src/tsconfig.json' mocha"
+    "unit": "cross-env TS_NODE_PROJECT='src/tsconfig.json' mocha",
+    "watch": "tsc -b src/tsconfig.json --watch & rollup --config configs/rollup.config.js --watch"
   },
   "files": [
     "lib"

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -24,7 +24,7 @@ import {OutgoingBidiMessage} from './OutgoindBidiMessage.js';
 import {EventManager} from './domains/events/EventManager.js';
 import {BidiParser, CommandProcessor} from './CommandProcessor.js';
 import {CdpConnection} from './CdpConnection.js';
-import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
+import {getTopLevelContexts} from './domains/context/browsingContextStorage.js';
 
 type BidiServerEvents = {
   message: Message.RawCommandRequest;
@@ -85,9 +85,7 @@ export class BidiServer extends EventEmitter<BidiServerEvents> {
       flatten: true,
     });
 
-    await Promise.all(
-      BrowsingContextStorage.getTopLevelContexts().map((c) => c.awaitLoaded())
-    );
+    await Promise.all(getTopLevelContexts().map((c) => c.awaitLoaded()));
     return server;
   }
 

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -22,7 +22,11 @@ import {IEventManager} from '../events/EventManager.js';
 import {Deferred} from '../../../utils/deferred.js';
 import {LogManager} from '../log/logManager.js';
 import {Realm, RealmType} from '../script/realm.js';
-import {BrowsingContextStorage} from './browsingContextStorage.js';
+import {
+  addContext,
+  getKnownContext,
+  removeContext,
+} from './browsingContextStorage.js';
 
 export class BrowsingContextImpl {
   readonly #targetDefers = {
@@ -77,7 +81,7 @@ export class BrowsingContextImpl {
 
     this.#initListeners();
 
-    BrowsingContextStorage.addContext(this);
+    addContext(this);
   }
 
   public static async createFrameContext(
@@ -164,7 +168,7 @@ export class BrowsingContextImpl {
 
     // Remove context from the parent.
     if (this.parentId !== null) {
-      const parent = BrowsingContextStorage.getKnownContext(this.parentId);
+      const parent = getKnownContext(this.parentId);
       parent.#children.delete(this.contextId);
     }
 
@@ -175,7 +179,7 @@ export class BrowsingContextImpl {
       },
       this.contextId
     );
-    BrowsingContextStorage.removeContext(this.contextId);
+    removeContext(this.contextId);
   }
 
   async #removeChildContexts() {

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -18,41 +18,37 @@
 import {BrowsingContextImpl} from './browsingContextImpl.js';
 import {Message} from '../../../protocol/protocol.js';
 
-export class BrowsingContextStorage {
-  static #contexts: Map<string, BrowsingContextImpl> = new Map();
+const contexts = new Map<string, BrowsingContextImpl>();
 
-  static getTopLevelContexts(): BrowsingContextImpl[] {
-    return Array.from(BrowsingContextStorage.#contexts.values()).filter(
-      (c) => c.parentId === null
-    );
+export function removeContext(contextId: string) {
+  contexts.delete(contextId);
+}
+
+export function findContext(
+  contextId: string
+): BrowsingContextImpl | undefined {
+  return contexts.get(contextId);
+}
+
+export function hasKnownContext(contextId: string): boolean {
+  return contexts.has(contextId);
+}
+
+export function getTopLevelContexts(): BrowsingContextImpl[] {
+  return Array.from(contexts.values()).filter((c) => c.parentId === null);
+}
+
+export function getKnownContext(contextId: string): BrowsingContextImpl {
+  const result = findContext(contextId);
+  if (result === undefined) {
+    throw new Message.NoSuchFrameException(`Context ${contextId} not found`);
   }
+  return result;
+}
 
-  static removeContext(contextId: string) {
-    BrowsingContextStorage.#contexts.delete(contextId);
-  }
-
-  static addContext(context: BrowsingContextImpl) {
-    BrowsingContextStorage.#contexts.set(context.contextId, context);
-    if (context.parentId !== null) {
-      BrowsingContextStorage.getKnownContext(context.parentId).addChild(
-        context
-      );
-    }
-  }
-
-  static hasKnownContext(contextId: string): boolean {
-    return BrowsingContextStorage.#contexts.has(contextId);
-  }
-
-  static findContext(contextId: string): BrowsingContextImpl | undefined {
-    return BrowsingContextStorage.#contexts.get(contextId)!;
-  }
-
-  static getKnownContext(contextId: string): BrowsingContextImpl {
-    const result = BrowsingContextStorage.findContext(contextId);
-    if (result === undefined) {
-      throw new Message.NoSuchFrameException(`Context ${contextId} not found`);
-    }
-    return result;
+export function addContext(context: BrowsingContextImpl) {
+  contexts.set(context.contextId, context);
+  if (context.parentId !== null) {
+    getKnownContext(context.parentId).addChild(context);
   }
 }

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -25,7 +25,7 @@ import {OutgoingBidiMessage} from '../../OutgoindBidiMessage.js';
 import {SubscriptionManager} from './SubscriptionManager.js';
 import {IdWrapper} from '../../../utils/idWrapper.js';
 import {Buffer} from '../../../utils/buffer.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import {hasKnownContext} from '../context/browsingContextStorage.js';
 
 class EventWrapper extends IdWrapper {
   readonly #contextId: CommonDataTypes.BrowsingContext | null;
@@ -159,10 +159,7 @@ export class EventManager implements IEventManager {
   ): Promise<void> {
     for (let eventName of events) {
       for (let contextId of contextIds) {
-        if (
-          contextId !== null &&
-          !BrowsingContextStorage.hasKnownContext(contextId)
-        ) {
+        if (contextId !== null && !hasKnownContext(contextId)) {
           // Unknown context. Do nothing.
           continue;
         }

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -22,7 +22,7 @@ import {
   Log,
   Session,
 } from '../../../protocol/protocol.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import {findContext} from '../context/browsingContextStorage.js';
 
 export class SubscriptionManager {
   #subscriptionPriority = 0;
@@ -96,7 +96,7 @@ export class SubscriptionManager {
     const result: (CommonDataTypes.BrowsingContext | null)[] = [null];
     while (contextId !== null) {
       result.push(contextId);
-      const maybeParentContext = BrowsingContextStorage.findContext(contextId);
+      const maybeParentContext = findContext(contextId);
       contextId = maybeParentContext?.parentId ?? null;
     }
     return result;

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -18,7 +18,7 @@
 import {Protocol} from 'devtools-protocol';
 import {CommonDataTypes, Script, Message} from '../../../protocol/protocol.js';
 import {ScriptEvaluator} from './scriptEvaluator.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import {getKnownContext} from '../context/browsingContextStorage.js';
 import {CdpClient} from '../../CdpConnection.js';
 
 export enum RealmType {
@@ -221,9 +221,7 @@ export class Realm {
     awaitPromise: boolean,
     resultOwnership: Script.OwnershipModel
   ): Promise<Script.CallFunctionResult> {
-    const context = BrowsingContextStorage.getKnownContext(
-      this.browsingContextId
-    );
+    const context = getKnownContext(this.browsingContextId);
     await context.awaitUnblocked();
 
     return {
@@ -243,9 +241,7 @@ export class Realm {
     awaitPromise: boolean,
     resultOwnership: Script.OwnershipModel
   ): Promise<Script.EvaluateResult> {
-    const context = BrowsingContextStorage.getKnownContext(
-      this.browsingContextId
-    );
+    const context = getKnownContext(this.browsingContextId);
     await context.awaitUnblocked();
 
     return {


### PR DESCRIPTION
> Users who come from a OOP paradigm may wrap their utility functions in
an extra class, instead of putting them at the top level of an ECMAScript module. Doing so is generally unnecessary in JavaScript and TypeScript projects.

Bug: #392
Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-extraneous-class.md