### PR TITLE
`run*.sh` scripts: check number of arguments before evaluating `"$1"`

### DIFF
--- a/runBiDiServer.sh
+++ b/runBiDiServer.sh
@@ -13,7 +13,7 @@ usage() {
   log "The --headless flag takes precedence over the HEADLESS environment variable."
 }
 
-if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+if [[ $# -gt 0 && ("$1" == "-h" || "$1" == "--help") ]]; then
   usage
   exit 0
 fi

--- a/runWPT.sh
+++ b/runWPT.sh
@@ -11,7 +11,7 @@ usage() {
   log "Usage: [HEADLESS=<true | false>] [UPDATE_EXPECTATIONS=<true | false>] $0 [webdriver/tests/bidi/[...]]"
 }
 
-if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+if [[ $# -gt 0 && ("$1" == "-h" || "$1" == "--help") ]]; then
   usage
   exit 0
 fi


### PR DESCRIPTION
Because of `set -euo pipefail`, we need to explicitly check that `"$1"` is a valid expression before referencing it.

Follow-up-of: #524