### PR TITLE
EventEmitter: fix type signature to match mitt's

### DIFF
--- a/src/utils/EventEmitter.spec.ts
+++ b/src/utils/EventEmitter.spec.ts
@@ -21,7 +21,7 @@ import sinon from 'sinon';
 describe('EventEmitter', () => {
   type Events = {
     foo: undefined;
-    bar: undefined;
+    bar: string;
   };
   let emitter: EventEmitter<Events>;
 
@@ -40,9 +40,9 @@ describe('EventEmitter', () => {
 
       it(`${methodName} sends the event data to the handler`, () => {
         const listener = sinon.spy();
-        const data = {};
-        emitter[methodName]('foo', listener);
-        emitter.emit('foo', data);
+        const data = 'data';
+        emitter[methodName]('bar', listener);
+        emitter.emit('bar', data);
         expect(listener.callCount).to.equal(1);
         expect(listener.firstCall.args[0]!).to.equal(data);
       });
@@ -112,7 +112,7 @@ describe('EventEmitter', () => {
     it('passes data through to the listener', () => {
       const listener = sinon.spy();
       emitter.on('foo', listener);
-      const data = {};
+      const data = undefined;
 
       emitter.emit('foo', data);
       expect(listener.callCount).to.equal(1);

--- a/src/utils/EventEmitter.ts
+++ b/src/utils/EventEmitter.ts
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import mitt, {Emitter, EventType, Handler, WildcardHandler} from 'mitt';
 
 export class EventEmitter<Events extends Record<EventType, unknown>> {
@@ -74,7 +73,7 @@ export class EventEmitter<Events extends Record<EventType, unknown>> {
    * @param eventData - any data you'd like to emit with the event
    * @returns `true` if there are any listeners, `false` if there are not.
    */
-  emit(event: EventType, eventData: Events[EventType]): void {
+  emit<Key extends keyof Events>(event: Key, eventData: Events[Key]): void {
     this.#emitter.emit(event, eventData);
   }
 }


### PR DESCRIPTION
Currently there is no type safety when calling `emit`.

Bug: #433