### PR TITLE
fix a couple of pytest issues by introducing a pytest.ini file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "e2e-headful": "npm run server-no-build -- --headless=false & npm run e2e-only",
     "e2e-headless": "npm run server-no-build & npm run e2e-only",
     "e2e": "npm run e2e-headless",
-    "e2e-only": "python3 -m pytest --rootdir=tests",
+    "e2e-only": "python3 -m pytest",
     "eslint": "eslint --ext js --ext ts --fix .",
     "format": "npm run eslint && npm run prettier & npm run yapf",
     "prepare": "npm run clean && npm run build",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+# https://docs.pytest.org/en/latest/reference/customize.html
+[pytest]
+minversion = 7.0
+testpaths = tests


### PR DESCRIPTION
- Issue 1: python version mismatch. macOS 13.2 python is 3.9.6. Homebrew python is 3.10.9. If we run our e2e tests with python 3.9.x they fail with the following message:

> AttributeError: module 'pytest_asyncio' has no attribute 'fixture'

This error message is confusing and it's not obvious it is related to the python version. By introducing `minversion = 7.0` in pytest.ini, the error message then becomes

> 'minversion' requires pytest-7.0, actual pytest-6.1.2

...which makes it much clearer it's an issue related to an old pytest version. pytest 7.x matches what is in 'requirements.txt'.

This is relevant because VSCode's integrated terminal and tmux do not pick up custom $PATH settings in the user shell rc file, thus python3 is /usr/bin/python3 instead of /opt/homebrew/bin/python3.

- Issue 2: add `tests` explicitly to `testpaths`, so that there's no need to specify `--rootdir=tests` when running pytest.

This is not only a matter of ergonomics, it also addresses a pytest failure that comes from wpt/:

> _______________________________________ ERROR collecting test session _______________________________________
> Defining 'pytest_plugins' in a non-top-level conftest is no longer supported:
> It affects the entire test suite instead of just below the conftest as expected.
> [...]/chromium-bidi/wpt/infrastructure/webdriver/tests/conftest.py

Docs: https://docs.pytest.org/en/latest/reference/customize.html