### PR TITLE
eslint: add no-extraneous-class rule and fix most of mapperTabPage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,9 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'import', 'mocha'],
   extends: ['plugin:prettier/recommended'],
-  rules: {},
+  rules: {
+    '@typescript-eslint/no-extraneous-class': 'warn',
+  },
   overrides: [
     {
       files: ['*.ts'],

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -22,23 +22,53 @@ declare global {
   }
 }
 
-export class MapperTabPage {
-  // HTML source code for the user-facing Mapper tab.
-  static #mapperPageSource =
-    '<!DOCTYPE html><title>BiDi-CDP Mapper</title><style>body{font-family: Roboto, serif; font-size: 13px; color: #202124;}.log{padding: 12px; font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace; font-size: 11px; line-height: 180%; background: #f1f3f4; border-radius: 4px;}.pre{overflow-wrap: break-word; padding: 10px;}.card{margin: 60px auto; padding: 2px 0; max-width: 900px; box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15), 0 1px 6px rgba(0, 0, 0, 0.2); border-radius: 8px;}.divider{height: 1px; background: #f0f0f0;}.item{padding: 16px 20px;}</style><div class="card"><div class="item"><h1>BiDi-CDP Mapper is controlling this tab</h1><p>Closing or reloading it will stop the BiDi process. <a target="_blank" title="BiDi-CDP Mapper GitHub Repository" href="https://github.com/GoogleChromeLabs/chromium-bidi">Details.</a></p></div><div class="divider"></div><details id="details"><summary class="item">Debug information</summary></details></div>';
+/** HTML source code for the user-facing Mapper tab. */
+const mapperPageSource =
+  '<!DOCTYPE html><title>BiDi-CDP Mapper</title><style>body{font-family: Roboto, serif; font-size: 13px; color: #202124;}.log{padding: 12px; font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace; font-size: 11px; line-height: 180%; background: #f1f3f4; border-radius: 4px;}.pre{overflow-wrap: break-word; padding: 10px;}.card{margin: 60px auto; padding: 2px 0; max-width: 900px; box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15), 0 1px 6px rgba(0, 0, 0, 0.2); border-radius: 8px;}.divider{height: 1px; background: #f0f0f0;}.item{padding: 16px 20px;}</style><div class="card"><div class="item"><h1>BiDi-CDP Mapper is controlling this tab</h1><p>Closing or reloading it will stop the BiDi process. <a target="_blank" title="BiDi-CDP Mapper GitHub Repository" href="https://github.com/GoogleChromeLabs/chromium-bidi">Details.</a></p></div><div class="divider"></div><details id="details"><summary class="item">Debug information</summary></details></div>';
 
+/**
+ * The following piece of HTML should be added to the `debug` element:
+ *
+ * <div class="divider"></div>
+ * <div class="item">
+ * <h3>${name}</h3>
+ * <div id="${name}_log" class="log">
+ */
+function findOrCreateTypeLogContainer(logType: string): HTMLElement {
+  const containerId = logType + '_log';
+
+  const existingContainer = document.getElementById(containerId);
+  if (existingContainer) {
+    return existingContainer;
+  }
+
+  const debugElement = document.getElementById('details')!;
+
+  const divider = document.createElement('div');
+  divider.className = 'divider';
+  debugElement.appendChild(divider);
+
+  const htmlItem = document.createElement('div');
+  htmlItem.className = 'item';
+  htmlItem.innerHTML = `<h3>${logType}</h3><div id="${containerId}" class="log"></div>`;
+  debugElement.appendChild(htmlItem);
+
+  return document.getElementById(containerId)!;
+}
+
+export class MapperTabPage {
   static generatePage() {
     // If run not in browser (e.g. unit test), do nothing.
     if (!globalThis.document?.documentElement) {
       return;
     }
     window.MapperTabPage = MapperTabPage;
-    window.document.documentElement.innerHTML = this.#mapperPageSource;
+    window.document.documentElement.innerHTML = mapperPageSource;
     // Create main log containers in proper order.
-    this.#findOrCreateTypeLogContainer('System');
-    this.#findOrCreateTypeLogContainer('BiDi Messages');
-    this.#findOrCreateTypeLogContainer('Browsing Contexts');
-    this.#findOrCreateTypeLogContainer('CDP');
+    findOrCreateTypeLogContainer('System');
+    findOrCreateTypeLogContainer('BiDi Messages');
+    findOrCreateTypeLogContainer('Browsing Contexts');
+    findOrCreateTypeLogContainer('CDP');
   }
 
   static log(logType: LogType, ...messages: unknown[]) {
@@ -46,7 +76,7 @@ export class MapperTabPage {
     if (!globalThis.document?.documentElement) {
       return;
     }
-    const typeLogContainer = this.#findOrCreateTypeLogContainer(logType);
+    const typeLogContainer = findOrCreateTypeLogContainer(logType);
 
     // This piece of HTML should be added:
     /*
@@ -56,34 +86,5 @@ export class MapperTabPage {
     lineElement.className = 'pre';
     lineElement.textContent = messages.join(', ');
     typeLogContainer.appendChild(lineElement);
-  }
-
-  // This piece of HTML should be added to the `debug` element:
-  /*
-      <div class="divider"></div>
-      <div class="item">
-        <h3>${name}</h3>
-        <div id="${name}_log" class="log">
-  */
-  static #findOrCreateTypeLogContainer(logType: string) {
-    const containerId = logType + '_log';
-
-    const existingContainer = document.getElementById(containerId);
-    if (existingContainer) {
-      return existingContainer;
-    }
-
-    const debugElement = document.getElementById('details')!;
-
-    const divider = document.createElement('div');
-    divider.className = 'divider';
-    debugElement.appendChild(divider);
-
-    const htmlItem = document.createElement('div');
-    htmlItem.className = 'item';
-    htmlItem.innerHTML = `<h3>${logType}</h3><div id="${containerId}" class="log"></div>`;
-    debugElement.appendChild(htmlItem);
-
-    return document.getElementById(containerId)!;
   }
 }


### PR DESCRIPTION
> Users who come from a OOP paradigm may wrap their utility functions in
an extra class, instead of putting them at the top level of an ECMAScript module. Doing so is generally unnecessary in JavaScript and TypeScript projects.

Bug: #392
Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-extraneous-class.md