### PR TITLE
miscellaneous protocol improvements

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -42,9 +42,9 @@ export interface BidiParser {
   parseDisownParams(params: object): Script.DisownParameters;
   parseSendCommandParams(params: object): CDP.SendCommandParams;
   parseGetSessionParams(params: object): CDP.GetSessionParams;
+  parseSubscribeParams(params: object): Session.SubscribeParameters;
   parseNavigateParams(params: object): BrowsingContext.NavigateParameters;
   parseGetTreeParams(params: object): BrowsingContext.GetTreeParameters;
-  parseSubscribeParams(params: object): Session.SubscribeParameters;
   parseCreateParams(params: object): BrowsingContext.CreateParameters;
   parseCloseParams(params: object): BrowsingContext.CloseParameters;
 }
@@ -68,14 +68,14 @@ class BidiNoOpParser implements BidiParser {
   parseGetSessionParams(params: object): CDP.GetSessionParams {
     return params as CDP.GetSessionParams;
   }
+  parseSubscribeParams(params: object): Session.SubscribeParameters {
+    return params as Session.SubscribeParameters;
+  }
   parseNavigateParams(params: object): BrowsingContext.NavigateParameters {
     return params as BrowsingContext.NavigateParameters;
   }
   parseGetTreeParams(params: object): BrowsingContext.GetTreeParameters {
     return params as BrowsingContext.GetTreeParameters;
-  }
-  parseSubscribeParams(params: object): Session.SubscribeParameters {
-    return params as Session.SubscribeParameters;
   }
   parseCreateParams(params: object): BrowsingContext.CreateParameters {
     return params as BrowsingContext.CreateParameters;

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -287,14 +287,14 @@ class BidiParserImpl implements BidiParser {
   parseGetSessionParams(params: object): CDP.GetSessionParams {
     return Parser.CDP.parseGetSessionParams(params);
   }
+  parseSubscribeParams(params: object): Session.SubscribeParameters {
+    return Parser.Session.parseSubscribeParams(params);
+  }
   parseNavigateParams(params: object): BrowsingContext.NavigateParameters {
     return Parser.BrowsingContext.parseNavigateParams(params);
   }
   parseGetTreeParams(params: object): BrowsingContext.GetTreeParameters {
     return Parser.BrowsingContext.parseGetTreeParams(params);
-  }
-  parseSubscribeParams(params: object): Session.SubscribeParameters {
-    return Parser.Session.parseSubscribeParams(params);
   }
   parseCreateParams(params: object): BrowsingContext.CreateParameters {
     return Parser.BrowsingContext.parseCreateParams(params);

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -126,7 +126,6 @@ export namespace CommonDataTypes {
   //   RegExpLocalValue //
   //   SetLocalValue //
   // }
-
   // `LocalValue` is a recursive type, so lazy declaration is needed:
   // https://github.com/colinhacks/zod#recursive-types
   export type LocalValue =
@@ -345,7 +344,7 @@ export namespace CommonDataTypes {
     namespaceURI?: string;
     childNodeCount: number;
     children?: [NodeRemoteValue];
-    attributes?: unknown;
+    attributes?: Record<string, string>;
     shadowRoot?: NodeRemoteValue | null;
   };
 
@@ -358,6 +357,7 @@ export namespace CommonDataTypes {
   export type BrowsingContext = zod.infer<typeof BrowsingContextSchema>;
 }
 
+/** @see https://w3c.github.io/webdriver-bidi/#module-script */
 export namespace Script {
   export type Command =
     | EvaluateCommand
@@ -460,7 +460,7 @@ export namespace Script {
 
   export type GetRealmsParameters = zod.infer<typeof GetRealmsParametersSchema>;
 
-  export function parseGetRealmsParams(params: unknown): GetRealmsParameters {
+  export function parseGetRealmsParams(params: object): GetRealmsParameters {
     return parseObject(params, GetRealmsParametersSchema);
   }
 
@@ -516,7 +516,7 @@ export namespace Script {
   });
   export type EvaluateParameters = zod.infer<typeof EvaluateParametersSchema>;
 
-  export function parseEvaluateParams(params: unknown): EvaluateParameters {
+  export function parseEvaluateParams(params: object): EvaluateParameters {
     return parseObject(params, EvaluateParametersSchema);
   }
 
@@ -536,7 +536,7 @@ export namespace Script {
 
   export type DisownParameters = zod.infer<typeof DisownParametersSchema>;
 
-  export function parseDisownParams(params: unknown): DisownParameters {
+  export function parseDisownParams(params: object): DisownParameters {
     return parseObject(params, DisownParametersSchema);
   }
 
@@ -567,7 +567,7 @@ export namespace Script {
   >;
 
   export function parseCallFunctionParams(
-    params: unknown
+    params: object
   ): CallFunctionParameters {
     return parseObject(params, ScriptCallFunctionParametersSchema);
   }
@@ -593,7 +593,7 @@ export namespace Script {
   };
 }
 
-// https://w3c.github.io/webdriver-bidi/#module-browsingContext
+/** @see https://w3c.github.io/webdriver-bidi/#module-browsingContext */
 export namespace BrowsingContext {
   export type Command =
     | GetTreeCommand
@@ -624,7 +624,7 @@ export namespace BrowsingContext {
   });
   export type GetTreeParameters = zod.infer<typeof GetTreeParametersSchema>;
 
-  export function parseGetTreeParams(params: unknown): GetTreeParameters {
+  export function parseGetTreeParams(params: object): GetTreeParameters {
     return parseObject(params, GetTreeParametersSchema);
   }
 
@@ -663,7 +663,7 @@ export namespace BrowsingContext {
   });
   export type NavigateParameters = zod.infer<typeof NavigateParametersSchema>;
 
-  export function parseNavigateParams(params: unknown): NavigateParameters {
+  export function parseNavigateParams(params: object): NavigateParameters {
     return parseObject(params, NavigateParametersSchema);
   }
 
@@ -690,7 +690,7 @@ export namespace BrowsingContext {
   });
   export type CreateParameters = zod.infer<typeof CreateParametersSchema>;
 
-  export function parseCreateParams(params: unknown): CreateParameters {
+  export function parseCreateParams(params: object): CreateParameters {
     return parseObject(params, CreateParametersSchema);
   }
 
@@ -711,13 +711,12 @@ export namespace BrowsingContext {
   });
   export type CloseParameters = zod.infer<typeof CloseParametersSchema>;
 
-  export function parseCloseParams(params: unknown): CloseParameters {
+  export function parseCloseParams(params: object): CloseParameters {
     return parseObject(params, CloseParametersSchema);
   }
 
   export type CloseResult = {result: {}};
 
-  // events
   export type LoadEvent = EventResponse<EventNames.LoadEvent, NavigationInfo>;
 
   export type DomContentLoadedEvent = EventResponse<
@@ -751,7 +750,7 @@ export namespace BrowsingContext {
   }
 }
 
-// https://w3c.github.io/webdriver-bidi/#module-log
+/** @see https://w3c.github.io/webdriver-bidi/#module-log */
 export namespace Log {
   export type LogEntry = GenericLogEntry | ConsoleLogEntry | JavascriptLogEntry;
   export type Event = LogEntryAddedEvent;
@@ -810,7 +809,7 @@ export namespace CDP {
   });
   export type SendCommandParams = zod.infer<typeof SendCommandParamsSchema>;
 
-  export function parseSendCommandParams(params: unknown): SendCommandParams {
+  export function parseSendCommandParams(params: object): SendCommandParams {
     return parseObject(params, SendCommandParamsSchema);
   }
 
@@ -826,7 +825,7 @@ export namespace CDP {
   });
   export type GetSessionParams = zod.infer<typeof GetSessionParamsSchema>;
 
-  export function parseGetSessionParams(params: unknown): GetSessionParams {
+  export function parseGetSessionParams(params: object): GetSessionParams {
     return parseObject(params, GetSessionParamsSchema);
   }
 
@@ -850,6 +849,7 @@ export namespace CDP {
   }
 }
 
+/** @see https://w3c.github.io/webdriver-bidi/#module-session */
 export namespace Session {
   export type Command = StatusCommand | SubscribeCommand | UnsubscribeCommand;
 
@@ -897,7 +897,7 @@ export namespace Session {
   });
   export type SubscribeParameters = zod.infer<typeof SubscribeParametersSchema>;
 
-  export function parseSubscribeParams(params: unknown): SubscribeParameters {
+  export function parseSubscribeParams(params: object): SubscribeParameters {
     return parseObject(params, SubscribeParametersSchema);
   }
 

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -25,6 +25,22 @@ export interface EventResponse<MethodType, ParamsType> {
   params: ParamsType;
 }
 
+export type Method =
+  | 'browsingContext.close'
+  | 'browsingContext.create'
+  | 'browsingContext.getTree'
+  | 'browsingContext.navigate'
+  | 'cdp.getSession'
+  | 'cdp.sendCommand'
+  | 'cdp.sendMessage'
+  | 'script.callFunction'
+  | 'script.disown'
+  | 'script.evaluate'
+  | 'script.getRealms'
+  | 'session.status'
+  | 'session.subscribe'
+  | 'session.unsubscribe';
+
 export namespace Message {
   export type OutgoingMessage =
     | CommandResponse
@@ -33,7 +49,7 @@ export namespace Message {
 
   export type RawCommandRequest = {
     id: number;
-    method: string;
+    method: Method;
     params: object;
     channel?: string;
   };
@@ -206,7 +222,6 @@ export namespace CommonDataTypes {
   //   RegExpLocalValue //
   //   SetLocalValue //
   // }
-
   export type LocalValue =
     | PrimitiveProtocolValue
     | ArrayLocalValue
@@ -390,7 +405,7 @@ export namespace CommonDataTypes {
     namespaceURI?: string;
     childNodeCount: number;
     children?: [NodeRemoteValue];
-    attributes?: unknown;
+    attributes?: Record<string, string>;
     shadowRoot?: NodeRemoteValue | null;
   };
 
@@ -402,6 +417,7 @@ export namespace CommonDataTypes {
   export type BrowsingContext = string;
 }
 
+/** @see https://w3c.github.io/webdriver-bidi/#module-script */
 export namespace Script {
   export type Command =
     | EvaluateCommand
@@ -580,10 +596,10 @@ export namespace Script {
 
   export type CallFunctionParameters = {
     functionDeclaration: string;
+    awaitPromise: boolean;
     target: Target;
     arguments?: ArgumentValue[];
     this?: ArgumentValue;
-    awaitPromise: boolean;
     resultOwnership?: OwnershipModel;
   };
 
@@ -712,7 +728,6 @@ export namespace BrowsingContext {
 
   export type CloseResult = {result: {}};
 
-  // events
   export type LoadEvent = EventResponse<EventNames.LoadEvent, NavigationInfo>;
 
   export type DomContentLoadedEvent = EventResponse<
@@ -746,7 +761,7 @@ export namespace BrowsingContext {
   export const AllEvents = 'browsingContext';
 }
 
-// https://w3c.github.io/webdriver-bidi/#module-log
+/** @see https://w3c.github.io/webdriver-bidi/#module-log */
 export namespace Log {
   export type LogEntry = GenericLogEntry | ConsoleLogEntry | JavascriptLogEntry;
   export type Event = LogEntryAddedEvent;
@@ -833,6 +848,7 @@ export namespace CDP {
   }
 }
 
+/** @see https://w3c.github.io/webdriver-bidi/#module-session */
 export namespace Session {
   export type Command = StatusCommand | SubscribeCommand | UnsubscribeCommand;
 


### PR DESCRIPTION
- ~remove redundant comments, as they are hard to keep up-to-date as the spec evolves: http://go/java-practices/comments#what_for~
- `params: unknown` -> `params: object`
- add type to attributes: from "unknown" to "Record<string, string>" (`?attributes: {*text => text}`)
- add documentation links to all top-level modules
- group methods by module
- introduce a type for all BiDi commands