### PR TITLE
python: do not use wildcard imports

### DIFF
--- a/examples/classic_to_bidi_example.py
+++ b/examples/classic_to_bidi_example.py
@@ -19,10 +19,11 @@
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 
 import requests
-from _helpers import *
+from _helpers import get_webdriver_session, run_and_wait_command, websockets
 
 logging.basicConfig(
     format="%(message)s",

--- a/examples/console_log_example.py
+++ b/examples/console_log_example.py
@@ -18,7 +18,8 @@
 import asyncio
 import logging
 
-from _helpers import *
+from _helpers import (get_websocket, read_JSON_message, run_and_wait_command,
+                      send_JSON_command)
 
 logging.basicConfig(
     format="%(message)s",

--- a/examples/script_example.py
+++ b/examples/script_example.py
@@ -22,7 +22,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from _helpers import *
+from _helpers import get_websocket, run_and_wait_command
 
 logging.basicConfig(
     format="%(message)s",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import os
 
 import pytest_asyncio
 import websockets
-from test_helpers import *
+from test_helpers import execute_command, goto_url
 
 
 @pytest_asyncio.fixture

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -15,7 +15,8 @@
 
 import pytest
 from anys import ANY_STR
-from test_helpers import *
+from test_helpers import (execute_command, read_JSON_message,
+                          send_JSON_command, subscribe, wait_for_event)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -17,7 +17,8 @@ from unittest.mock import ANY
 
 import pytest
 from anys import ANY_DICT, ANY_INT, ANY_NUMBER, ANY_STR
-from test_helpers import *
+from test_helpers import (ANY_TIMESTAMP, execute_command, read_JSON_message,
+                          send_JSON_command, subscribe)
 
 
 @pytest.mark.asyncio

--- a/tests/test_log_events.py
+++ b/tests/test_log_events.py
@@ -17,7 +17,8 @@ from unittest.mock import ANY
 
 import pytest
 from anys import ANY_NUMBER, ANY_STR
-from test_helpers import *
+from test_helpers import (ANY_TIMESTAMP, read_JSON_message, send_JSON_command,
+                          subscribe, wait_for_event)
 
 
 @pytest.mark.asyncio

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -15,7 +15,8 @@
 
 import pytest
 from anys import ANY_STR
-from test_helpers import *
+from test_helpers import (execute_command, read_JSON_message,
+                          send_JSON_command, subscribe)
 
 
 @pytest.mark.asyncio

--- a/tests/test_protocol_basics.py
+++ b/tests/test_protocol_basics.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import pytest
-from test_helpers import *
+from test_helpers import json, read_JSON_message, send_JSON_command
 
 # Tests for "handle an incoming message" error handling, when the message
 # can't be decoded as known command.

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import pytest
-from test_helpers import *
+from test_helpers import execute_command
 
 
 async def _evaluate(script, sandbox, context_id, websocket):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -17,7 +17,7 @@ from unittest.mock import ANY
 
 import pytest
 from anys import ANY_STR
-from test_helpers import *
+from test_helpers import execute_command, goto_url
 
 
 @pytest.mark.asyncio

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -17,7 +17,8 @@ import copy
 
 import pytest
 from anys import ANY_STR
-from test_helpers import *
+from test_helpers import (ANY_SHARED_ID, execute_command, goto_url,
+                          read_JSON_message, send_JSON_command, subscribe)
 
 
 def _strip_handle(obj):

--- a/tests/test_shared_id.py
+++ b/tests/test_shared_id.py
@@ -15,7 +15,7 @@
 
 import pytest
 from anys import AnyContains
-from test_helpers import *
+from test_helpers import execute_command, goto_url, set_html_content
 
 
 @pytest.mark.asyncio

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -17,7 +17,8 @@ from unittest.mock import ANY
 
 import pytest
 from anys import ANY_DICT, ANY_STR
-from test_helpers import *
+from test_helpers import (ANY_TIMESTAMP, execute_command, get_next_command_id,
+                          read_JSON_message, send_JSON_command, subscribe)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
https://docs.python.org/3/faq/programming.html?highlight=faq#what-are-the-best-practices-for-using-import-in-a-module:

> In general, don’t use from modulename import *. Doing so clutters the
importer’s namespace, and makes it much harder for linters to detect undefined names.

Reference: https://www.asmeurer.com/removestar/