### PR TITLE
improve pytest ergonomics with native assertions

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+anys==0.2.1
 pytest==7.2.0
 pytest-asyncio==0.20.2
 pytest-icdiff==0.6

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import pytest
+from anys import ANY_STR
 from test_helpers import *
 
 
@@ -86,15 +87,14 @@ async def test_browsingContext_noInitialLoadEvents(websocket):
 
     # Wait for the navigated page to be loaded.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            'method': 'browsingContext.load',
-            'params': {
-                'context': context_id,
-                'navigation': navigation,
-                'url': url
-            }
-        }, resp)
+    assert {
+        'method': 'browsingContext.load',
+        'params': {
+            'context': context_id,
+            'navigation': navigation,
+            'url': url
+        }
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -202,19 +202,18 @@ async def test_browsingContext_getTreeWithNestedSameOriginContexts_contextsRetur
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [{
-                    "context": any_string,
-                    "url": nested_iframe,
-                    "children": []
-                }],
-                "parent": None,
-                "url": page_with_nested_iframe
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": ANY_STR,
+                "url": nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": page_with_nested_iframe
+        }]
+    } == result
 
 
 # TODO(sadym): make offline.
@@ -239,19 +238,18 @@ async def test_browsingContext_getTreeWithNestedCrossOriginContexts_contextsRetu
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [{
-                    "context": any_string,
-                    "url": nested_iframe,
-                    "children": []
-                }],
-                "parent": None,
-                "url": page_with_nested_iframe
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": ANY_STR,
+                "url": nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": page_with_nested_iframe
+        }]
+    } == result
 
 
 # TODO(sadym): make offline.
@@ -290,19 +288,18 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedCrossOriginConte
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [{
-                    "context": any_string,
-                    "url": another_nested_iframe,
-                    "children": []
-                }],
-                "parent": None,
-                "url": another_page_with_nested_iframe
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": ANY_STR,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": another_page_with_nested_iframe
+        }]
+    } == result
 
 
 @pytest.mark.asyncio
@@ -330,19 +327,18 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_context
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [{
-                    "context": any_string,
-                    "url": nested_iframe,
-                    "children": []
-                }],
-                "parent": None,
-                "url": page_with_nested_iframe
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": ANY_STR,
+                "url": nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": page_with_nested_iframe
+        }]
+    } == result
 
     await execute_command(
         websocket, {
@@ -359,19 +355,18 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_context
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [{
-                    "context": any_string,
-                    "url": another_nested_iframe,
-                    "children": []
-                }],
-                "parent": None,
-                "url": another_page_with_nested_iframe
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [{
+                "context": ANY_STR,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": None,
+            "url": another_page_with_nested_iframe
+        }]
+    } == result
 
 
 @pytest.mark.asyncio
@@ -421,38 +416,35 @@ async def test_browsingContext_create_eventContextCreatedEmitted(
     }
 
     # Assert "browsingContext.contextCreated" event emitted.
-    recursive_compare(
-        {
-            "method": "browsingContext.contextCreated",
-            "params": {
-                "context": new_context_id,
-                "url": "about:blank",
-                "children": None,
-                "parent": None
-            }
-        }, context_created_event)
+    assert {
+        "method": "browsingContext.contextCreated",
+        "params": {
+            "context": new_context_id,
+            "url": "about:blank",
+            "children": None,
+            "parent": None
+        }
+    } == context_created_event
 
     # Assert "browsingContext.domContentLoaded" event emitted.
-    recursive_compare(
-        {
-            "method": "browsingContext.domContentLoaded",
-            "params": {
-                "context": new_context_id,
-                "navigation": any_string,
-                "url": "about:blank"
-            }
-        }, dom_content_loaded_event)
+    assert {
+        "method": "browsingContext.domContentLoaded",
+        "params": {
+            "context": new_context_id,
+            "navigation": ANY_STR,
+            "url": "about:blank"
+        }
+    } == dom_content_loaded_event
 
     # Assert "browsingContext.load" event emitted.
-    recursive_compare(
-        {
-            "method": "browsingContext.load",
-            "params": {
-                "context": new_context_id,
-                "navigation": any_string,
-                "url": "about:blank"
-            }
-        }, load_event)
+    assert {
+        "method": "browsingContext.load",
+        "params": {
+            "context": new_context_id,
+            "navigation": ANY_STR,
+            "url": "about:blank"
+        }
+    } == load_event
 
 
 @pytest.mark.asyncio
@@ -492,28 +484,26 @@ async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCr
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": any_string,
-                "parent": None,
-                "url": top_level_page,
-                "children": [
-                    {
-                        "context": any_string,
+    assert {
+        "contexts": [{
+            "context": ANY_STR,
+            "parent": None,
+            "url": top_level_page,
+            "children": [
+                {
+                    "context": ANY_STR,
+                    # It's not guaranteed the nested page is already loaded.
+                    "url": ANY_STR,
+                    "children": [{
+                        "context": ANY_STR,
                         # It's not guaranteed the nested page is already loaded.
-                        "url": any_string,
-                        "children": [{
-                            "context": any_string,
-                            # It's not guaranteed the nested page is already loaded.
-                            "url": any_string,
-                            "children": []
-                        }]
-                    },
-                ]
-            }]
-        },
-        tree)
+                        "url": ANY_STR,
+                        "children": []
+                    }]
+                },
+            ]
+        }]
+    } == tree
 
     intermediate_page_context_id = tree["contexts"][0]["children"][0][
         "context"]
@@ -815,15 +805,14 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitInteractive_na
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [],
-                "parent": None,
-                "url": url_with_hash_1
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_1
+        }]
+    } == result
 
     resp = await execute_command(
         websocket, {
@@ -843,15 +832,14 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitInteractive_na
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [],
-                "parent": None,
-                "url": url_with_hash_2
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_2
+        }]
+    } == result
 
 
 @pytest.mark.asyncio
@@ -890,15 +878,14 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitComplete_navig
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [],
-                "parent": None,
-                "url": url_with_hash_1
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_1
+        }]
+    } == result
 
     resp = await execute_command(
         websocket, {
@@ -918,15 +905,14 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitComplete_navig
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": context_id,
-                "children": [],
-                "parent": None,
-                "url": url_with_hash_2
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": context_id,
+            "children": [],
+            "parent": None,
+            "url": url_with_hash_2
+        }]
+    } == result
 
 
 @pytest.mark.asyncio

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import ANY
+
 import pytest
+from anys import ANY_DICT, ANY_INT, ANY_NUMBER, ANY_STR
 from test_helpers import *
 
 
@@ -28,7 +31,7 @@ async def test_cdp_sendCommand_commandResultReturned(websocket):
             }
         })
 
-    recursive_compare({"targetInfos": any_value}, command_result)
+    assert {"targetInfos": ANY} == command_result
 
 
 @pytest.mark.asyncio
@@ -58,25 +61,24 @@ async def test_cdp_subscribeCdpEvents_cdpEventReceived(websocket, context_id):
 
     resp = await read_JSON_message(websocket)
 
