### PR TITLE
make session.unsubscribe command atomic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "name": "Run Server",
       "skipFiles": ["<node_internals>/**"],
@@ -24,7 +24,6 @@
       "request": "launch",
       "name": "Mocha Tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [],
       "internalConsoleOptions": "openOnSessionStart",
       "env": {
         "TS_NODE_PROJECT": "${workspaceFolder}/src/tsconfig.json"

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -190,19 +190,11 @@ export class EventManager implements IEventManager {
     contextIds: (CommonDataTypes.BrowsingContext | null)[],
     channel: string | null
   ): Promise<void> {
-    // First check if all the contexts are known.
-    for (const contextId of contextIds) {
-      if (contextId !== null) {
-        // Assert the context is known. Throw exception otherwise.
-        this.#bidiServer.getBrowsingContextStorage().getKnownContext(contextId);
-      }
-    }
-
-    for (const eventName of eventNames) {
-      for (const contextId of contextIds) {
-        this.#subscriptionManager.unsubscribe(eventName, contextId, channel);
-      }
-    }
+    await this.#subscriptionManager.unsubscribeAll(
+      eventNames,
+      contextIds,
+      channel
+    );
   }
 
   /**

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -190,11 +190,7 @@ export class EventManager implements IEventManager {
     contextIds: (CommonDataTypes.BrowsingContext | null)[],
     channel: string | null
   ): Promise<void> {
-    await this.#subscriptionManager.unsubscribeAll(
-      eventNames,
-      contextIds,
-      channel
-    );
+    this.#subscriptionManager.unsubscribeAll(eventNames, contextIds, channel);
   }
 
   /**

--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -21,23 +21,26 @@ import {SubscriptionManager} from './SubscriptionManager.js';
 import sinon from 'sinon';
 
 const expect = chai.expect;
+
 const ALL_EVENTS = BrowsingContext.AllEvents;
 const SOME_EVENT = BrowsingContext.EventNames.LoadEvent;
 const ANOTHER_EVENT = BrowsingContext.EventNames.ContextCreatedEvent;
 const YET_ANOTHER_EVENT = BrowsingContext.EventNames.DomContentLoadedEvent;
+
 const SOME_CONTEXT = 'SOME_CONTEXT';
 const SOME_NESTED_CONTEXT = 'SOME_NESTED_CONTEXT';
 const ANOTHER_CONTEXT = 'ANOTHER_CONTEXT';
 const ANOTHER_NESTED_CONTEXT = 'ANOTHER_NESTED_CONTEXT';
+
 const SOME_CHANNEL = 'SOME_CHANNEL';
 const ANOTHER_CHANNEL = 'ANOTHER_CHANNEL';
 
 describe('test SubscriptionManager', () => {
   let subscriptionManager: SubscriptionManager;
+
   beforeEach(() => {
-    const browsingContextStorage = sinon.createStubInstance(
-      BrowsingContextStorage
-    ) as BrowsingContextStorage;
+    const browsingContextStorage: BrowsingContextStorage =
+      sinon.createStubInstance(BrowsingContextStorage);
     browsingContextStorage.findContext = sinon
       .stub()
       .callsFake((contextId: string) => {
@@ -52,80 +55,7 @@ describe('test SubscriptionManager', () => {
 
     subscriptionManager = new SubscriptionManager(browsingContextStorage);
   });
-  describe('with null context', () => {
-    it('should send proper event in any context', () => {
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          SOME_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([SOME_CHANNEL]);
-    });
-    it('should not send wrong event', () => {
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          ANOTHER_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([]);
-    });
-    it('should unsubscribe', () => {
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          SOME_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([]);
-    });
-    it('should not unsubscribe specific context subscription', () => {
-      subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          SOME_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([SOME_CHANNEL]);
-    });
-    it('should subscribe in proper order', () => {
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          SOME_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
-    });
-    it('should re-subscribe in proper order', () => {
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
-      subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          SOME_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([ANOTHER_CHANNEL, SOME_CHANNEL]);
-    });
-    it('should re-subscribe global and specific context in proper order', () => {
-      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
-      subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
-      subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
-      expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
-          SOME_EVENT,
-          SOME_CONTEXT
-        )
-      ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
-    });
-  });
+
   it('should re-subscribe global and specific event in proper order', () => {
     subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
     subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
@@ -156,6 +86,88 @@ describe('test SubscriptionManager', () => {
       )
     ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
   });
+
+  describe('with null context', () => {
+    it('should send proper event in any context', () => {
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          SOME_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([SOME_CHANNEL]);
+    });
+
+    it('should not send wrong event', () => {
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          ANOTHER_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([]);
+    });
+
+    it('should unsubscribe', () => {
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          SOME_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([]);
+    });
+
+    it('should not unsubscribe specific context subscription', () => {
+      subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          SOME_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([SOME_CHANNEL]);
+    });
+
+    it('should subscribe in proper order', () => {
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          SOME_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
+    });
+
+    it('should re-subscribe in proper order', () => {
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
+      subscriptionManager.unsubscribe(SOME_EVENT, null, SOME_CHANNEL);
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          SOME_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([ANOTHER_CHANNEL, SOME_CHANNEL]);
+    });
+
+    it('should re-subscribe global and specific context in proper order', () => {
+      subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
+      subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);
+      subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
+      expect(
+        subscriptionManager.getChannelsSubscribedToEvent(
+          SOME_EVENT,
+          SOME_CONTEXT
+        )
+      ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
+    });
+  });
+
   describe('with some context', () => {
     it('should send proper event in proper context', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
@@ -166,6 +178,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([SOME_CHANNEL]);
     });
+
     it('should not send proper event in wrong context', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       expect(
@@ -175,6 +188,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([]);
     });
+
     it('should not send wrong event in proper context', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       expect(
@@ -184,6 +198,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([]);
     });
+
     it('should unsubscribe', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.unsubscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
@@ -194,6 +209,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([]);
     });
+
     it('should unsubscribe the domain', () => {
       subscriptionManager.subscribe(ALL_EVENTS, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.unsubscribe(ALL_EVENTS, SOME_CONTEXT, SOME_CHANNEL);
@@ -204,6 +220,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([]);
     });
+
     it('should not unsubscribe the domain if not subscribed', () => {
       subscriptionManager.subscribe(ALL_EVENTS, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.unsubscribe(ALL_EVENTS, SOME_CONTEXT, SOME_CHANNEL);
@@ -214,6 +231,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([]);
     });
+
     it('should not unsubscribe global subscription', () => {
       subscriptionManager.subscribe(SOME_EVENT, null, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
@@ -225,6 +243,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([SOME_CHANNEL]);
     });
+
     it('should subscribe in proper order', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, ANOTHER_CHANNEL);
@@ -235,6 +254,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([SOME_CHANNEL, ANOTHER_CHANNEL]);
     });
+
     it('should re-subscribe in proper order', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, ANOTHER_CHANNEL);
@@ -247,6 +267,7 @@ describe('test SubscriptionManager', () => {
         )
       ).to.deep.equal([ANOTHER_CHANNEL, SOME_CHANNEL]);
     });
+
     it('should re-subscribe global and specific context in proper order', () => {
       subscriptionManager.subscribe(SOME_EVENT, SOME_CONTEXT, SOME_CHANNEL);
       subscriptionManager.subscribe(SOME_EVENT, null, ANOTHER_CHANNEL);

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -26,6 +26,43 @@ import {
 import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 import InvalidArgumentException = Message.InvalidArgumentException;
 
+/**
+ * Returns the cartesian product of the given arrays.
+ *
+ * Example:
+ *   cartesian([1, 2], ['a', 'b']); => [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
+ */
+function cartesianProduct(...a: any[][]) {
+  return a.reduce((a: unknown[], b: unknown[]) =>
+    a.flatMap((d: unknown) => b.map((e: unknown) => [d, e].flat()))
+  );
+}
+
+/** Expands "AllEvents" events into atomic events. */
+function unrollEvents(
+  events: Session.SubscribeParametersEvent[]
+): Session.SubscribeParametersEvent[] {
+  const allEvents: Session.SubscribeParametersEvent[] = [];
+
+  for (const event of events) {
+    switch (event) {
+      case BrowsingContext.AllEvents:
+        allEvents.push(...Object.values(BrowsingContext.EventNames));
+        break;
+      case CDP.AllEvents:
+        allEvents.push(...Object.values(CDP.EventNames));
+        break;
+      case Log.AllEvents:
+        allEvents.push(...Object.values(Log.EventNames));
+        break;
+      default:
+        allEvents.push(event);
+    }
+  }
+
+  return allEvents;
+}
+
 export class SubscriptionManager {
   #subscriptionPriority = 0;
   // BrowsingContext `null` means the event has subscription across all the
@@ -158,32 +195,61 @@ export class SubscriptionManager {
     eventMap.set(event, this.#subscriptionPriority++);
   }
 
-  unsubscribe(
+  /**
+   * Unsubscribes atomically from all events in the given contexts and channel.
+   */
+  async unsubscribeAll(
+    eventNames: Session.SubscribeParametersEvent[],
+    contextIds: (CommonDataTypes.BrowsingContext | null)[],
+    channel: string | null
+  ): Promise<void> {
+    // Assert all contexts are known.
+    for (const contextId of contextIds) {
+      if (contextId !== null) {
+        this.#browsingContextStorage.getKnownContext(contextId);
+      }
+    }
+
+    const eventContextPairs: Array<
+      [
+        eventName: Session.SubscribeParametersEvent,
+        contextId: CommonDataTypes.BrowsingContext | null
+      ]
+    > = cartesianProduct(unrollEvents(eventNames), contextIds);
+
+    // Assert all unsubscriptions are valid.
+    // If any of the unsubscriptions are invalid, do not unsubscribe from anything.
+    const unsubscribes: Array<Function> = await Promise.all(
+      eventContextPairs.map(([eventName, contextId]) =>
+        this.#checkUnsubscribe(eventName, contextId, channel)
+      )
+    );
+
+    // Unsubscribe from all.
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe();
+    }
+  }
+
+  /**
+   * Unsubscribes from the event in the given context and channel.
+   * Syntactic sugar for "unsubscribeAll".
+   */
+  async unsubscribe(
+    eventName: Session.SubscribeParametersEvent,
+    contextId: CommonDataTypes.BrowsingContext | null,
+    channel: string | null
+  ): Promise<void> {
+    return this.unsubscribeAll([eventName], [contextId], channel);
+  }
+
+  async #checkUnsubscribe(
     event: Session.SubscribeParametersEvent,
     contextId: CommonDataTypes.BrowsingContext | null,
     channel: string | null
-  ): void {
+  ): Promise<Function> {
     // All the subscriptions are handled on the top-level contexts.
     contextId = this.#findTopLevelContextId(contextId);
-
-    if (event === BrowsingContext.AllEvents) {
-      Object.values(BrowsingContext.EventNames).map((specificEvent) =>
-        this.unsubscribe(specificEvent, contextId, channel)
-      );
-      return;
-    }
-    if (event === CDP.AllEvents) {
-      Object.values(CDP.EventNames).map((specificEvent) =>
-        this.unsubscribe(specificEvent, contextId, channel)
-      );
-      return;
-    }
-    if (event === Log.AllEvents) {
-      Object.values(Log.EventNames).map((specificEvent) =>
-        this.unsubscribe(specificEvent, contextId, channel)
-      );
-      return;
-    }
 
     if (!this.#channelToContextToEventMap.has(channel)) {
       throw new InvalidArgumentException(
@@ -205,14 +271,16 @@ export class SubscriptionManager {
       );
     }
 
-    eventMap.delete(event);
+    return () => {
+      eventMap.delete(event);
 
-    // Clean up maps if empty.
-    if (eventMap.size === 0) {
-      contextToEventMap.delete(event);
-    }
-    if (contextToEventMap.size === 0) {
-      this.#channelToContextToEventMap.delete(channel);
-    }
+      // Clean up maps if empty.
+      if (eventMap.size === 0) {
+        contextToEventMap.delete(event);
+      }
+      if (contextToEventMap.size === 0) {
+        this.#channelToContextToEventMap.delete(channel);
+      }
+    };
   }
 }

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -502,7 +502,6 @@ async def test_subscribeWithoutContext_bufferedEventsFromNotClosedContextsAreRet
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="#482")
 async def test_unsubscribeIsAtomic(websocket, context_id, iframe_id):
     await subscribe(websocket, "log.entryAdded", iframe_id)
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/session/unsubscribe/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/session/unsubscribe/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_unsubscribe_from_one_event_and_then_from_module]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/session/unsubscribe/invalid.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/session/unsubscribe/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_unsubscribe_from_one_event_and_then_from_module]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/session/unsubscribe/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/session/unsubscribe/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_unsubscribe_from_one_event_and_then_from_module]
-    expected: FAIL


### PR DESCRIPTION
If an operation failed for some reason (not subscribed, browsing context not found, etc), do not unsubscribe partially.

Closes #482