### PR TITLE
Implement `browsingContext.print` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "e2e-headless": "npm run server-no-build & npm run e2e-only",
     "e2e": "npm run e2e-headless",
     "e2e-only": "python3 -m pytest",
-    "eslint": "eslint --ext js --ext ts --fix .",
+    "eslint": "eslint --ext .js,.ts --fix .",
     "flake8": "flake8 examples/ tests/",
     "format": "npm run eslint && npm run prettier & npm run yapf",
     "pre-commit": "pre-commit run --all-files",

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -51,6 +51,7 @@ export interface BidiParser {
   parseCaptureScreenshotParams(
     params: object
   ): BrowsingContext.CaptureScreenshotParameters;
+  parsePrintParams(params: object): BrowsingContext.PrintParameters;
 }
 
 class BidiNoOpParser implements BidiParser {
@@ -91,6 +92,9 @@ class BidiNoOpParser implements BidiParser {
     params: object
   ): BrowsingContext.CaptureScreenshotParameters {
     return params as BrowsingContext.CaptureScreenshotParameters;
+  }
+  parsePrintParams(params: object): BrowsingContext.PrintParameters {
+    return params as BrowsingContext.PrintParameters;
   }
 }
 
@@ -187,6 +191,10 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEvents> {
       case 'browsingContext.captureScreenshot':
         return this.#contextProcessor.process_browsingContext_captureScreenshot(
           this.#parser.parseCaptureScreenshotParams(commandData.params)
+        );
+      case 'browsingContext.print':
+        return this.#contextProcessor.process_browsingContext_print(
+          this.#parser.parsePrintParams(commandData.params)
         );
 
       case 'script.getRealms':

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -248,6 +248,15 @@ export class BrowsingContextProcessor {
     return context.captureScreenshot();
   }
 
+  async process_browsingContext_print(
+    params: BrowsingContext.PrintParameters
+  ): Promise<BrowsingContext.PrintResult> {
+    const context = this.#browsingContextStorage.getKnownContext(
+      params.context
+    );
+    return context.print(params);
+  }
+
   async #getRealm(target: Script.Target): Promise<Realm> {
     if ('realm' in target) {
       return this.#realmStorage.getRealm({

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -306,6 +306,9 @@ class BidiParserImpl implements BidiParser {
   ): BrowsingContext.CaptureScreenshotParameters {
     return Parser.BrowsingContext.parseCaptureScreenshotParams(params);
   }
+  parsePrintParams(params: object): BrowsingContext.PrintParameters {
+    return Parser.BrowsingContext.parsePrintParams(params);
+  }
 }
 
 // Needed to filter out info related to BiDi target.

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -35,6 +35,7 @@ export type BiDiMethod =
   | 'browsingContext.create'
   | 'browsingContext.getTree'
   | 'browsingContext.navigate'
+  | 'browsingContext.print'
   | 'cdp.getSession'
   | 'cdp.sendCommand'
   | 'cdp.sendMessage'
@@ -636,13 +637,15 @@ export namespace BrowsingContext {
     | NavigateCommand
     | CreateCommand
     | CloseCommand
-    | CaptureScreenshotCommand;
+    | CaptureScreenshotCommand
+    | PrintCommand;
   export type CommandResult =
     | GetTreeResult
     | NavigateResult
     | CreateResult
     | CloseResult
-    | CaptureScreenshotResult;
+    | CaptureScreenshotResult
+    | PrintResult;
   export type Event =
     | LoadEvent
     | DomContentLoadedEvent
@@ -745,6 +748,42 @@ export namespace BrowsingContext {
   };
 
   export type CaptureScreenshotResult = {
+    result: {
+      data: string;
+    };
+  };
+
+  export type PrintCommand = {
+    method: 'browsingContext.print';
+    params: PrintParameters;
+  };
+
+  export type PrintParameters = {
+    context: CommonDataTypes.BrowsingContext;
+    background?: boolean;
+    margin?: PrintMarginParameters;
+    orientation?: 'portrait' | 'landscape';
+    page?: PrintPageParams;
+    pageRanges?: (string | number)[];
+    scale?: number;
+    shrinkToFit?: boolean;
+  };
+
+  // All units are in cm.
+  export type PrintMarginParameters = {
+    bottom?: number;
+    left?: number;
+    right?: number;
+    top?: number;
+  };
+
+  // All units are in cm.
+  export type PrintPageParams = {
+    height?: number;
+    width?: number;
+  };
+
+  export type PrintResult = {
     result: {
       data: string;
     };

--- a/src/utils/unitConversions.spec.ts
+++ b/src/utils/unitConversions.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect} from 'chai';
+
+import {inchesFromCm} from './unitConversions.js';
+
+describe('unit conversions', () => {
+  it('inches from cm', () => {
+    expect(inchesFromCm(2.54)).to.equal(1);
+    expect(inchesFromCm(27.94)).to.equal(11);
+  });
+});

--- a/src/utils/unitConversions.ts
+++ b/src/utils/unitConversions.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @return Given an input in cm, convert it to inches. */
+export function inchesFromCm(cm: number): number {
+  return cm / 2.54;
+}

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from anys import ANY_STR
+from test_helpers import goto_url, read_JSON_message, send_JSON_command
+
+
+@pytest.mark.asyncio
+async def test_print_happy_path(websocket, context_id):
+    await goto_url(websocket, context_id, 'about:blank')
+
+    await send_JSON_command(
+        websocket, {
+            "id": 1,
+            "method": "browsingContext.print",
+            "params": {
+                "context": context_id,
+                "background": False,
+                "orientation": "portrait",
+                "page": {
+                    "width": 800,
+                    "height": 600,
+                },
+                "pageRanges": ["1", "1-", "-1", "1-1", 1],
+                "scale": 1.0,
+            }
+        })
+
+    resp = await read_JSON_message(websocket)
+
+    # 'data' is not deterministic.
+    # There is always ~half a dozen characters that differ between runs.
+    assert resp == {'id': 1, 'result': {'data': ANY_STR}}


### PR DESCRIPTION
Bug: #518
Spec: https://w3c.github.io/webdriver-bidi/#command-browsingContext-print
CDP method: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF

## Status

- [x] [UP: #518] CDP does not have a `shrinkToFit` equivalent.
- [x] Use `.refine()` / `.transform()` to check the first number is lower than the second as per the spec (https://w3c.github.io/webdriver/#dfn-parse-a-page-range)
- [x] Do we need E2E tests?