-    recursive_compare(
-        {
-            "method": "cdp.eventReceived",
-            "params": {
-                "cdpMethod": "Runtime.consoleAPICalled",
-                "cdpParams": {
-                    "type": "log",
-                    "args": [{
-                        "type": "number",
-                        "value": 1,
-                        "description": "1"
-                    }],
-                    "executionContextId": any_value,
-                    "timestamp": any_value,
-                    "stackTrace": any_value
-                },
-                "cdpSession": session_id
-            }
-        }, resp)
+    assert {
+        "method": "cdp.eventReceived",
+        "params": {
+            "cdpMethod": "Runtime.consoleAPICalled",
+            "cdpParams": {
+                "type": "log",
+                "args": [{
+                    "type": "number",
+                    "value": 1,
+                    "description": "1"
+                }],
+                "executionContextId": ANY_INT,
+                "timestamp": ANY_TIMESTAMP,
+                "stackTrace": ANY
+            },
+            "cdpSession": session_id
+        }
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -107,22 +109,21 @@ async def test_cdp_subscribeToAllCdpEvents_cdpEventReceived(
 
     resp = await read_JSON_message(websocket)
 
-    recursive_compare(
-        {
-            "method": "cdp.eventReceived",
-            "params": {
-                "cdpMethod": "Runtime.consoleAPICalled",
-                "cdpParams": {
-                    "type": "log",
-                    "args": [{
-                        "type": "number",
-                        "value": 1,
-                        "description": "1"
-                    }],
-                    "executionContextId": any_value,
-                    "timestamp": any_value,
-                    "stackTrace": any_value
-                },
-                "cdpSession": session_id
-            }
-        }, resp)
+    assert {
+        "method": "cdp.eventReceived",
+        "params": {
+            "cdpMethod": "Runtime.consoleAPICalled",
+            "cdpParams": {
+                "type": "log",
+                "args": [{
+                    "type": "number",
+                    "value": 1,
+                    "description": "1"
+                }],
+                "executionContextId": ANY_INT,
+                "timestamp": ANY_TIMESTAMP,
+                "stackTrace": ANY
+            },
+            "cdpSession": session_id
+        }
+    } == resp

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,6 +15,8 @@
 
 import json
 
+from anys import ANY_NUMBER, ANY_STR, AnyContains, AnyGT, AnyLT
+
 _command_counter = 0
 
 
@@ -44,81 +46,12 @@ async def subscribe(websocket, event_names, context_ids=None, channel=None):
     await execute_command(websocket, command)
 
 
-# Compares 2 objects recursively.
-# Expected value can be a callable delegate, asserting the value.
-def recursive_compare(expected, actual):
-    if callable(expected):
-        return expected(actual)
-    assert type(expected) == type(actual)
-    if type(expected) is list:
-        assert len(expected) == len(actual)
-        for index, val in enumerate(expected):
-            recursive_compare(expected[index], actual[index])
-        return
+ANY_SHARED_ID = ANY_STR & AnyContains("_element_")
 
-    if type(expected) is dict:
-        assert expected.keys() == actual.keys(), \
-            f"Key sets should be the same: " \
-            f"\nNot present: {set(expected.keys()) - set(actual.keys())}" \
-            f"\nUnexpected: {set(actual.keys()) - set(expected.keys())}"
-        for index, val in enumerate(expected):
-            recursive_compare(expected[val], actual[val])
-        return
-
-    assert expected == actual
-
-
-def any_string(actual):
-    assert isinstance(actual, str), \
-        f"'{actual}' should be string, " \
-        f"but is {type(actual)} instead."
-
-
-def string_containing(expected_substring):
-
-    def _(actual):
-        any_string(actual)
-        assert expected_substring in actual, f"'{actual}' should contain " \
-                                             f"{expected_substring}."
-
-    return _
-
-
-def any_shared_id(actual):
-    string_containing("_element_")(actual)
-
-
-def not_one_of(not_expected_list):
-
-    def _not_one_of(actual):
-        for not_expected in not_expected_list:
-            assert actual != not_expected
-
-    return _not_one_of
-
-
-def compare_sorted(key_name, expected):
-
-    def _compare_sorted(actual):
-        recursive_compare(sorted(expected, key=lambda x: x[key_name]),
-                          sorted(actual, key=lambda x: x[key_name]))
-
-    return _compare_sorted
-
-
-def any_timestamp(actual):
-    assert isinstance(actual, int), \
-        f"'{actual}' should be an integer, " \
-        f"but is {type(actual)} instead."
-    # Check if the timestamp has the proper order of magnitude between
-    # "2020-01-01 00:00:00" (1577833200000) and
-    # "2100-01-01 00:00:00" (4102441200000).
-    assert 1577833200000 < actual < 4102441200000, \
-        f"'{actual}' should be in epoch milliseconds format."
-
-
-def any_value(_):
-    return
+# Check if the timestamp has the proper order of magnitude between
+# "2020-01-01 00:00:00" (1577833200000) and
+# "2100-01-01 00:00:00" (4102441200000).
+ANY_TIMESTAMP = ANY_NUMBER & AnyGT(1577833200000) & AnyLT(4102441200000)
 
 
 async def send_JSON_command(websocket, command):

--- a/tests/test_log_events.py
+++ b/tests/test_log_events.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import ANY
+
 import pytest
+from anys import ANY_NUMBER, ANY_STR
 from test_helpers import *
 
 
@@ -92,95 +95,93 @@ async def test_consoleLog_textAndArgs(websocket, context_id):
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert "log.entryAdded" event emitted.
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "params": {
-                # BaseLogEntry
-                "level": "info",
-                "source": {
-                    "realm": any_string,
-                    "context": context_id
-                },
-                "text": "window "
-                        "undefined "
-                        "null "
-                        "42 "
-                        "text "
-                        "false "
-                        "123 "
-                        "/abc/g "
-                        "Array(2) "
-                        "Object(1) "
-                        "Map(1) "
-                        "Set(1)",
-                "timestamp": any_timestamp,
-                "stackTrace": {
-                    "callFrames": [{
-                        "url": "",
-                        "functionName": "",
-                        "lineNumber": 0,
-                        "columnNumber": 8
-                    }]
-                },
-                # ConsoleLogEntry
-                "type": "console",
-                "method": "log",
-                "args": [{
-                    'type': 'window'
-                }, {
-                    'type': 'undefined'
-                }, {
-                    'type': 'null'
-                }, {
-                    'type': 'number',
-                    'value': 42
-                }, {
-                    'type': 'string',
-                    'value': 'text'
-                }, {
-                    'type': 'boolean',
-                    'value': False
-                }, {
-                    "type": "bigint",
-                    "value": "123"
-                }, {
-                    "type": "regexp",
-                    "value": {
-                        "pattern": "abc",
-                        "flags": "g"
-                    }
-                }, {
-                    "type": "array",
-                    "value": [{
-                        "type": "number",
-                        "value": 1
-                    }, {
-                        "type": "string",
-                        "value": "str"
-                    }]
-                }, {
-                    "type": "object",
-                    "value": [["a", {
-                        "type": "number",
-                        "value": 1
-                    }]]
-                }, {
-                    "type": "map",
-                    "value": [["key1", {
-                        "type": "string",
-                        "value": "value1"
-                    }]]
-                }, {
-                    "type": "set",
-                    "value": [{
-                        "type": "string",
-                        "value": "value1"
-                    }]
+    assert {
+        "method": "log.entryAdded",
+        "params": {
+            # BaseLogEntry
+            "level": "info",
+            "source": {
+                "realm": ANY_STR,
+                "context": context_id
+            },
+            "text": "window "
+                    "undefined "
+                    "null "
+                    "42 "
+                    "text "
+                    "false "
+                    "123 "
+                    "/abc/g "
+                    "Array(2) "
+                    "Object(1) "
+                    "Map(1) "
+                    "Set(1)",
+            "timestamp": ANY_TIMESTAMP,
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 0,
+                    "columnNumber": 8
                 }]
-            }
-        },
-        event_response)
+            },
+            # ConsoleLogEntry
+            "type": "console",
+            "method": "log",
+            "args": [{
+                'type': 'window'
+            }, {
+                'type': 'undefined'
+            }, {
+                'type': 'null'
+            }, {
+                'type': 'number',
+                'value': 42
+            }, {
+                'type': 'string',
+                'value': 'text'
+            }, {
+                'type': 'boolean',
+                'value': False
+            }, {
+                "type": "bigint",
+                "value": "123"
+            }, {
+                "type": "regexp",
+                "value": {
+                    "pattern": "abc",
+                    "flags": "g"
+                }
+            }, {
+                "type": "array",
+                "value": [{
+                    "type": "number",
+                    "value": 1
+                }, {
+                    "type": "string",
+                    "value": "str"
+                }]
+            }, {
+                "type": "object",
+                "value": [["a", {
+                    "type": "number",
+                    "value": 1
+                }]]
+            }, {
+                "type": "map",
+                "value": [["key1", {
+                    "type": "string",
+                    "value": "value1"
+                }]]
+            }, {
+                "type": "set",
+                "value": [{
+                    "type": "string",
+                    "value": "value1"
+                }]
+            }]
+        }
+    } == event_response
 
 
 @pytest.mark.asyncio
