### PR TITLE
wpt: browsing_context/capture_screenshot/frame.py: mark as failing

### DIFF
--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,3 +1,9 @@
 [frame.py]
+  [test_context_origin[cross_origin\]]
+    expected: FAIL
+
+  [test_context_origin[same_origin\]]
+    expected: FAIL
+
   [test_iframe]
     expected: FAIL


### PR DESCRIPTION
This test is currently failing for the time being, likely due to the automation info bar in chrome.

Bug: #514