### PR TITLE
Move ScriptEvaluator.#knownHandlesToRealm to a newly introduced RealmStorage

### DIFF
--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -25,7 +25,16 @@ export enum RealmType {
   window = 'window',
 }
 
-const scriptEvaluator = new ScriptEvaluator();
+export class RealmStorage {
+  /** Keeps track of handles and their realms sent to client. */
+  readonly #knownHandlesToRealm = new Map<string, string>();
+
+  get knownHandlesToRealm() {
+    return this.#knownHandlesToRealm;
+  }
+}
+
+const scriptEvaluator = new ScriptEvaluator(new RealmStorage());
 
 export class Realm {
   static readonly #realmMap: Map<string, Realm> = new Map();


### PR DESCRIPTION
With the intent of making it possible to have multiple realm maps at some point, to support the ability to run multiple bidi sessions simultaneously.

Bug: #392