### PR TITLE
npm: always recompile sources upon running unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Verify mapper size
         run: du -sh lib/iife/mapperTab.js
       - name: Run unit tests
-        run: npm run unit
+        run: npm test
 
 env:
   FORCE_COLOR: 3

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ output to the file `log.txt`:
 Running:
 
 ```sh
-npm run unit
+npm test
 ```
 
 ### E2E tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "chai": "4.3.6",
         "chai-as-promised": "7.1.1",
         "chai-exclude": "2.1.0",
-        "cross-env": "7.0.3",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1007249",
         "eslint": "8.24.0",
@@ -1464,24 +1463,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {
@@ -7050,15 +7031,6 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
-      }
-    },
-    "cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.1"
       }
     },
     "cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "rollup": "rollup -c",
     "server": "npm run build && npm run server-no-build --",
     "server-no-build": "node lib/cjs/bidiServer/index.js",
-    "test": "npm run build && npm run unit",
-    "unit": "cross-env TS_NODE_PROJECT='src/tsconfig.json' mocha",
+    "test": "npm run build && mocha",
     "watch": "tsc -b src/tsconfig.json --watch & rollup -c --watch",
     "yapf": "yapf --in-place --parallel --recursive --exclude=wpt examples/ tests/"
   },
@@ -53,7 +52,6 @@
     "chai": "4.3.6",
     "chai-as-promised": "7.1.1",
     "chai-exclude": "2.1.0",
-    "cross-env": "7.0.3",
     "debug": "4.3.4",
     "devtools-protocol": "0.0.1007249",
     "eslint": "8.24.0",


### PR DESCRIPTION
Remove "unit" target, default to standard "test" target. Previously the "unit" target would not recompile sources.

Side effect: It's possible to do "npm test" in lieu of "npm run test".