### PR TITLE
Fix Realm's `navigableId`

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -403,9 +403,9 @@ export class BrowsingContextImpl {
         }
         const realm = new Realm(
           this.#realmStorage,
+          this.#browsingContextStorage,
           params.context.uniqueId,
           this.contextId,
-          this.navigableId ?? 'UNKNOWN',
           params.context.id,
           this.#getOrigin(params),
           // TODO: differentiate types.

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -260,8 +260,7 @@ export class BrowsingContextProcessor {
     return await realm.scriptEvaluate(
       params.expression,
       params.awaitPromise,
-      params.resultOwnership ?? 'none',
-      this.#browsingContextStorage
+      params.resultOwnership ?? 'none'
     );
   }
 
@@ -292,8 +291,7 @@ export class BrowsingContextProcessor {
       }, // `this` is `undefined` by default.
       params.arguments || [], // `arguments` is `[]` by default.
       params.awaitPromise,
-      params.resultOwnership ?? 'none',
-      this.#browsingContextStorage
+      params.resultOwnership ?? 'none'
     );
   }
 

--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -57,7 +57,7 @@ async function deserializeToCdpArg(
 
     if (realm.navigableId !== navigableId) {
       throw new Message.NoSuchNodeException(
-        `SharedId "${argumentValue.sharedId}" belongs to different document.`
+        `SharedId "${argumentValue.sharedId}" belongs to different document. Current document is ${realm.navigableId}.`
       );
     }
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -231,6 +231,21 @@ async def read_JSON_message(websocket):
     return json.loads(await websocket.recv())
 
 
+# Sets the current page content without navigation.
+async def set_html_content(websocket, context_id, html_content):
+    await execute_command(
+        websocket, {
+            "method": "script.evaluate",
+            "params": {
+                "expression": f"document.body.innerHTML = '{html_content}'",
+                "target": {
+                    "context": context_id,
+                },
+                "awaitPromise": True
+            }
+        })
+
+
 # Open given URL in the given context.
 async def goto_url(websocket, context_id, url):
     await execute_command(

--- a/tests/test_shared_id.py
+++ b/tests/test_shared_id.py
@@ -35,6 +35,48 @@ async def test_sharedId_in_same_realm_same_navigable(websocket, context_id):
         })
 
     shared_id = result["result"]["value"]["sharedId"]
+    assert "UNKNOWN" not in shared_id
+
+    result = await execute_command(
+        websocket, {
+            "method": "script.callFunction",
+            "params": {
+                "functionDeclaration": "(arg)=>arg",
+                "this": {
+                    "type": "undefined"
+                },
+                "arguments": [{
+                    "sharedId": shared_id
+                }],
+                "awaitPromise": False,
+                "target": {
+                    "context": context_id
+                }
+            }
+        })
+
+    assert result["type"] == "success"
+    assert result["result"]["value"]["sharedId"] == shared_id
+
+
+@pytest.mark.asyncio
+async def test_sharedId_without_navigation(websocket, context_id):
+    await set_html_content(websocket, context_id, "<div>some text</div>")
+
+    result = await execute_command(
+        websocket, {
+            "method": "script.evaluate",
+            "params": {
+                "expression": "document.querySelector('body > div');",
+                "target": {
+                    "context": context_id
+                },
+                "awaitPromise": True
+            }
+        })
+
+    shared_id = result["result"]["value"]["sharedId"]
+    assert "UNKNOWN" not in shared_id
 
     result = await execute_command(
         websocket, {


### PR DESCRIPTION
Addressing [4373 - Fix loader id information in the ids generated by BiDiMapper - chromedriver](https://crbug.com/chromedriver/4373).
At the moment the `realm` (`executionContext`) is created, there is no `navigableId` (`loaderId`) yet. Get the current `navigableId` on-demand from the `browsingContext` (`target`). The problem disappears after first navigation.