### PR TITLE
upgrade python: 3.9 -> 3.10

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
           cache: 'pip'
       - name: Install Python dependencies
         run: pip install -r tests/requirements.txt

--- a/.github/workflows/generate-wpt-report.yml
+++ b/.github/workflows/generate-wpt-report.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
           cache: 'pip'
       - name: Set up virtualenv
         run: pip install virtualenv

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,5 +16,5 @@ jobs:
       - run: npm ci
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
           cache: 'pip'
       - name: Install Python dependencies
         run: pip install -r tests/requirements.txt

--- a/.github/workflows/wpt-chromedriver.yml
+++ b/.github/workflows/wpt-chromedriver.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
           cache: 'pip'
       - name: Set up virtualenv
         run: pip install virtualenv

--- a/.github/workflows/wpt-mapper.yml
+++ b/.github/workflows/wpt-mapper.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.10'
           cache: 'pip'
       - name: Set up virtualenv
         run: pip install virtualenv


### PR DESCRIPTION
Not sure if this fixes flakiness, but it's worth a try.

On my macOS M1, python 3.9 fails immediately when running those tests. Python 3.10 works (go/bidi-g3doc#e2e)