@@ -348,31 +349,29 @@ async def test_exceptionThrown_logEntryAddedEventEmitted(
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert "log.entryAdded" event emitted.
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "params": {
-                # BaseLogEntry
-                "level": "error",
-                "source": {
-                    "realm": any_string,
-                    "context": context_id
-                },
-                "text": "Error: some error",
-                "timestamp": any_timestamp,
-                "stackTrace": {
-                    "callFrames": [{
-                        "url": "",
-                        "functionName": "",
-                        "lineNumber": 0,
-                        "columnNumber": 14
-                    }]
-                },
-                # ConsoleLogEntry
-                "type": "javascript"
-            }
-        },
-        event_response)
+    assert {
+        "method": "log.entryAdded",
+        "params": {
+            # BaseLogEntry
+            "level": "error",
+            "source": {
+                "realm": ANY_STR,
+                "context": context_id
+            },
+            "text": "Error: some error",
+            "timestamp": ANY_TIMESTAMP,
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 0,
+                    "columnNumber": 14
+                }]
+            },
+            # ConsoleLogEntry
+            "type": "javascript"
+        }
+    } == event_response
 
 
 @pytest.mark.asyncio
@@ -407,12 +406,12 @@ async def test_buffer_bufferedEventsReturned(websocket, context_id):
 
     # Wait for `LOG_ENTRY_1`.
     resp = await read_JSON_message(websocket)
-    recursive_compare({"method": "log.entryAdded", "params": any_value}, resp)
+    assert {"method": "log.entryAdded", "params": ANY} == resp
     assert resp["params"]["text"] == "LOG_ENTRY_1"
 
     # Wait for `LOG_ENTRY_2`.
     resp = await read_JSON_message(websocket)
-    recursive_compare({"method": "log.entryAdded", "params": any_value}, resp)
+    assert {"method": "log.entryAdded", "params": ANY} == resp
     assert resp["params"]["text"] == "LOG_ENTRY_2"
 
     # Wait for subscription command to finish.
@@ -446,33 +445,31 @@ async def test_runtimeException_emitted(websocket, context_id):
 
     # Assert event was emitted before the command is finished.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "params": {
-                "level": "error",
-                "source": {
-                    "realm": any_string,
-                    "context": any_string
-                },
-                "text": f"Error: {error_message}",
-                "timestamp": any_timestamp,
-                "stackTrace": any_value,
-                "type": "javascript"
-            }
-        }, resp)
+    assert {
+        "method": "log.entryAdded",
+        "params": {
+            "level": "error",
+            "source": {
+                "realm": ANY_STR,
+                "context": ANY_STR
+            },
+            "text": f"Error: {error_message}",
+            "timestamp": ANY_TIMESTAMP,
+            "stackTrace": ANY,
+            "type": "javascript"
+        }
+    } == resp
 
     # Assert evaluate command is finished after event emitted.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "id": command_id,
-            "result": {
-                "type": "success",
-                "realm": any_string,
-                "result": any_value
-            }
-        }, resp)
+    assert {
+        "id": command_id,
+        "result": {
+            "type": "success",
+            "realm": ANY_STR,
+            "result": ANY
+        }
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -498,7 +495,7 @@ async def test_runtimeException_buffered(websocket, context_id):
 
     # Assert evaluate command is finished.
     resp = await read_JSON_message(websocket)
-    recursive_compare({"id": command_id, "result": any_value}, resp)
+    assert {"id": command_id, "result": ANY} == resp
 
     # Subscribe to events with buffer.
     subscribe_command_id = await send_JSON_command(websocket, {
@@ -510,22 +507,21 @@ async def test_runtimeException_buffered(websocket, context_id):
 
     # Assert event was emitted.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "params": {
-                "level": "error",
-                "source": {
-                    "realm": any_string,
-                    "context": any_string
-                },
-                "text": f"Error: {error_message}",
-                "timestamp": any_timestamp,
-                "stackTrace": any_value,
-                "type": "javascript"
-            }
-        }, resp)
+    assert {
+        "method": "log.entryAdded",
+        "params": {
+            "level": "error",
+            "source": {
+                "realm": ANY_STR,
+                "context": ANY_STR
+            },
+            "text": f"Error: {error_message}",
+            "timestamp": ANY_TIMESTAMP,
+            "stackTrace": ANY,
+            "type": "javascript"
+        }
+    } == resp
 
     # Assert subscribe command is finished.
     resp = await read_JSON_message(websocket)
