### PR TITLE
Fix same document navigation race condition

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -330,7 +330,7 @@ export class BrowsingContextImpl {
         }
 
         if (params.name === 'init') {
-          this.#documentMaybeChanged(params.loaderId);
+          this.#documentChanged(params.loaderId);
           this.#targetDefers.documentInitialized.resolve();
         }
 
@@ -435,13 +435,13 @@ export class BrowsingContextImpl {
       : params.context.origin;
   }
 
-  #documentMaybeChanged(loaderId?: string) {
-    if (this.#targetDefers.Page.navigatedWithinDocument.isFinished) {
-      this.#targetDefers.Page.navigatedWithinDocument =
-        new Deferred<Protocol.Page.NavigatedWithinDocumentEvent>();
-    }
-
-    if (this.#loaderId === loaderId || loaderId === undefined) {
+  #documentChanged(loaderId?: string) {
+    // Same document navigation.
+    if (loaderId === undefined || this.#loaderId === loaderId) {
+      if (this.#targetDefers.Page.navigatedWithinDocument.isFinished) {
+        this.#targetDefers.Page.navigatedWithinDocument =
+          new Deferred<Protocol.Page.NavigatedWithinDocumentEvent>();
+      }
       return;
     }
 
@@ -486,7 +486,7 @@ export class BrowsingContextImpl {
       throw new Message.UnknownException(cdpNavigateResult.errorText);
     }
 
-    this.#documentMaybeChanged(cdpNavigateResult.loaderId);
+    this.#documentChanged(cdpNavigateResult.loaderId);
 
     // Wait for `wait` condition.
     switch (wait) {

--- a/wpt-metadata/chromedriver/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,3 @@
+[error.py]
+  [test_invalid_address[port\]]
+    disabled: https://github.com/GoogleChromeLabs/chromium-bidi/issues/463


### PR DESCRIPTION
In case of 2 consequent "same document navigation", the `navigatedWithinDocument` deferred was kept finished instead of being re-created.

This PR should fix the issue and flakiness of e2e tests

