### PR TITLE
github workflows: run npm ci instead of npm install

### DIFF
--- a/.github/workflows/e2e.js.yml
+++ b/.github/workflows/e2e.js.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 16
           cache: npm
       - name: Install npm dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Set up Python

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-      - run: npm install
+      - run: npm ci
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 16
           cache: npm
       - name: Install npm dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Set up Python

--- a/.github/workflows/unit.js.yml
+++ b/.github/workflows/unit.js.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 16
           cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Verify mapper size

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 16
           cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Set up Python


### PR DESCRIPTION
"npm run prepare" is always executed as part of "npm install".
Currently, CI is running "npm run build" redundantly twice, once as part
of "install", and once as part of an explicit build step.

"npm ci" does not execute "npm run prepare".