-    recursive_compare({"id": subscribe_command_id, "result": {}}, resp)
+    assert {"id": subscribe_command_id, "result": {}} == resp

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import pytest
+from anys import ANY_STR
 from test_helpers import *
 
 
@@ -41,15 +42,14 @@ async def test_nestedBrowsingContext_navigateToPageWithHash_contextInfoUpdated(
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "children": [],
-                "parent": any_string,
-                "url": url_with_hash_1
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": ANY_STR,
+            "url": url_with_hash_1
+        }]
+    } == result
 
 
 @pytest.mark.asyncio
@@ -72,14 +72,13 @@ async def test_nestedBrowsingContext_navigateWaitNone_navigated(
 
     # Assert command done.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "id": 13,
-            "result": {
-                "navigation": any_string,
-                "url": "data:text/html,<h2>test</h2>"
-            }
-        }, resp)
+    assert {
+        "id": 13,
+        "result": {
+            "navigation": ANY_STR,
+            "url": "data:text/html,<h2>test</h2>"
+        }
+    } == resp
 
     navigation_id = resp["result"]["navigation"]
 
@@ -289,15 +288,14 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitInteract
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "children": [],
-                "parent": any_string,
-                "url": url_with_hash_1
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": ANY_STR,
+            "url": url_with_hash_1
+        }]
+    } == result
 
     resp = await execute_command(
         websocket, {
@@ -317,15 +315,14 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitInteract
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "children": [],
-                "parent": any_string,
-                "url": url_with_hash_2
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": ANY_STR,
+            "url": url_with_hash_2
+        }]
+    } == result
 
 
 @pytest.mark.asyncio
@@ -364,15 +361,14 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitComplete
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "children": [],
-                "parent": any_string,
-                "url": url_with_hash_1
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": ANY_STR,
+            "url": url_with_hash_1
+        }]
+    } == result
 
     resp = await execute_command(
         websocket, {
@@ -392,15 +388,14 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitComplete
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "children": [],
-                "parent": any_string,
-                "url": url_with_hash_2
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "children": [],
+            "parent": ANY_STR,
+            "url": url_with_hash_2
+        }]
+    } == result
 
 
 # TODO(sadym): make offline.
@@ -441,19 +436,18 @@ async def test_nestedBrowsingContext_afterNavigation_getTreeWithNestedCrossOrigi
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "children": [{
-                    "context": any_string,
-                    "url": another_nested_iframe,
-                    "children": []
-                }],
-                "parent": any_string,
-                "url": another_page_with_nested_iframe
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "children": [{
+                "context": ANY_STR,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": ANY_STR,
+            "url": another_page_with_nested_iframe
+        }]
+    } == result
 
 
 @pytest.mark.asyncio
@@ -493,16 +487,15 @@ async def test_nestedBrowsingContext_afterNavigation_getTreeWithNestedContexts_c
         }
     })
 
-    recursive_compare(
-        {
-            "contexts": [{
-                "context": iframe_id,
-                "url": another_page_with_nested_iframe,
-                "children": [{
-                    "context": any_string,
-                    "url": another_nested_iframe,
-                    "children": []
-                }],
-                "parent": any_string
-            }]
-        }, result)
+    assert {
+        "contexts": [{
+            "context": iframe_id,
+            "url": another_page_with_nested_iframe,
+            "children": [{
+                "context": ANY_STR,
+                "url": another_nested_iframe,
+                "children": []
+            }],
+            "parent": ANY_STR
+        }]
+    } == result

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import ANY
+
 import pytest
+from anys import ANY_STR
 from test_helpers import *
 
 
@@ -33,48 +36,47 @@ async def test_script_evaluateThrowingPrimitive_exceptionReturned(
             }
         })
 
-    recursive_compare(
-        {
-            "type": "exception",
-            "realm": any_string,
-            "exceptionDetails": {
-                "text": "1",
-                "columnNumber": 19,
-                "lineNumber": 0,
-                "exception": {
-                    "type": "number",
-                    "value": 1
-                },
-                "stackTrace": {
-                    "callFrames": [{
-                        "url": "",
-                        "functionName": "a",
-                        "lineNumber": 0,
-                        "columnNumber": 19
-                    }, {
-                        "url": "",
-                        "functionName": "b",
-                        "lineNumber": 0,
-                        "columnNumber": 43
-                    }, {
-                        "url": "",
-                        "functionName": "c",
-                        "lineNumber": 1,
-                        "columnNumber": 13
-                    }, {
-                        "url": "",
-                        "functionName": "",
-                        "lineNumber": 1,
-                        "columnNumber": 19
-                    }, {
-                        "url": "",
-                        "functionName": "",
-                        "lineNumber": 1,
-                        "columnNumber": 25
-                    }]
-                }
+    assert {
+        "type": "exception",
+        "realm": ANY_STR,
+        "exceptionDetails": {
+            "text": "1",
+            "columnNumber": 19,
+            "lineNumber": 0,
+            "exception": {
+                "type": "number",
+                "value": 1
+            },
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "",
+                    "functionName": "a",
+                    "lineNumber": 0,
+                    "columnNumber": 19
+                }, {
+                    "url": "",
+                    "functionName": "b",
+                    "lineNumber": 0,
+                    "columnNumber": 43
+                }, {
+                    "url": "",
+                    "functionName": "c",
+                    "lineNumber": 1,
+                    "columnNumber": 13
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 19
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 25
+                }]
             }
-        }, result)
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -93,48 +95,47 @@ async def test_script_evaluateThrowingError_exceptionReturned(
             }
         })
 
-    recursive_compare(
-        {
-            "type": "exception",
-            "realm": any_string,
-            "exceptionDetails": {
-                "text": "Error: foo",
-                "columnNumber": 19,
-                "lineNumber": 0,
-                "exception": {
-                    "type": "error",
-                    "handle": any_string
-                },
-                "stackTrace": {
-                    "callFrames": [{
-                        "url": "",
-                        "functionName": "a",
-                        "lineNumber": 0,
-                        "columnNumber": 25
-                    }, {
-                        "url": "",
-                        "functionName": "b",
-                        "lineNumber": 0,
-                        "columnNumber": 58
-                    }, {
-                        "url": "",
-                        "functionName": "c",
-                        "lineNumber": 1,
-                        "columnNumber": 13
-                    }, {
-                        "url": "",
-                        "functionName": "",
-                        "lineNumber": 1,
-                        "columnNumber": 19
-                    }, {
-                        "url": "",
-                        "functionName": "",
-                        "lineNumber": 1,
-                        "columnNumber": 25
-                    }]
-                }
+    assert {
+        "type": "exception",
+        "realm": ANY_STR,
+        "exceptionDetails": {
+            "text": "Error: foo",
+            "columnNumber": 19,
+            "lineNumber": 0,
+            "exception": {
+                "type": "error",
+                "handle": ANY_STR
+            },
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "",
+                    "functionName": "a",
+                    "lineNumber": 0,
+                    "columnNumber": 25
+                }, {
+                    "url": "",
+                    "functionName": "b",
+                    "lineNumber": 0,
+                    "columnNumber": 58
+                }, {
+                    "url": "",
+                    "functionName": "c",
+                    "lineNumber": 1,
+                    "columnNumber": 13
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 19
+                }, {
+                    "url": "",
+                    "functionName": "",
+                    "lineNumber": 1,
+                    "columnNumber": 25
+                }]
             }
-        }, exception_details)
+        }
+    } == exception_details
 
 
 @pytest.mark.asyncio
