### PR TITLE
eslint: add no-extraneous-class rule and fix BrowsingContextStorage

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -92,7 +92,7 @@ export class BidiServer extends EventEmitter<BidiServerEvents> {
     return server;
   }
 
-  async awaitLoadTopLevelContexts() {
+  async topLevelContextsLoaded() {
     await Promise.all(
       this.#browsingContextStorage
         .getTopLevelContexts()

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -14,42 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {BrowsingContextImpl} from './browsingContextImpl.js';
 import {Message} from '../../../protocol/protocol.js';
+import {BrowsingContextImpl} from './browsingContextImpl.js';
 
 export class BrowsingContextStorage {
-  static #contexts: Map<string, BrowsingContextImpl> = new Map();
+  #contexts = new Map<string, BrowsingContextImpl>();
 
-  static getTopLevelContexts(): BrowsingContextImpl[] {
-    return Array.from(BrowsingContextStorage.#contexts.values()).filter(
+  public getTopLevelContexts(): BrowsingContextImpl[] {
+    return Array.from(this.#contexts.values()).filter(
       (c) => c.parentId === null
     );
   }
 
-  static removeContext(contextId: string) {
-    BrowsingContextStorage.#contexts.delete(contextId);
+  public removeContext(contextId: string) {
+    this.#contexts.delete(contextId);
   }
 
-  static addContext(context: BrowsingContextImpl) {
-    BrowsingContextStorage.#contexts.set(context.contextId, context);
+  public addContext(context: BrowsingContextImpl) {
+    this.#contexts.set(context.contextId, context);
     if (context.parentId !== null) {
-      BrowsingContextStorage.getKnownContext(context.parentId).addChild(
-        context
-      );
+      this.getKnownContext(context.parentId).addChild(context);
     }
   }
 
-  static hasKnownContext(contextId: string): boolean {
-    return BrowsingContextStorage.#contexts.has(contextId);
+  public hasKnownContext(contextId: string): boolean {
+    return this.#contexts.has(contextId);
   }
 
-  static findContext(contextId: string): BrowsingContextImpl | undefined {
-    return BrowsingContextStorage.#contexts.get(contextId)!;
+  public findContext(contextId: string): BrowsingContextImpl | undefined {
+    return this.#contexts.get(contextId);
   }
 
-  static getKnownContext(contextId: string): BrowsingContextImpl {
-    const result = BrowsingContextStorage.findContext(contextId);
+  public getKnownContext(contextId: string): BrowsingContextImpl {
+    const result = this.findContext(contextId);
     if (result === undefined) {
       throw new Message.NoSuchFrameException(`Context ${contextId} not found`);
     }

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -14,18 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import type {
   CommonDataTypes,
   Message,
   Session,
 } from '../../../protocol/protocol.js';
+import {Buffer} from '../../../utils/buffer.js';
+import {IdWrapper} from '../../../utils/idWrapper.js';
 import type {BidiServer} from '../../BidiServer.js';
 import {OutgoingBidiMessage} from '../../OutgoindBidiMessage.js';
 import {SubscriptionManager} from './SubscriptionManager.js';
-import {IdWrapper} from '../../../utils/idWrapper.js';
-import {Buffer} from '../../../utils/buffer.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 
 class EventWrapper extends IdWrapper {
   readonly #contextId: CommonDataTypes.BrowsingContext | null;
@@ -161,7 +159,9 @@ export class EventManager implements IEventManager {
       for (let contextId of contextIds) {
         if (
           contextId !== null &&
-          !BrowsingContextStorage.hasKnownContext(contextId)
+          !this.#bidiServer
+            .getBrowsingContextStorage()
+            .hasKnownContext(contextId)
         ) {
           // Unknown context. Do nothing.
           continue;

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -22,7 +22,7 @@ import {BidiServer} from '../bidiMapper/BidiServer.js';
 import {BidiTransport} from '../bidiMapper/bidiMapper.js';
 
 import {log, LogType} from '../utils/log.js';
-import {MapperTabPage} from './mapperTabPage.js';
+import {generatePage} from './mapperTabPage.js';
 import {OutgoingBidiMessage} from '../bidiMapper/OutgoindBidiMessage.js';
 import type {
   BrowsingContext,
@@ -62,7 +62,7 @@ declare global {
 const _waitSelfTargetIdPromise = _waitSelfTargetId();
 
 (async () => {
-  MapperTabPage.generatePage();
+  generatePage();
 
   // Needed to filter out info related to BiDi target.
   const selfTargetId = await _waitSelfTargetIdPromise;

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -56,21 +56,20 @@ function findOrCreateTypeLogContainer(logType: string): HTMLElement {
   return document.getElementById(containerId)!;
 }
 
-export class MapperTabPage {
-  static generatePage() {
-    // If run not in browser (e.g. unit test), do nothing.
-    if (!globalThis.document?.documentElement) {
-      return;
-    }
-    window.MapperTabPage = MapperTabPage;
-    window.document.documentElement.innerHTML = mapperPageSource;
-    // Create main log containers in proper order.
-    findOrCreateTypeLogContainer('System');
-    findOrCreateTypeLogContainer('BiDi Messages');
-    findOrCreateTypeLogContainer('Browsing Contexts');
-    findOrCreateTypeLogContainer('CDP');
+export function generatePage() {
+  // If run not in browser (e.g. unit test), do nothing.
+  if (!globalThis.document?.documentElement) {
+    return;
   }
+  window.document.documentElement.innerHTML = mapperPageSource;
+  // Create main log containers in proper order.
+  findOrCreateTypeLogContainer('System');
+  findOrCreateTypeLogContainer('BiDi Messages');
+  findOrCreateTypeLogContainer('Browsing Contexts');
+  findOrCreateTypeLogContainer('CDP');
+}
 
+export class MapperTabPage {
   static log(logType: LogType, ...messages: unknown[]) {
     // If run not in browser (e.g. unit test), do nothing.
     if (!globalThis.document?.documentElement) {


### PR DESCRIPTION
> Users who come from a OOP paradigm may wrap their utility functions in
an extra class, instead of putting them at the top level of an ECMAScript module. Doing so is generally unnecessary in JavaScript and TypeScript projects.

- prerefactor BidiServer static factory, create helper function to load all top level contexts
- make EventManager use a non-static version of BrowsingContextStorage

Bug: #392
Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-extraneous-class.md