### PR TITLE
github workflow: fix warning: update upload-artifact action to v3

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -54,18 +54,17 @@ jobs:
         working-directory: wpt
       - name: Upload expectations
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wpt-metadata
           path: wpt-metadata
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs
           # Note: runBiDiServer.sh will be run multiple times and log.txt will be
           # overwritten. The problem might not be in the log.txt written last.
           path: logs
-
 env:
   FORCE_COLOR: 3


### PR DESCRIPTION
> Node.js 12 actions are deprecated. Please update the following actions
to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.