@@ -154,15 +155,14 @@ async def test_script_evaluateDontWaitPromise_promiseReturned(
         })
 
     # Compare ignoring `handle`.
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "promise",
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "promise",
+            "handle": ANY_STR
+        }
+    } == result
 
 
 # Uncomment after behaviour is clarified:
@@ -205,15 +205,14 @@ async def test_script_evaluateWaitPromise_resultReturned(
         })
 
     # Compare ignoring `handle`.
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "SOME_RESULT"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "SOME_RESULT"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -245,19 +244,18 @@ async def test_script_evaluateChangingObject_resultObjectDidNotChange(
         })
 
     # Verify the object wasn't changed.
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "object",
-                "value": [["i", {
-                    "type": "number",
-                    "value": 0
-                }]],
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "object",
+            "value": [["i", {
+                "type": "number",
+                "value": 0
+            }]],
+            "handle": ANY_STR
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -277,15 +275,14 @@ async def test_script_evaluateInteractsWithDom_resultReceived(
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "!!@@##, about:blank"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "!!@@##, about:blank"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -310,22 +307,21 @@ async def test_script_callFunctionWithArgs_resultReturn(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "array",
-                "value": [{
-                    "type": 'string',
-                    "value": 'ARGUMENT_STRING_VALUE'
-                }, {
-                    "type": 'number',
-                    "value": 42
-                }],
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "array",
+            "value": [{
+                "type": 'string',
+                "value": 'ARGUMENT_STRING_VALUE'
+            }, {
+                "type": 'number',
+                "value": 42
+            }],
+            "handle": ANY_STR
+        }
+    } == result
 
 
 # Uncomment after behaviour is clarified:
@@ -348,7 +344,7 @@ async def test_script_callFunctionWithArgs_resultReturn(websocket, context_id):
 #             "target": {"context": context_id}}})
 #
 #     recursiveCompare({
-#         "handle": any_string,
+#         "handle": ANY_STR,
 #         "type": "object",
 #         "value": [[
 #             "then", {
@@ -379,15 +375,14 @@ async def test_script_callFunctionWithArgsAndDoNotAwaitPromise_promiseReturn(
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "promise",
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "promise",
+            "handle": ANY_STR
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -424,15 +419,14 @@ async def test_script_callFunctionWithRemoteValueArgument_resultReturn(
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "SOME_VALUE"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "SOME_VALUE"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -455,15 +449,14 @@ async def test_script_callFunctionWithAsyncArrowFunctionAndAwaitPromise_resultRe
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "SOME_VALUE"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "SOME_VALUE"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -486,15 +479,14 @@ async def test_script_callFunctionWithAsyncArrowFunctionAndAwaitPromiseFalse_pro
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "promise",
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "promise",
+            "handle": ANY_STR
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -517,15 +509,14 @@ async def test_script_callFunctionWithAsyncClassicFunctionAndAwaitPromise_result
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "SOME_VALUE"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "SOME_VALUE"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -548,15 +539,14 @@ async def test_script_callFunctionWithAsyncClassicFunctionAndAwaitPromiseFalse_p
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "promise",
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "promise",
+            "handle": ANY_STR
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -579,15 +569,14 @@ async def test_script_callFunctionWithArrowFunctionAndThisParameter_thisIsIgnore
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "Window"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "Window"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -610,15 +599,14 @@ async def test_script_callFunctionWithClassicFunctionAndThisParameter_thisIsUsed
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "Number"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "Number"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -643,15 +631,14 @@ async def test_script_callFunctionWithClassicFunctionAndThisParameter_thisIsUsed
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "number",
-                "value": 42
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "number",
+            "value": 42
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -694,15 +681,14 @@ async def test_script_callFunctionWithNode_resultReceived(
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "string",
-                "value": "!!@@##, test"
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "string",
+            "value": "!!@@##, test"
+        }
+    } == result
 
 
 @pytest.mark.asyncio
@@ -720,15 +706,14 @@ async def test_script_evaluate_windowOpen_windowOpened(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "realm": any_string,
-            "result": {
-                "type": "window",
-                "handle": any_string
-            }
-        }, result)
+    assert {
+        "type": "success",
+        "realm": ANY_STR,
+        "result": {
+            "type": "window",
+            "handle": ANY_STR
+        }
+    } == result
 
     result = await execute_command(websocket, {
         "method": "browsingContext.getTree",
@@ -756,15 +741,14 @@ async def test_scriptEvaluate_realm(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "string",
-                "value": "bar"
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "string",
+            "value": "bar"
+        },
+        "realm": ANY_STR
+    } == result
 
     realm = result["realm"]
 
@@ -782,15 +766,14 @@ async def test_scriptEvaluate_realm(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "string",
-                "value": "bar"
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "string",
+            "value": "bar"
+        },
+        "realm": ANY_STR
+    } == result
 
     # Throw an exception in the sandbox.
     result = await execute_command(
@@ -808,12 +791,11 @@ async def test_scriptEvaluate_realm(websocket, context_id):
         })
 
     # Assert result contains realm.
-    recursive_compare(
-        {
-            "type": "exception",
-            "exceptionDetails": any_value,
-            "realm": realm
-        }, result)
+    assert {
+        "type": "exception",
+        "exceptionDetails": ANY,
+        "realm": realm
+    } == result
 
 
 @pytest.mark.asyncio
@@ -834,15 +816,14 @@ async def test_scriptCallFunction_realm(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "string",
-                "value": "bar"
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "string",
+            "value": "bar"
+        },
+        "realm": ANY_STR
+    } == result
 
     realm = result["realm"]
 
@@ -861,15 +842,14 @@ async def test_scriptCallFunction_realm(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "string",
-                "value": "bar"
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "string",
+            "value": "bar"
+        },
+        "realm": ANY_STR
+    } == result
 
     # Throw an exception in the sandbox.
     result = await execute_command(
@@ -887,12 +867,11 @@ async def test_scriptCallFunction_realm(websocket, context_id):
         })
 
     # Assert result contains realm.
-    recursive_compare(
-        {
-            "type": "exception",
-            "exceptionDetails": any_value,
-            "realm": realm
-        }, result)
+    assert {
+        "type": "exception",
+        "exceptionDetails": ANY,
+        "realm": realm
+    } == result
 
 
 @pytest.mark.asyncio
@@ -902,15 +881,14 @@ async def test_scriptGetRealms(websocket, context_id):
         "params": {}
     })
 
