### PR TITLE
Add mitt as a prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "chromium-bidi",
       "version": "0.4.3",
       "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.0",
         "@rollup/plugin-node-resolve": "13.3.0",
@@ -35,7 +38,6 @@
         "eslint-plugin-mocha": "10.1.0",
         "eslint-plugin-prettier": "4.2.1",
         "gts": "3.1.1",
-        "mitt": "3.0.0",
         "mocha": "10.0.0",
         "prettier": "2.6.2",
         "puppeteer": "19.3.0",
@@ -50,8 +52,7 @@
         "zod": "3.17.3"
       },
       "peerDependencies": {
-        "devtools-protocol": "*",
-        "mitt": "*"
+        "devtools-protocol": "*"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3981,8 +3982,7 @@
     "node_modules/mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "dev": true
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -8874,8 +8874,7 @@
     "mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "dev": true
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mkdirp-classic": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "author": "The Chromium Authors",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "devtools-protocol": "*",
-    "mitt": "*"
+    "devtools-protocol": "*"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.0",
@@ -60,7 +59,6 @@
     "eslint-plugin-mocha": "10.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "gts": "3.1.1",
-    "mitt": "3.0.0",
     "mocha": "10.0.0",
     "prettier": "2.6.2",
     "puppeteer": "19.3.0",
@@ -73,5 +71,8 @@
     "websocket": "1.0.34",
     "ws": "8.6.0",
     "zod": "3.17.3"
+  },
+  "dependencies": {
+    "mitt": "3.0.0"
   }
 }


### PR DESCRIPTION
In Puppeteer we moved away from bundling for now and, thus, mitt would be needed as a prod dependency.