### PR TITLE
_command_counter: start from 1 instead of 2

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,7 +19,7 @@ import os
 import pytest_asyncio
 import websockets
 
-_command_counter = 1
+_command_counter = 0
 
 
 def get_next_command_id():

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -281,6 +281,7 @@ async def test_subscribeWithContext_doesNotSubscribeToEventsInAnotherContexts(
 
     # 3.2 Navigate second context.
     command_id_2 = get_next_command_id()
+    assert command_id_1 != command_id_2
     await send_JSON_command(
         websocket, {
             "id": command_id_2,


### PR DESCRIPTION
The fact it starts from 2 today seems to have been a tiny mistake.