-    recursive_compare(
-        {
-            "realms": [{
-                "realm": any_string,
-                "origin": "null",
-                "type": "window",
-                "context": context_id
-            }]
-        }, result)
+    assert {
+        "realms": [{
+            "realm": ANY_STR,
+            "origin": "null",
+            "type": "window",
+            "context": context_id
+        }]
+    } == result
 
     old_realm = result["realms"][0]["realm"]
 
@@ -938,22 +916,23 @@ async def test_scriptGetRealms(websocket, context_id):
         "params": {}
     })
 
+    assert ["realms"] == list(result.keys())
+
     # Assert 2 realms are created.
-    recursive_compare(
-        {
-            "realms": compare_sorted("realm", [{
-                "realm": old_realm,
-                "origin": "null",
-                "type": "window",
-                "context": context_id
-            }, {
-                "realm": sandbox_realm,
-                "origin": "null",
-                "type": "window",
-                "sandbox": "some_sandbox",
-                "context": context_id
-            }])
-        }, result)
+    realm_key = lambda x: x["realm"]
+    assert sorted([{
+        "realm": old_realm,
+        "origin": "null",
+        "type": "window",
+        "context": context_id
+    }, {
+        "realm": sandbox_realm,
+        "origin": "null",
+        "type": "window",
+        "sandbox": "some_sandbox",
+        "context": context_id
+    }],
+                  key=realm_key) == sorted(result["realms"], key=realm_key)
 
     # Assert closing browsing context destroys its realms.
     await execute_command(websocket, {
@@ -969,7 +948,7 @@ async def test_scriptGetRealms(websocket, context_id):
     })
 
     # Assert no more realms existed.
-    recursive_compare({"realms": []}, result)
+    assert {"realms": []} == result
 
 
 @pytest.mark.asyncio
@@ -986,16 +965,15 @@ async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):
                 "resultOwnership": "root"
             }
         })
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "object",
-                "value": any_value,
-                "handle": any_string
-            },
-            "realm": default_realm
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "object",
+            "value": ANY,
+            "handle": ANY_STR
+        },
+        "realm": default_realm
+    } == result
 
     handle = result["result"]["handle"]
 
@@ -1015,15 +993,14 @@ async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "object",
-                "value": any_value
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "object",
+            "value": ANY
+        },
+        "realm": ANY_STR
+    } == result
 
     # Disown in the wrong realm does not have any effect.
     result = await execute_command(
@@ -1037,7 +1014,7 @@ async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):
             }
         })
 
-    recursive_compare({}, result)
+    assert {} == result
 
     # Assert the object is not disposed.
     result = await execute_command(
@@ -1056,15 +1033,14 @@ async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "object",
-                "value": any_value
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "object",
+            "value": ANY
+        },
+        "realm": ANY_STR
+    } == result
 
     # Disown the object in proper realm.
     result = await execute_command(
@@ -1078,7 +1054,7 @@ async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):
             }
         })
 
-    recursive_compare({}, result)
+    assert {} == result
 
     # Assert the object is disposed.
     with pytest.raises(Exception) as exception_info:
@@ -1098,8 +1074,7 @@ async def test_disown_releasesObject(websocket, default_realm, sandbox_realm):
                 }
             })
 
-    recursive_compare(
-        {
-            "error": "invalid argument",
-            "message": "Handle was not found."
-        }, exception_info.value.args[0])
+    assert {
+        "error": "invalid argument",
+        "message": "Handle was not found."
+    } == exception_info.value.args[0]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -16,6 +16,7 @@
 import copy
 
 import pytest
+from anys import ANY_STR
 from test_helpers import *
 
 
@@ -53,13 +54,13 @@ async def assert_serialization(websocket, context_id, js_str_object,
         expected_serialized_object)
     resp = await read_JSON_message(websocket)
     assert resp["method"] == "log.entryAdded"
-    recursive_compare(expected_serialized_object_without_handle,
-                      resp["params"]["args"][0])
+    assert expected_serialized_object_without_handle == resp["params"]["args"][
+        0]
 
     # Assert result serialized properly.
     resp = await read_JSON_message(websocket)
     assert resp["id"] == command_id
