### PR TITLE
use source maps when running mocha unit tests

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,5 @@
 {
+  "require": ["source-map-support/register"],
+  "source-maps": true,
   "spec": "lib/**/*.spec.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "rimraf": "3.0.2",
         "rollup": "2.74.1",
         "sinon": "14.0.0",
+        "source-map-support": "^0.5.21",
         "terser": "5.14.2",
         "tslib": "2.4.0",
         "typescript": "4.7.4",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "rimraf": "3.0.2",
     "rollup": "2.74.1",
     "sinon": "14.0.0",
+    "source-map-support": "^0.5.21",
     "terser": "5.14.2",
     "tslib": "2.4.0",
     "typescript": "4.7.4",


### PR DESCRIPTION
This improves debugging natively with our original TS files.

Previously, we would need to debug using the generated JS files.

References:

- https://jonnyreeves.co.uk/2015/getting-proper-stack-traces-with-mocha-and-typescript/
- https://futurestud.io/tutorials/mocha-migrating-from-mocha-opts-to-mocharc-js-configuration-file