### PR TITLE
github workflow: remove redundant apt install xvfb from ubuntu-latest

### DIFF
--- a/.github/workflows/e2e.js.yml
+++ b/.github/workflows/e2e.js.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Install chrome-dev
         run: |
-          sudo apt-get install -y xvfb
           wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
           sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
           sudo apt-get update


### PR DESCRIPTION
It is already included out-of-the-box:
https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md

Same for 18.04 and 20.04, thus it is unlikely to be removed.