### PR TITLE
chore: Remove +Infinity from SpecialNumber

### DIFF
--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -100,8 +100,6 @@ async function deserializeToCdpArg(
         return {unserializableValue: 'NaN'};
       } else if (argumentValue.value === '-0') {
         return {unserializableValue: '-0'};
-      } else if (argumentValue.value === '+Infinity') {
-        return {unserializableValue: '+Infinity'};
       } else if (argumentValue.value === 'Infinity') {
         return {unserializableValue: 'Infinity'};
       } else if (argumentValue.value === '-Infinity') {

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -75,14 +75,8 @@ export namespace CommonDataTypes {
     value: zod.string(),
   });
 
-  // SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
-  const SpecialNumberSchema = zod.enum([
-    'NaN',
-    '-0',
-    'Infinity',
-    '+Infinity',
-    '-Infinity',
-  ]);
+  // SpecialNumber = "NaN" / "-0" / "Infinity" / "-Infinity";
+  const SpecialNumberSchema = zod.enum(['NaN', '-0', 'Infinity', '-Infinity']);
 
   //
   // NumberValue = {

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -160,13 +160,8 @@ export namespace CommonDataTypes {
     value: string;
   };
 
-  // SpecialNumber = "NaN" / "-0" / "+Infinity" / "-Infinity";
-  export type SpecialNumber =
-    | 'NaN'
-    | '-0'
-    | 'Infinity'
-    | '+Infinity'
-    | '-Infinity';
+  // SpecialNumber = "NaN" / "-0" / "Infinity" / "-Infinity";
+  export type SpecialNumber = 'NaN' | '-0' | 'Infinity' | '-Infinity';
 
   //
   // NumberValue = {


### PR DESCRIPTION
The BiDi spec was updated to only include `Infinity` and `-Infinity`.