### PR TITLE
eslint: standardize import order with the import/ autofixer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,10 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-this-alias': 'off',
     'func-names': 'error',
+    'import/first': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-duplicates': 'error',
+    'import/order': ['error', {'newlines-between': 'always'}],
     'no-duplicate-imports': 'error',
     'no-else-return': 'error',
     'no-empty': ['error', {allowEmptyCatch: true}],
@@ -54,7 +58,6 @@ module.exports = {
     'no-underscore-dangle': 'error',
     'prefer-promise-reject-errors': 'error',
     'prefer-template': 'error',
-    'sort-imports': 'error',
     eqeqeq: 'error',
   },
 };

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
+import {EventEmitter} from '../utils/EventEmitter.js';
+import {LoggerFn} from '../utils/log.js';
+import type {Message} from '../protocol/protocol.js';
+import {ProcessingQueue} from '../utils/processingQueue.js';
+
 import {BidiParser, CommandProcessor} from './CommandProcessor.js';
 import {BidiTransport} from './BidiTransport.js';
 import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 import {CdpConnection} from './CdpConnection.js';
-import {EventEmitter} from '../utils/EventEmitter.js';
 import {EventManager} from './domains/events/EventManager.js';
-import {LoggerFn} from '../utils/log.js';
-import type {Message} from '../protocol/protocol.js';
 import {OutgoingBidiMessage} from './OutgoingBidiMessage.js';