-    recursive_compare(expected_serialized_object, resp["result"]["result"])
+    assert expected_serialized_object == resp["result"]["result"]
 
     resp = await execute_command(
         websocket, {
@@ -75,8 +76,7 @@ async def assert_serialization(websocket, context_id, js_str_object,
         })
 
     # Assert exception serialized properly.
-    recursive_compare(expected_serialized_object,
-                      resp["exceptionDetails"]["exception"])
+    assert expected_serialized_object == resp["exceptionDetails"]["exception"]
 
 
 async def assert_callFunction_deserialization_serialization(
@@ -113,12 +113,12 @@ async def assert_callFunction_deserialization_serialization(
         expected_serialized_object)
     resp = await read_JSON_message(websocket)
     assert resp["method"] == "log.entryAdded"
-    recursive_compare(expected_serialized_object_without_handle,
-                      resp["params"]["args"][0])
+    assert expected_serialized_object_without_handle == resp["params"]["args"][
+        0]
 
     resp = await read_JSON_message(websocket)
     assert resp["id"] == command_id
-    recursive_compare(expected_serialized_object, resp["result"]["result"])
+    assert expected_serialized_object == resp["result"]["result"]
 
     resp = await execute_command(
         websocket, {
@@ -136,8 +136,7 @@ async def assert_callFunction_deserialization_serialization(
                 "resultOwnership": "root"
             }
         })
-    recursive_compare(expected_serialized_object,
-                      resp["exceptionDetails"]["exception"])
+    assert expected_serialized_object == resp["exceptionDetails"]["exception"]
 
 
 @pytest.mark.asyncio
@@ -187,31 +186,31 @@ async def test_serialization_deserialization(websocket, context_id,
 @pytest.mark.parametrize("jsString, excepted_serialized",
                          [("function(){}", {
                              "type": "function",
-                             "handle": any_string
+                             "handle": ANY_STR
                          }),
                           ("Promise.resolve(1)", {
                               "type": "promise",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("new WeakMap()", {
                               "type": "weakmap",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("new WeakSet()", {
                               "type": "weakset",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("new Proxy({}, {})", {
                               "type": "proxy",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("new Int32Array()", {
                               "type": "typedarray",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("{'foo': {'bar': 'baz'}, 'qux': 'quux'}", {
                               "type": "object",
-                              "handle": any_string,
+                              "handle": ANY_STR,
                               "value": [["foo", {
                                   "type": "object"
                               }], ["qux", {
@@ -221,7 +220,7 @@ async def test_serialization_deserialization(websocket, context_id,
                           }),
                           ("[1, 'a', {foo: 'bar'}, [2,[3,4]]]", {
                               "type": "array",
-                              "handle": any_string,
+                              "handle": ANY_STR,
                               "value": [{
                                   "type": "number",
                                   "value": 1
@@ -236,7 +235,7 @@ async def test_serialization_deserialization(websocket, context_id,
                           }),
                           ("new Set([1, 'a', {foo: 'bar'}, [2,[3,4]]])", {
                               "type": "set",
-                              "handle": any_string,
+                              "handle": ANY_STR,
                               "value": [{
                                   "type": "number",
                                   "value": 1
@@ -251,15 +250,15 @@ async def test_serialization_deserialization(websocket, context_id,
                           }),
                           ("Symbol('foo')", {
                               "type": "symbol",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("this.window", {
                               "type": "window",
-                              "handle": any_string
+                              "handle": ANY_STR
                           }),
                           ("new Error('Woops!')", {
                               "type": "error",
-                              "handle": any_string
+                              "handle": ANY_STR
                           })])
 async def test_serialization_function(websocket, context_id, jsString,
                                       excepted_serialized):
@@ -284,7 +283,7 @@ async def test_serialization_function(websocket, context_id, jsString,
                   }]]
     }, {
         "type": "object",
-        "handle": any_string,
+        "handle": ANY_STR,
         "value": [["foo", {
             "type": "object"
         }], ["qux", {
@@ -307,7 +306,7 @@ async def test_serialization_function(websocket, context_id, jsString,
                   }]]
     }, {
         "type": "map",
-        "handle": any_string,
+        "handle": ANY_STR,
         "value": [["foo", {
             "type": "object"
         }], ["qux", {
@@ -326,7 +325,7 @@ async def test_serialization_function(websocket, context_id, jsString,
         }]
     }, {
         "type": "array",
-        "handle": any_string,
+        "handle": ANY_STR,
         "value": [{
             "type": "number",
             "value": 1
@@ -346,7 +345,7 @@ async def test_serialization_function(websocket, context_id, jsString,
         }]
     }, {
         "type": "set",
-        "handle": any_string,
+        "handle": ANY_STR,
         "value": [{
             "type": "number",
             "value": 1.23
@@ -363,7 +362,7 @@ async def test_serialization_function(websocket, context_id, jsString,
         }
     }, {
         "type": "regexp",
-        "handle": any_string,
+        "handle": ANY_STR,
         "value": {
             "pattern": "ab+c",
             "flags": "i"
@@ -425,38 +424,37 @@ async def test_serialization_node(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "node",
-            "value": {
-                "nodeType": 1,
-                "sharedId": any_shared_id,
-                "localName": "div",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "childNodeCount": 2,
-                "attributes": {
-                    "some_attr_name": "some_attr_value"
-                },
-                "children": [{
-                    "type": "node",
-                    "value": {
-                        "nodeType": 3,
-                        "nodeValue": "some text",
-                        "sharedId": any_shared_id,
-                    }
-                }, {
-                    "type": "node",
-                    "value": {
-                        "nodeType": 1,
-                        "sharedId": any_shared_id,
-                        "localName": "h2",
-                        "namespaceURI": "http://www.w3.org/1999/xhtml",
-                        "childNodeCount": 1,
-                        "attributes": {}
-                    }
-                }]
-            }
-        }, result["result"])
+    assert {
+        "type": "node",
+        "value": {
+            "nodeType": 1,
+            "sharedId": ANY_SHARED_ID,
+            "localName": "div",
+            "namespaceURI": "http://www.w3.org/1999/xhtml",
+            "childNodeCount": 2,
+            "attributes": {
+                "some_attr_name": "some_attr_value"
+            },
+            "children": [{
+                "type": "node",
+                "value": {
+                    "nodeType": 3,
+                    "nodeValue": "some text",
+                    "sharedId": ANY_SHARED_ID,
+                }
+            }, {
+                "type": "node",
+                "value": {
+                    "nodeType": 1,
+                    "sharedId": ANY_SHARED_ID,
+                    "localName": "h2",
+                    "namespaceURI": "http://www.w3.org/1999/xhtml",
+                    "childNodeCount": 1,
+                    "attributes": {}
+                }
+            }]
+        }
+    } == result["result"]
 
 
 # Verify node nested in other data structures are serialized with the proper
@@ -489,20 +487,19 @@ async def test_serialization_nested_node(websocket, context_id, eval_delegate,
             }
         })
 
-    recursive_compare(
-        {
-            "type": "node",
-            "value": {
-                "nodeType": 1,
-                "localName": "div",
-                "namespaceURI": "http://www.w3.org/1999/xhtml",
-                "childNodeCount": 2,
-                "attributes": {
-                    "some_attr_name": "some_attr_value"
-                },
-                "sharedId": any_shared_id
-            }
-        }, extract_delegate(result["result"]))
+    assert {
+        "type": "node",
+        "value": {
+            "nodeType": 1,
+            "localName": "div",
+            "namespaceURI": "http://www.w3.org/1999/xhtml",
+            "childNodeCount": 2,
+            "attributes": {
+                "some_attr_name": "some_attr_value"
+            },
+            "sharedId": ANY_SHARED_ID
+        }
+    } == extract_delegate(result["result"])
 
 
 @pytest.mark.asyncio
@@ -545,17 +542,16 @@ async def test_deserialization_nestedObjectInObject(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "object",
-                "value": [["nested_object", {
-                    "type": "object"
-                }]]
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "object",
+            "value": [["nested_object", {
+                "type": "object"
+            }]]
+        },
+        "realm": ANY_STR
+    } == result
 
 
 @pytest.mark.asyncio
@@ -593,17 +589,16 @@ async def test_deserialization_nestedObjectInArray(websocket, context_id):
             }
         })
 
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "array",
-                "value": [{
-                    "type": "object"
-                }]
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "array",
+            "value": [{
+                "type": "object"
+            }]
+        },
+        "realm": ANY_STR
+    } == result
 
 
 @pytest.mark.asyncio
@@ -652,15 +647,14 @@ async def test_deserialization_handleAndValue(websocket, context_id):
         })
 
     # Assert the `type` and `value` were ignored.
-    recursive_compare(
-        {
-            "type": "success",
-            "result": {
-                "type": "object",
-                "value": [["a", {
-                    "type": "number",
-                    "value": 1
-                }]]
-            },
-            "realm": any_string
-        }, result)
+    assert {
+        "type": "success",
+        "result": {
+            "type": "object",
+            "value": [["a", {
+                "type": "number",
+                "value": 1
+            }]]
+        },
+        "realm": ANY_STR
+    } == result

--- a/tests/test_shared_id.py
+++ b/tests/test_shared_id.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import pytest
+from anys import AnyContains
 from test_helpers import *
 
 
@@ -186,11 +187,10 @@ async def test_sharedId_in_different_navigable(websocket, context_id):
                 }
             })
 
-    recursive_compare(
-        {
-            "error": "no such node",
-            "message": string_containing("different document")
-        }, exception_info.value.args[0])
+    assert {
+        "error": "no such node",
+        "message": AnyContains("different document")
+    } == exception_info.value.args[0]
 
 
 @pytest.mark.asyncio
@@ -231,8 +231,7 @@ async def test_sharedId_not_found(websocket, context_id):
                 }
             })
 
-    recursive_compare(
-        {
-            "error": "no such node",
-            "message": string_containing("was not found")
-        }, exception_info.value.args[0])
+    assert {
+        "error": "no such node",
+        "message": AnyContains("was not found")
+    } == exception_info.value.args[0]

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import ANY
+
 import pytest
+from anys import ANY_DICT, ANY_STR
 from test_helpers import *
 
 
@@ -28,11 +31,10 @@ async def test_subscribeForUnknownContext_exceptionReturned(websocket):
                     "contexts": ["UNKNOWN_CONTEXT_ID"]
                 }
             })
-    recursive_compare(
-        {
-            'error': 'no such frame',
-            'message': 'Context UNKNOWN_CONTEXT_ID not found'
-        }, exception_info.value.args[0])
+    assert {
+        'error': 'no such frame',
+        'message': 'Context UNKNOWN_CONTEXT_ID not found'
+    } == exception_info.value.args[0]
 
 
 @pytest.mark.asyncio
@@ -115,16 +117,15 @@ async def test_subscribeWithContext_subscribesToEventsInNestedContext(
 
     # Wait for `browsingContext.load` event.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "browsingContext.contextCreated",
-            "params": {
-                "context": any_string,
-                "url": "about:blank",
-                "children": None,
-                "parent": context_id
-            }
-        }, resp)
+    assert {
+        "method": "browsingContext.contextCreated",
+        "params": {
+            "context": ANY_STR,
+            "url": "about:blank",
+            "children": None,
+            "parent": context_id
+        }
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -146,10 +147,10 @@ async def test_subscribeToNestedContext_subscribesToTopLevelContext(
 
     # Assert event received.
     resp = await read_JSON_message(websocket)
-    recursive_compare({
+    assert {
         "method": "log.entryAdded",
-        "params": any_value,
-    }, resp)
+        "params": ANY,
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -180,7 +181,7 @@ async def test_subscribeToNestedContextAndUnsubscribeFromTopLevelContext_unsubsc
 
     # Assert evaluate script is ended without any events before.
     resp = await read_JSON_message(websocket)
-    recursive_compare({'id': command_id, 'result': any_value}, resp)
+    assert {'id': command_id, 'result': ANY} == resp
 
     # Assert unsubscribed from nested context.
     command_id = await send_JSON_command(
@@ -197,7 +198,7 @@ async def test_subscribeToNestedContextAndUnsubscribeFromTopLevelContext_unsubsc
 
     # Assert evaluate script is ended without any events before.
     resp = await read_JSON_message(websocket)
-    recursive_compare({'id': command_id, 'result': any_value}, resp)
+    assert {'id': command_id, 'result': ANY} == resp
 
 
 @pytest.mark.asyncio
@@ -228,7 +229,7 @@ async def test_subscribeToTopLevelContextAndUnsubscribeFromNestedContext_unsubsc
 
     # Assert evaluate script is ended without any events before.
     resp = await read_JSON_message(websocket)
-    recursive_compare({'id': command_id, 'result': any_value}, resp)
+    assert {'id': command_id, 'result': ANY} == resp
 
     # Assert unsubscribed from nested context.
     command_id = await send_JSON_command(
@@ -245,7 +246,7 @@ async def test_subscribeToTopLevelContextAndUnsubscribeFromNestedContext_unsubsc
 
     # Assert evaluate script is ended without any events before.
     resp = await read_JSON_message(websocket)
-    recursive_compare({'id': command_id, 'result': any_value}, resp)
+    assert {'id': command_id, 'result': ANY} == resp
 
 
 @pytest.mark.asyncio
@@ -344,12 +345,11 @@ async def test_subscribeToOneChannel_eventReceivedWithProperChannel(
 
     # Assert event received in `CHANNEL_2`.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "params": any_value,
-            "channel": "CHANNEL_2"
-        }, resp)
+    assert {
+        "method": "log.entryAdded",
+        "params": ANY_DICT,
+        "channel": "CHANNEL_2"
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -404,31 +404,28 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
 
     # Empty string channel is considered as no channel provided.
     resp = await read_JSON_message(websocket)
-    recursive_compare({"method": "log.entryAdded", "params": any_value}, resp)
+    assert {"method": "log.entryAdded", "params": ANY_DICT} == resp
 
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "channel": channel_2,
-            "params": any_value
-        }, resp)
+    assert {
+        "method": "log.entryAdded",
+        "channel": channel_2,
+        "params": ANY_DICT
+    } == resp
 
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "channel": channel_3,
-            "params": any_value
-        }, resp)
+    assert {
+        "method": "log.entryAdded",
+        "channel": channel_3,
+        "params": ANY_DICT
+    } == resp
 
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "channel": channel_4,
-            "params": any_value
-        }, resp)
+    assert {
+        "method": "log.entryAdded",
+        "channel": channel_4,
+        "params": ANY_DICT
+    } == resp
 
 
 @pytest.mark.asyncio
@@ -477,27 +474,27 @@ async def test_subscribeWithoutContext_bufferedEventsFromNotClosedContextsAreRet
 
     # Assert only message from not closed context is received.
     resp = await read_JSON_message(websocket)
-    recursive_compare(
-        {
-            "method": "log.entryAdded",
-            "params": {
-                "level": "info",
-                "source": {
-                    "realm": any_value,
-                    "context": context_id
-                },
-                "text": "SOME_MESSAGE",
-                "timestamp": any_value,
-                "stackTrace": any_value,
-                "type": "console",
-                "method": "log",
-                "args": [{
-                    "type": "string",
-                    "value": "SOME_MESSAGE"
-                }]
-            }
-        }, resp)
+
+    assert {
+        "method": "log.entryAdded",
+        "params": {
+            "level": "info",
+            "source": {
+                "realm": ANY,
+                "context": context_id
+            },
+            "text": "SOME_MESSAGE",
+            "timestamp": ANY_TIMESTAMP,
+            "stackTrace": ANY,
+            "type": "console",
+            "method": "log",
+            "args": [{
+                "type": "string",
+                "value": "SOME_MESSAGE"
+            }]
+        }
+    } == resp
 
     # Assert no more events were buffered.
     resp = await read_JSON_message(websocket)
-    recursive_compare({'id': command_id, 'result': any_value}, resp)
+    assert {'id': command_id, 'result': ANY} == resp


### PR DESCRIPTION
- introduce and use `anys` pytest matchers
- use native assert comparisons instead of custom `recursive_compare`
- use type comparisons instead of `any_value` in some circumstances

Reference: https://github.com/jwodder/anys

As of now:

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/2840106/220808861-62c79836-f37c-4006-ab65-055525ac88ae.png">

With Anys, but without icdiff:

<img width="2558" alt="image" src="https://user-images.githubusercontent.com/2840106/220808358-8e077007-47e2-4b82-bd6e-33af169f422a.png">

With this PR (=Anys + icdiff):

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/2840106/220808380-f1caf76d-e66e-4132-8b52-1f81b95f744b.png">
