### PR TITLE
use puppeteer/browsers to install google chrome in CI and add macOS E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-# This workflow will run headful and headless e2e tests.
+# This workflow will run headful and headless E2E tests.
 
 name: E2E tests
 
@@ -10,19 +10,15 @@ on:
 jobs:
   e2e:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         head: [headful, headless]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install chrome-dev
-        run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-unstable
       - name: Set up node.js
         uses: actions/setup-node@v3
         with:
@@ -30,6 +26,10 @@ jobs:
           cache: npm
       - name: Install and build npm dependencies
         run: npm ci
+      - name: Install Chromium
+        run: |
+          # browsers from @puppeteer/browsers
+          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -37,8 +37,12 @@ jobs:
           cache: pip
       - name: Install Python dependencies
         run: pip install -r tests/requirements.txt
-      - name: Run e2e tests
-        run: CHANNEL=chrome-dev xvfb-run --auto-servernum npm run e2e-${{ matrix.head }}
+      - name: Run E2E tests
+        if: runner.os == 'Linux'
+        run: PUPPETEER_EXECUTABLE_PATH="${{ env.chromium_binary }}" xvfb-run --auto-servernum npm run e2e-${{ matrix.head }}
+      - name: Run E2E tests
+        if: runner.os == 'macOS'
+        run: PUPPETEER_EXECUTABLE_PATH="${{ env.chromium_binary }}" npm run e2e-${{ matrix.head }}
 
 env:
   FORCE_COLOR: 3

--- a/.github/workflows/generate-wpt-report.yml
+++ b/.github/workflows/generate-wpt-report.yml
@@ -43,15 +43,10 @@ jobs:
       - name: Set up hosts
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: wpt
-      # TODO: Install a pinned version of Chromium. This may become possible
-      # after https://github.com/web-platform-tests/wpt/issues/28970.
       - name: Install Chromium
-        # This installs dev chrome to `/usr/bin/google-chrome-unstable`.
         run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-unstable
+          # browsers from @puppeteer/browsers
+          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Run tests
         run: >
           ./wpt/wpt run
@@ -59,6 +54,7 @@ jobs:
           --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
           --webdriver-arg="--log-path=out/chromedriver.log"
           --webdriver-arg="--verbose"
+          --binary ${{ env.chromium_binary }}
           --install-webdriver --channel=dev --yes
           --manifest MANIFEST.json
           --metadata wpt-metadata/chromedriver/headless

--- a/.github/workflows/wpt-chromedriver.yml
+++ b/.github/workflows/wpt-chromedriver.yml
@@ -35,15 +35,10 @@ jobs:
       - name: Set up hosts
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: wpt
-      # TODO: Install a pinned version of Chromium. This may become possible
-      # after https://github.com/web-platform-tests/wpt/issues/28970.
       - name: Install Chromium
-        # This installs dev chrome to `/usr/bin/google-chrome-unstable`.
         run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-unstable
+          # browsers from @puppeteer/browsers
+          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Run tests
         run: >
           ./wpt/wpt run
@@ -51,6 +46,7 @@ jobs:
           --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
           --webdriver-arg="--log-path=out/chromedriver.log"
           --webdriver-arg="--verbose"
+          --binary ${{ env.chromium_binary }}
           --install-webdriver --channel=dev --yes
           --manifest MANIFEST.json
           --metadata wpt-metadata/chromedriver/headless

--- a/.github/workflows/wpt-mapper.yml
+++ b/.github/workflows/wpt-mapper.yml
@@ -48,15 +48,10 @@ jobs:
       - name: Set up hosts
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: wpt
-      # TODO: Install a pinned version of Chromium. This may become possible
-      # after https://github.com/web-platform-tests/wpt/issues/28970.
       - name: Install Chromium
-        # This installs dev chrome to `/usr/bin/google-chrome-unstable`.
         run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-unstable
+          # browsers from @puppeteer/browsers
+          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Run tests
         # For verbose logging, add --log-mach - --log-mach-level info
         run: >
@@ -64,7 +59,7 @@ jobs:
           ./wpt/wpt run
           --webdriver-binary runBiDiServer.sh
           ${{ matrix.wpt_headless_argument }}
-          --binary /usr/bin/google-chrome-unstable
+          --binary ${{ env.chromium_binary }}
           --manifest MANIFEST.json
           --metadata wpt-metadata/mapper/${{ matrix.head }}
           --log-wptreport out/wptreport-mapper.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "mitt": "3.0.0"
       },
       "devDependencies": {
+        "@puppeteer/browsers": "^0.0.5",
         "@rollup/plugin-commonjs": "22.0.0",
         "@rollup/plugin-node-resolve": "13.3.0",
         "@rollup/plugin-terser": "^0.3.0",
@@ -46,7 +47,7 @@
         "sinon": "14.0.0",
         "terser": "5.14.2",
         "tslib": "2.4.0",
-        "typescript": "4.7.2",
+        "typescript": "4.7.4",
         "websocket": "1.0.34",
         "ws": "8.6.0",
         "zod": "3.17.3"
@@ -315,6 +316,77 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.0.5.tgz",
+      "integrity": "sha512-aOgzcFCR1YGD9eVuZY6+/e0E2gALQbX8f1lwicfUbljwtKPEI7ixnnFJOlDFXShnR+FH5zGzIn+dxTNdRewupQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.1"
+      },
+      "bin": {
+        "browsers": "lib/cjs/browsers.js"
+      },
+      "engines": {
+        "node": ">=14.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -5638,9 +5710,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6213,6 +6285,56 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@puppeteer/browsers": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.0.5.tgz",
+      "integrity": "sha512-aOgzcFCR1YGD9eVuZY6+/e0E2gALQbX8f1lwicfUbljwtKPEI7ixnnFJOlDFXShnR+FH5zGzIn+dxTNdRewupQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "yargs": {
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "@rollup/plugin-commonjs": {
@@ -10114,9 +10236,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "devtools-protocol": "*"
   },
   "devDependencies": {
+    "@puppeteer/browsers": "^0.0.5",
     "@rollup/plugin-commonjs": "22.0.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-terser": "^0.3.0",
@@ -68,7 +69,7 @@
     "sinon": "14.0.0",
     "terser": "5.14.2",
     "tslib": "2.4.0",
-    "typescript": "4.7.2",
+    "typescript": "4.7.4",
     "websocket": "1.0.34",
     "ws": "8.6.0",
     "zod": "3.17.3"


### PR DESCRIPTION
Make the installation method platform-agnostic, in order to eventually support running CI on Windows and macOS.

While we're here, add macOS to E2E tests.

Bug: #361
Docs: https://github.com/puppeteer/puppeteer/tree/main/packages/browsers