-import {ProcessingQueue} from '../utils/processingQueue.js';
 import {RealmStorage} from './domains/script/realmStorage.js';
 
 type BidiServerEvents = {

--- a/src/bidiMapper/CdpConnection.ts
+++ b/src/bidiMapper/CdpConnection.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import {EventEmitter} from '../utils/EventEmitter.js';
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+
+import {EventEmitter} from '../utils/EventEmitter.js';
 
 type CdpEvents = {
   [Property in keyof ProtocolMapping.Events]: ProtocolMapping.Events[Property][0];

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -23,10 +23,11 @@ import {
   Session,
 } from '../protocol/protocol.js';
 import {LogType, LoggerFn} from '../utils/log.js';
+import {EventEmitter} from '../utils/EventEmitter.js';
+
 import {BrowsingContextProcessor} from './domains/context/browsingContextProcessor.js';
 import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 import {CdpConnection} from './CdpConnection.js';
-import {EventEmitter} from '../utils/EventEmitter.js';
 import {IEventManager} from './domains/events/EventManager.js';
 import {OutgoingBidiMessage} from './OutgoingBidiMessage.js';
 import {RealmStorage} from './domains/script/realmStorage.js';

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
+import {Protocol} from 'devtools-protocol';
+
 import {BrowsingContext, Message} from '../../../protocol/protocol.js';
 import {LogType, LoggerFn} from '../../../utils/log.js';
-import {BrowsingContextStorage} from './browsingContextStorage.js';
 import {CdpClient} from '../../CdpConnection.js';
 import {Deferred} from '../../../utils/deferred.js';
 import {IEventManager} from '../events/EventManager.js';
 import {LogManager} from '../log/logManager.js';
-import {Protocol} from 'devtools-protocol';
 import {Realm} from '../script/realm.js';
 import {RealmStorage} from '../script/realmStorage.js';
+
+import {BrowsingContextStorage} from './browsingContextStorage.js';
 
 export class BrowsingContextImpl {
   readonly #targetDefers = {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import Protocol from 'devtools-protocol';
+
 import {
   BrowsingContext,
   CDP,
@@ -22,12 +24,12 @@ import {
 } from '../../../protocol/protocol.js';
 import {CdpClient, CdpConnection} from '../../CdpConnection.js';
 import {LogType, LoggerFn} from '../../../utils/log.js';
-import {BrowsingContextImpl} from './browsingContextImpl.js';
-import {BrowsingContextStorage} from './browsingContextStorage.js';
 import {IEventManager} from '../events/EventManager.js';
-import Protocol from 'devtools-protocol';
 import {Realm} from '../script/realm.js';
 import {RealmStorage} from '../script/realmStorage.js';
+
+import {BrowsingContextStorage} from './browsingContextStorage.js';
+import {BrowsingContextImpl} from './browsingContextImpl.js';
 
 export class BrowsingContextProcessor {
   readonly #browsingContextStorage: BrowsingContextStorage;

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import {BrowsingContextImpl} from './browsingContextImpl.js';
 import {Message} from '../../../protocol/protocol.js';
+
+import {BrowsingContextImpl} from './browsingContextImpl.js';
 
 export class BrowsingContextStorage {
   readonly #contexts = new Map<string, BrowsingContextImpl>();

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -24,6 +24,7 @@ import type {BidiServer} from '../../BidiServer.js';
 import {Buffer} from '../../../utils/buffer.js';
 import {IdWrapper} from '../../../utils/idWrapper.js';
 import {OutgoingBidiMessage} from '../../OutgoingBidiMessage.js';
+
 import {SubscriptionManager} from './SubscriptionManager.js';
 
 class EventWrapper extends IdWrapper {

--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -16,14 +16,16 @@
  */
 
 import * as chai from 'chai';
+import sinon from 'sinon';
+
 import {BrowsingContext, CDP, Log} from '../../../protocol/protocol.js';
+import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+
 import {
   SubscriptionManager,
   cartesianProduct,
   unrollEvents,
 } from './SubscriptionManager.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
-import sinon from 'sinon';
 
 const expect = chai.expect;
 

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -24,6 +24,7 @@ import {
   Session,
 } from '../../../protocol/protocol.js';
 import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+
 import InvalidArgumentException = Message.InvalidArgumentException;
 
 /**

--- a/src/bidiMapper/domains/log/logHelper_getRemoteValuesText.spec.ts
+++ b/src/bidiMapper/domains/log/logHelper_getRemoteValuesText.spec.ts
@@ -16,7 +16,9 @@
  */
 
 import * as chai from 'chai';
+
 import type {CommonDataTypes} from '../../../protocol/protocol.js';
+
 import {getRemoteValuesText} from './logHelper.js';
 
 const expect = chai.expect;

--- a/src/bidiMapper/domains/log/logHelper_logMessageFormatter.spec.ts
+++ b/src/bidiMapper/domains/log/logHelper_logMessageFormatter.spec.ts
@@ -16,7 +16,9 @@
  */
 
 import * as chai from 'chai';
+
 import type {CommonDataTypes} from '../../../protocol/protocol.js';
+
 import {logMessageFormatter} from './logHelper.js';
 
 const expect = chai.expect;

--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -14,12 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {Protocol} from 'devtools-protocol';
+
 import {CommonDataTypes, Log, Script} from '../../../protocol/protocol.js';
 import {CdpClient} from '../../CdpConnection.js';
 import {IEventManager} from '../events/EventManager.js';
-import {Protocol} from 'devtools-protocol';
 import {Realm} from '../script/realm.js';
 import {RealmStorage} from '../script/realmStorage.js';
+
 import {getRemoteValuesText} from './logHelper.js';
 
 /** Converts CDP StackTrace object to Bidi StackTrace object. */

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
+import {Protocol} from 'devtools-protocol';
+
 import {CommonDataTypes, Script} from '../../../protocol/protocol.js';
+import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import {CdpClient} from '../../CdpConnection.js';
+
 import {
   SHARED_ID_DIVIDER,
   ScriptEvaluator,
   stringifyObject,
 } from './scriptEvaluator.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
-import {CdpClient} from '../../CdpConnection.js';
-import {Protocol} from 'devtools-protocol';
 import {RealmStorage} from './realmStorage.js';
 
 export type RealmType = Script.RealmType;

--- a/src/bidiMapper/domains/script/realmStorage.ts
+++ b/src/bidiMapper/domains/script/realmStorage.ts
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Realm, RealmType} from './realm.js';
-import {Message} from '../../../protocol/protocol.js';
 import {Protocol} from 'devtools-protocol';
+
+import {Message} from '../../../protocol/protocol.js';
+
+import {Realm, RealmType} from './realm.js';
 
 type RealmFilter = {
   realmId?: string;

--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -14,8 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {CommonDataTypes, Message, Script} from '../../../protocol/protocol.js';
 import {Protocol} from 'devtools-protocol';
+
+import {CommonDataTypes, Message, Script} from '../../../protocol/protocol.js';
+
 import {Realm} from './realm.js';
 
 // As `script.evaluate` wraps call into serialization script, `lineNumber`

--- a/src/bidiServer/bidiServerRunner.ts
+++ b/src/bidiServer/bidiServerRunner.ts
@@ -14,10 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ITransport} from '../utils/transport.js';
-import debug from 'debug';
 import http from 'http';
+
+import debug from 'debug';
 import websocket from 'websocket';
+
+import {ITransport} from '../utils/transport.js';
 
 const log = debug('bidiServer:log');
 const debugInternal = debug('bidiServer:internal');

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -15,13 +15,15 @@
  * limitations under the License.
  */
 
-import {BidiServerRunner} from './bidiServerRunner.js';
-import {ITransport} from '../utils/transport.js';
-import {MapperServer} from './mapperServer.js';
 import argparse from 'argparse';
 import debug from 'debug';
-import mapperReader from './mapperReader.js';
 import puppeteer from 'puppeteer';
+
+import {ITransport} from '../utils/transport.js';
+
+import {BidiServerRunner} from './bidiServerRunner.js';
+import {MapperServer} from './mapperServer.js';
+import mapperReader from './mapperReader.js';
 
 const log = debug('bidiServer:log');
 

--- a/src/bidiServer/mapperServer.ts
+++ b/src/bidiServer/mapperServer.ts
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import {CdpClient, CdpConnection, WebSocketTransport} from '../cdp/index.js';
 import Protocol from 'devtools-protocol';
 import WebSocket from 'ws';
 import debug from 'debug';
+
+import {CdpClient, CdpConnection, WebSocketTransport} from '../cdp/index.js';
 
 const debugInternal = debug('bidiMapper:internal');
 const debugLog = debug('bidiMapper:log');

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -25,7 +25,6 @@ import type {
   Script,
   Session,
 } from '../protocol/protocol';
-import {generatePage, log} from './mapperTabPage.js';
 import {BidiParser} from '../bidiMapper/CommandProcessor.js';
 import {BidiServer} from '../bidiMapper/BidiServer.js';
 import {BidiTransport} from '../bidiMapper/bidiMapper.js';
@@ -33,6 +32,8 @@ import {CdpConnection} from '../cdp/index.js';
 import {ITransport} from '../utils/transport.js';
 import {LogType} from '../utils/log.js';
 import {OutgoingBidiMessage} from '../bidiMapper/OutgoingBidiMessage.js';
+
+import {generatePage, log} from './mapperTabPage.js';
 
 declare global {
   interface Window {

--- a/src/cdp/cdpClient.spec.ts
+++ b/src/cdp/cdpClient.spec.ts
@@ -17,10 +17,11 @@
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
-import {CdpConnection} from './cdpConnection.js';
 import {Protocol} from 'devtools-protocol';
-import {StubTransport} from './stubTransport.spec.js';
 import chaiAsPromised from 'chai-as-promised';
+
+import {CdpConnection} from './cdpConnection.js';
+import {StubTransport} from './stubTransport.spec.js';
 
 chai.use(chaiAsPromised);
 

--- a/src/cdp/cdpClient.ts
+++ b/src/cdp/cdpClient.ts
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import {CdpConnection} from './cdpConnection.js';
+import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+
 import {EventEmitter} from '../utils/EventEmitter.js';
 
-import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
+import {CdpConnection} from './cdpConnection.js';
 
 type Mapping = {
   [Property in keyof ProtocolMapping.Events]: ProtocolMapping.Events[Property][0];

--- a/src/cdp/cdpConnection.spec.ts
+++ b/src/cdp/cdpConnection.spec.ts
@@ -17,10 +17,11 @@
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+
 import {CdpConnection} from './cdpConnection.js';
 import {StubTransport} from './stubTransport.spec.js';
 
-import chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 
 const SOME_SESSION_ID = 'ABCD';

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {ITransport} from '../utils/transport.js';
+
 import {CdpClient, createClient} from './cdpClient.js';
 import {CdpMessage} from './cdpMessage.js';
-import {ITransport} from '../utils/transport.js';
 
 interface CdpCallbacks {
   resolve: (messageObj: object) => void;

--- a/src/cdp/stubTransport.spec.ts
+++ b/src/cdp/stubTransport.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import {SinonSpy, assert, spy} from 'sinon';
+
 import {ITransport} from '../utils/transport.js';
 
 type TypedSpy<T extends (...args: any[]) => unknown> = SinonSpy<

--- a/src/cdp/websocketTransport.ts
+++ b/src/cdp/websocketTransport.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import {ITransport} from '../utils/transport.js';
 import WebSocket from 'ws';
+
+import {ITransport} from '../utils/transport.js';
 
 export class WebSocketTransport implements ITransport {
   #onMessage: ((message: string) => void) | null = null;

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -20,10 +20,11 @@
  * Parser types should match the `../protocol` types.
  */
 
-const MAX_INT = 9007199254740991 as const;
+import {ZodType, z as zod} from 'zod';
 
 import {EventResponse, Message} from '../protocol/protocol.js';
-import {ZodType, z as zod} from 'zod';
+
+const MAX_INT = 9007199254740991 as const;
 
 export function parseObject<T extends ZodType>(
   obj: unknown,

--- a/src/utils/EventEmitter.spec.ts
+++ b/src/utils/EventEmitter.spec.ts
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import {EventEmitter} from './EventEmitter.js';
 import {expect} from 'chai';
 import sinon from 'sinon';
+
+import {EventEmitter} from './EventEmitter.js';
 
 describe('EventEmitter', () => {
   type Events = {

--- a/src/utils/buffer.spec.ts
+++ b/src/utils/buffer.spec.ts
@@ -17,6 +17,7 @@
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
+
 import {Buffer} from './buffer.js';
 
 const expect = chai.expect;

--- a/src/utils/idWrapper.spec.ts
+++ b/src/utils/idWrapper.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import * as chai from 'chai';
+
 import {IdWrapper} from './idWrapper.js';
 
 const expect = chai.expect;

--- a/src/utils/processingQueue.spec.ts
+++ b/src/utils/processingQueue.spec.ts
@@ -16,8 +16,8 @@
  */
 
 import * as chai from 'chai';
-
 import * as sinon from 'sinon';
+
 import {Deferred} from './deferred.js';
 import {ProcessingQueue} from './processingQueue.js';
 


### PR DESCRIPTION
Previously we were using `simple-import-sort` which did not support an autofixer and thus was causing development pain. The new setup includes an autofixer and does not fiddle with sorting imports, but merely with grouping similar groups together.