### PR TITLE
Align binding (script message and channel) protocol with the spec

### DIFF
--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -18,7 +18,13 @@
 import {expect} from 'chai';
 import * as sinon from 'sinon';
 
-import {BrowsingContext, CDP, Log} from '../../../protocol/protocol.js';
+import {
+  BrowsingContext,
+  CDP,
+  Log,
+  Network,
+  Script,
+} from '../../../protocol/protocol.js';
 import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 
 import {
@@ -414,7 +420,7 @@ describe('cartesian product', () => {
 });
 
 describe('unroll events', () => {
-  it('all browser events', () => {
+  it('all Browsing Context events', () => {
     expect(unrollEvents([BrowsingContext.AllEvents])).to.deep.equal([
       BrowsingContext.EventNames.LoadEvent,
       BrowsingContext.EventNames.DomContentLoadedEvent,
@@ -429,9 +435,22 @@ describe('unroll events', () => {
     ]);
   });
 
-  it('all log events', () => {
+  it('all Log events', () => {
     expect(unrollEvents([Log.AllEvents])).to.deep.equal([
       Log.EventNames.LogEntryAddedEvent,
+    ]);
+  });
+
+  it('all Network events', () => {
+    expect(unrollEvents([Network.AllEvents])).to.deep.equal([
+      Network.EventNames.BeforeRequestSentEvent,
+      Network.EventNames.ResponseCompletedEvent,
+    ]);
+  });
+
+  it('all Script events', () => {
+    expect(unrollEvents([Script.AllEvents])).to.deep.equal([
+      Script.EventNames.MessageEvent,
     ]);
   });
 

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -22,6 +22,7 @@ import {
   Log,
   Message,
   Network,
+  Script,
   Session,
 } from '../../../protocol/protocol.js';
 import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
@@ -59,6 +60,9 @@ export function unrollEvents(
         break;
       case Network.AllEvents:
         allEvents.push(...Object.values(Network.EventNames));
+        break;
+      case Script.AllEvents:
+        allEvents.push(...Object.values(Script.EventNames));
         break;
       default:
         allEvents.push(event);
@@ -183,6 +187,12 @@ export class SubscriptionManager {
     }
     if (event === Network.AllEvents) {
       Object.values(Network.EventNames).map((specificEvent) =>
+        this.subscribe(specificEvent, contextId, channel)
+      );
+      return;
+    }
+    if (event === Script.AllEvents) {
+      Object.values(Script.EventNames).map((specificEvent) =>
         this.subscribe(specificEvent, contextId, channel)
       );
       return;

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -94,7 +94,7 @@ export class Realm {
     cdpValue:
       | Protocol.Runtime.CallFunctionOnResponse
       | Protocol.Runtime.EvaluateResponse,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.ResultOwnership
   ): Promise<CommonDataTypes.RemoteValue> {
     const cdpWebDriverValue = cdpValue.result.webDriverValue!;
     const bidiValue = this.webDriverValueToBiDi(cdpWebDriverValue);
@@ -205,7 +205,7 @@ export class Realm {
     _this: Script.ArgumentValue,
     _arguments: Script.ArgumentValue[],
     awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.ResultOwnership
   ): Promise<Script.CallFunctionResult> {
     const context = this.#browsingContextStorage.getKnownContext(
       this.browsingContextId
@@ -227,7 +227,7 @@ export class Realm {
   async scriptEvaluate(
     expression: string,
     awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.ResultOwnership
   ): Promise<Script.EvaluateResult> {
     const context = this.#browsingContextStorage.getKnownContext(
       this.browsingContextId
@@ -248,11 +248,11 @@ export class Realm {
    * Serializes a given CDP object into BiDi, keeping references in the
    * target's `globalThis`.
    * @param cdpObject CDP remote object to be serialized.
-   * @param resultOwnership indicates desired OwnershipModel.
+   * @param resultOwnership Indicates desired ResultOwnership.
    */
   async serializeCdpObject(
     cdpObject: Protocol.Runtime.RemoteObject,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.ResultOwnership
   ): Promise<CommonDataTypes.RemoteValue> {
     return scriptEvaluator.serializeCdpObject(cdpObject, resultOwnership, this);
   }

--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -268,12 +268,12 @@ export class ScriptEvaluator {
    * Serializes a given CDP object into BiDi, keeping references in the
    * target's `globalThis`.
    * @param cdpRemoteObject CDP remote object to be serialized.
-   * @param resultOwnership indicates desired OwnershipModel.
+   * @param resultOwnership Indicates desired ResultOwnership.
    * @param realm
    */
   async serializeCdpObject(
     cdpRemoteObject: Protocol.Runtime.RemoteObject,
-    resultOwnership: Script.OwnershipModel,
+    resultOwnership: Script.ResultOwnership,
     realm: Realm
   ): Promise<CommonDataTypes.RemoteValue> {
     const arg = cdpRemoteObjectToCallArgument(cdpRemoteObject);
@@ -293,7 +293,7 @@ export class ScriptEvaluator {
     realm: Realm,
     expression: string,
     awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.ResultOwnership
   ): Promise<Script.ScriptResult> {
     const cdpEvaluateResult = await realm.cdpClient.sendCommand(
       'Runtime.evaluate',
@@ -332,7 +332,7 @@ export class ScriptEvaluator {
     _this: Script.ArgumentValue,
     _arguments: Script.ArgumentValue[],
     awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
+    resultOwnership: Script.ResultOwnership
   ): Promise<Script.ScriptResult> {
     const callFunctionAndSerializeScript = `(...args)=>{ return _callFunction((\n${functionDeclaration}\n), args);
       function _callFunction(f, args) {
@@ -443,7 +443,7 @@ export class ScriptEvaluator {
   async #serializeCdpExceptionDetails(
     cdpExceptionDetails: Protocol.Runtime.ExceptionDetails,
     lineOffset: number,
-    resultOwnership: Script.OwnershipModel,
+    resultOwnership: Script.ResultOwnership,
     realm: Realm
   ): Promise<Script.ExceptionDetails> {
     const callFrames = cdpExceptionDetails.stackTrace?.callFrames.map(

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -84,7 +84,8 @@ export namespace Message {
     | BrowsingContext.Event
     | Log.Event
     | CDP.Event
-    | Network.Event;
+    | Network.Event
+    | Script.Event;
 
   export type ErrorCode =
     | 'unknown error'
@@ -441,6 +442,7 @@ export namespace Script {
     | CallFunctionResult
     | GetRealmsResult
     | DisownResult;
+  export type Event = MessageEvent;
 
   export type Realm = string;
 
@@ -565,19 +567,20 @@ export namespace Script {
   // `RealmTargetSchema` has higher priority.
   export type Target = RealmTarget | ContextTarget;
 
-  export type OwnershipModel = 'root' | 'none';
+  // ResultOwnership = "root" / "none"
+  export type ResultOwnership = 'root' | 'none';
 
   // ScriptEvaluateParameters = {
   //   expression: text;
   //   target: Target;
   //   ?awaitPromise: bool;
-  //   ?resultOwnership: OwnershipModel;
+  //   ?resultOwnership: ResultOwnership;
   // }
   export type EvaluateParameters = {
     expression: string;
     awaitPromise: boolean;
     target: Target;
-    resultOwnership?: OwnershipModel;
+    resultOwnership?: ResultOwnership;
   };
 
   export type EvaluateResult = {
@@ -612,7 +615,7 @@ export namespace Script {
     target: Target;
     arguments?: ArgumentValue[];
     this?: ArgumentValue;
-    resultOwnership?: OwnershipModel;
+    resultOwnership?: ResultOwnership;
   };
 
   export type CallFunctionResult = {
@@ -634,6 +637,41 @@ export namespace Script {
     lineNumber: number;
     url: string;
   };
+
+  export type ChannelId = string;
+
+  export type ChannelProperties = {
+    channel: ChannelId;
+    maxDepth?: number;
+    ownership?: ResultOwnership;
+  };
+
+  export type Channel = {
+    type: 'channel';
+    value: ChannelProperties;
+  };
+
+  export type Message = {
+    method: 'script.message';
+    params: MessageParameters;
+  };
+
+  export type MessageParameters = {
+    channel: Channel;
+    data: CommonDataTypes.RemoteValue;
+    source: Source;
+  };
+
+  export type MessageEvent = EventResponse<
+    EventNames.MessageEvent,
+    Script.MessageParameters
+  >;
+
+  export enum EventNames {
+    MessageEvent = 'script.message',
+  }
+
+  export const AllEvents = 'script';
 }
 
 // https://w3c.github.io/webdriver-bidi/#module-browsingContext
@@ -1059,7 +1097,9 @@ export namespace Session {
     | CDP.EventNames
     | typeof CDP.AllEvents
     | Network.EventNames
-    | typeof Network.AllEvents;
+    | typeof Network.AllEvents
+    | Script.EventNames
+    | typeof Script.AllEvents;
 
   // SessionSubscribeParameters = {
   //   events: [*text],


### PR DESCRIPTION
References:

- `s/OwnershipModel/ResultOwnership/` to align with the spec
- `script.Channel`: https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/361.html#type-script-Channel
- `script.Message`: https://pr-preview.s3.amazonaws.com/w3c/webdriver-bidi/pull/361.html#event-script-message

Bug: #294
Reference: https://github.com/GoogleChromeLabs/chromium-bidi/pull/319#issuecomment-1453236068