### PR TITLE
Make BrowsingContextStorage non-static, and an instance of BidiServer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-extraneous-class': 'warn',
+    '@typescript-eslint/no-extraneous-class': 'error',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-this-alias': 'off',

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -27,6 +27,7 @@ import {CdpConnection} from './CdpConnection.js';
 import {OutgoingBidiMessage} from './OutgoindBidiMessage.js';
 import {IEventManager} from './domains/events/EventManager.js';
 import {EventEmitter} from '../utils/EventEmitter.js';
+import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 
 type CommandProcessorEvents = {
   response: Promise<OutgoingBidiMessage>;
@@ -91,14 +92,16 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEvents> {
     cdpConnection: CdpConnection,
     eventManager: IEventManager,
     selfTargetId: string,
-    parser: BidiParser = new BidiNoOpParser()
+    parser: BidiParser = new BidiNoOpParser(),
+    browsingContextStorage: BrowsingContextStorage
   ) {
     super();
     this.#eventManager = eventManager;
     this.#contextProcessor = new BrowsingContextProcessor(
       cdpConnection,
       selfTargetId,
-      eventManager
+      eventManager,
+      browsingContextStorage
     );
     this.#parser = parser;
   }

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -19,37 +19,35 @@ import {BrowsingContextImpl} from './browsingContextImpl.js';
 import {Message} from '../../../protocol/protocol.js';
 
 export class BrowsingContextStorage {
-  static #contexts: Map<string, BrowsingContextImpl> = new Map();
+  readonly #contexts = new Map<string, BrowsingContextImpl>();
 
-  static getTopLevelContexts(): BrowsingContextImpl[] {
-    return Array.from(BrowsingContextStorage.#contexts.values()).filter(
+  getTopLevelContexts(): BrowsingContextImpl[] {
+    return Array.from(this.#contexts.values()).filter(
       (c) => c.parentId === null
     );
   }
 
-  static removeContext(contextId: string) {
-    BrowsingContextStorage.#contexts.delete(contextId);
+  removeContext(contextId: string) {
+    this.#contexts.delete(contextId);
   }
 
-  static addContext(context: BrowsingContextImpl) {
-    BrowsingContextStorage.#contexts.set(context.contextId, context);
+  addContext(context: BrowsingContextImpl) {
+    this.#contexts.set(context.contextId, context);
     if (context.parentId !== null) {
-      BrowsingContextStorage.getKnownContext(context.parentId).addChild(
-        context
-      );
+      this.getKnownContext(context.parentId).addChild(context);
     }
   }
 
-  static hasKnownContext(contextId: string): boolean {
-    return BrowsingContextStorage.#contexts.has(contextId);
+  hasKnownContext(contextId: string): boolean {
+    return this.#contexts.has(contextId);
   }
 
-  static findContext(contextId: string): BrowsingContextImpl | undefined {
-    return BrowsingContextStorage.#contexts.get(contextId)!;
+  findContext(contextId: string): BrowsingContextImpl {
+    return this.#contexts.get(contextId)!;
   }
 
-  static getKnownContext(contextId: string): BrowsingContextImpl {
-    const result = BrowsingContextStorage.findContext(contextId);
+  getKnownContext(contextId: string): BrowsingContextImpl {
+    const result = this.findContext(contextId);
     if (result === undefined) {
       throw new Message.NoSuchFrameException(`Context ${contextId} not found`);
     }

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -25,7 +25,6 @@ import {OutgoingBidiMessage} from '../../OutgoindBidiMessage.js';
 import {SubscriptionManager} from './SubscriptionManager.js';
 import {IdWrapper} from '../../../utils/idWrapper.js';
 import {Buffer} from '../../../utils/buffer.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 
 class EventWrapper extends IdWrapper {
   readonly #contextId: CommonDataTypes.BrowsingContext | null;
@@ -107,7 +106,9 @@ export class EventManager implements IEventManager {
 
   constructor(bidiServer: BidiServer) {
     this.#bidiServer = bidiServer;
-    this.#subscriptionManager = new SubscriptionManager();
+    this.#subscriptionManager = new SubscriptionManager(
+      bidiServer.getBrowsingContextStorage()
+    );
   }
 
   /**
@@ -162,7 +163,9 @@ export class EventManager implements IEventManager {
       for (const contextId of contextIds) {
         if (
           contextId !== null &&
-          !BrowsingContextStorage.hasKnownContext(contextId)
+          !this.#bidiServer
+            .getBrowsingContextStorage()
+            .hasKnownContext(contextId)
         ) {
           // Unknown context. Do nothing.
           continue;

--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -17,6 +17,7 @@
 import * as chai from 'chai';
 import {SubscriptionManager} from './SubscriptionManager.js';
 import {BrowsingContext} from '../../../protocol/protocol.js';
+import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 
 const expect = chai.expect;
 const ALL_EVENTS = BrowsingContext.AllEvents;
@@ -31,7 +32,9 @@ const ANOTHER_CHANNEL = 'ANOTHER_CHANNEL';
 describe('test SubscriptionManager', () => {
   describe('with null context', () => {
     it('should send proper event in any context', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       expect(
         subscriptionManager.getChannelsSubscribedToEvent(
@@ -41,7 +44,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([SOME_CHANNEL]);
     });
     it('should not send wrong event', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       expect(
         subscriptionManager.getChannelsSubscribedToEvent(
@@ -51,7 +56,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([]);
     });
     it('should unsubscribe', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
       expect(
@@ -62,7 +69,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([]);
     });
     it('should not unsubscribe specific context subscription', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
@@ -74,7 +83,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([SOME_CHANNEL]);
     });
     it('should subscribe in proper order', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
       expect(
@@ -85,7 +96,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
     });
     it('should re-subscribe in proper order', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
@@ -98,7 +111,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([ANOTHER_CHANNEL, SOME_CHANNEL]);
     });
     it('should re-subscribe global and specific context in proper order', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
@@ -111,7 +126,9 @@ describe('test SubscriptionManager', () => {
     });
   });
   it('should re-subscribe global and specific event in proper order', () => {
-    const subscriptionManager = new SubscriptionManager();
+    const subscriptionManager = new SubscriptionManager(
+      new BrowsingContextStorage()
+    );
     subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
     subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
     subscriptionManager.subscribe(ANOTHER_EVENT, null, ANOTHER_CHANNEL);
@@ -143,7 +160,9 @@ describe('test SubscriptionManager', () => {
   });
   describe('with some context', () => {
     it('should send proper event in proper context', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       expect(
         subscriptionManager.getChannelsSubscribedToEvent(
@@ -153,7 +172,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([SOME_CHANNEL]);
     });
     it('should not send proper event in wrong context', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       expect(
         subscriptionManager.getChannelsSubscribedToEvent(
@@ -163,7 +184,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([]);
     });
     it('should not send wrong event in proper context', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       expect(
         subscriptionManager.getChannelsSubscribedToEvent(
@@ -173,7 +196,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([]);
     });
     it('should unsubscribe', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       expect(
@@ -184,7 +209,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([]);
     });
     it('should unsubscribe the domain', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.unsubscribe(ALL_EVENTS, SOME_CONTEXT, SOME_CHANNEL);
       expect(
@@ -195,7 +222,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([]);
     });
     it('should not unsubscribe global subscription', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
@@ -207,7 +236,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([SOME_CHANNEL]);
     });
     it('should subscribe in proper order', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, ANOTHER_CHANNEL);
       expect(
@@ -218,7 +249,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
     });
     it('should re-subscribe in proper order', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, ANOTHER_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
@@ -231,7 +264,9 @@ describe('test SubscriptionManager', () => {
       ).to.deep.equal([ANOTHER_CHANNEL, SOME_CHANNEL]);
     });
     it('should re-subscribe global and specific context in proper order', () => {
-      const subscriptionManager = new SubscriptionManager();
+      const subscriptionManager = new SubscriptionManager(
+        new BrowsingContextStorage()
+      );
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -36,6 +36,11 @@ export class SubscriptionManager {
       Map<Session.SubscribeParametersEvent, number>
     >
   > = new Map();
+  #browsingContextStorage: BrowsingContextStorage;
+
+  constructor(browsingContextStorage: BrowsingContextStorage) {
+    this.#browsingContextStorage = browsingContextStorage;
+  }
 
   getChannelsSubscribedToEvent(
     eventMethod: Session.SubscribeParametersEvent,
@@ -94,7 +99,8 @@ export class SubscriptionManager {
     const result: (CommonDataTypes.BrowsingContext | null)[] = [null];
     while (contextId !== null) {
       result.push(contextId);
-      const maybeParentContext = BrowsingContextStorage.findContext(contextId);
+      const maybeParentContext =
+        this.#browsingContextStorage.findContext(contextId);
       contextId = maybeParentContext?.parentId ?? null;
     }
     return result;

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -30,6 +30,16 @@ const scriptEvaluator = new ScriptEvaluator();
 export class Realm {
   static readonly #realmMap: Map<string, Realm> = new Map();
 
+  readonly #realmId: string;
+  readonly #browsingContextId: string;
+  readonly #navigableId: string;
+  readonly #executionContextId: Protocol.Runtime.ExecutionContextId;
+  readonly #origin: string;
+  readonly #type: RealmType;
+  readonly #sandbox: string | undefined;
+  readonly #cdpSessionId: string;
+  readonly #cdpClient: CdpClient;
+
   static create(
     realmId: string,
     browsingContextId: string,
@@ -146,16 +156,6 @@ export class Realm {
     scriptEvaluator.realmDestroyed(this);
   }
 
-  readonly #realmId: string;
-  readonly #browsingContextId: string;
-  readonly #navigableId: string;
-  readonly #executionContextId: Protocol.Runtime.ExecutionContextId;
-  readonly #origin: string;
-  readonly #type: RealmType;
-  readonly #sandbox: string | undefined;
-  readonly #cdpSessionId: string;
-  readonly #cdpClient: CdpClient;
-
   private constructor(
     realmId: string,
     browsingContextId: string,
@@ -221,9 +221,10 @@ export class Realm {
     _this: Script.ArgumentValue,
     _arguments: Script.ArgumentValue[],
     awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.OwnershipModel,
+    browsingContextStorage: BrowsingContextStorage
   ): Promise<Script.CallFunctionResult> {
-    const context = BrowsingContextStorage.getKnownContext(
+    const context = browsingContextStorage.getKnownContext(
       this.browsingContextId
     );
     await context.awaitUnblocked();
@@ -243,9 +244,10 @@ export class Realm {
   async scriptEvaluate(
     expression: string,
     awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.OwnershipModel,
+    browsingContextStorage: BrowsingContextStorage
   ): Promise<Script.EvaluateResult> {
-    const context = BrowsingContextStorage.getKnownContext(
+    const context = browsingContextStorage.getKnownContext(
       this.browsingContextId
     );
     await context.awaitUnblocked();


### PR DESCRIPTION
As a side effect it is now possible to have multiple
`#BrowsingContextStorage.contexts`.

Furthermore, enforce the `no-extraneous-class` ESLint rule.

The following classes were refactored in order to accommodate that:

- BidiServer
- BrowsingContextImpl
- BrowsingContextProcessor
- EventManager
- Realm
- SubscriptionManager

Bug: https://github.com/GoogleChromeLabs/chromium-bidi/issues/392
Docs: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-extraneous-class.md