### PR TITLE
refactor script evaluator

### DIFF
--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -38,260 +38,6 @@ function cdpRemoteObjectToCallArgument(
   return {value: cdpRemoteObject.value};
 }
 
-async function deserializeToCdpArg(
-  argumentValue: Script.ArgumentValue,
-  realm: Realm
-): Promise<Protocol.Runtime.CallArgument> {
-  if ('sharedId' in argumentValue) {
-    const [navigableId, rawBackendNodeId] =
-      argumentValue.sharedId.split(SHARED_ID_DIVIDER);
-
-    const backendNodeId = parseInt(rawBackendNodeId ?? '');
-    if (
-      isNaN(backendNodeId) ||
-      backendNodeId === undefined ||
-      navigableId === undefined
-    ) {
-      throw new Message.InvalidArgumentException(
-        `SharedId "${argumentValue.sharedId}" should have format "{navigableId}${SHARED_ID_DIVIDER}{backendNodeId}".`
-      );
-    }
-
-    if (realm.navigableId !== navigableId) {
-      throw new Message.NoSuchNodeException(
-        `SharedId "${argumentValue.sharedId}" belongs to different document. Current document is ${realm.navigableId}.`
-      );
-    }
-
-    try {
-      const obj = await realm.cdpClient.sendCommand('DOM.resolveNode', {
-        backendNodeId,
-        executionContextId: realm.executionContextId,
-      });
-      // TODO: release `obj.object.objectId` after using.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/375
-      return {objectId: obj.object.objectId};
-    } catch (e: any) {
-      // Heuristic to detect "no such node" exception. Based on the  specific
-      // CDP implementation.
-      if (e.code === -32000 && e.message === 'No node with given id found') {
-        throw new Message.NoSuchNodeException(
-          `SharedId "${argumentValue.sharedId}" was not found.`
-        );
-      }
-      throw e;
-    }
-  }
-  if ('handle' in argumentValue) {
-    return {objectId: argumentValue.handle};
-  }
-  switch (argumentValue.type) {
-    // Primitive Protocol Value
-    // https://w3c.github.io/webdriver-bidi/#data-types-protocolValue-primitiveProtocolValue
-    case 'undefined': {
-      return {unserializableValue: 'undefined'};
-    }
-    case 'null': {
-      return {unserializableValue: 'null'};
-    }
-    case 'string': {
-      return {value: argumentValue.value};
-    }
-    case 'number': {
-      if (argumentValue.value === 'NaN') {
-        return {unserializableValue: 'NaN'};
-      } else if (argumentValue.value === '-0') {
-        return {unserializableValue: '-0'};
-      } else if (argumentValue.value === 'Infinity') {
-        return {unserializableValue: 'Infinity'};
-      } else if (argumentValue.value === '-Infinity') {
-        return {unserializableValue: '-Infinity'};
-      }
-      return {
-        value: argumentValue.value,
-      };
-    }
-    case 'boolean': {
-      return {value: Boolean(argumentValue.value)};
-    }
-    case 'bigint': {
-      return {
-        unserializableValue: `BigInt(${JSON.stringify(argumentValue.value)})`,
-      };
-    }
-
-    // Local Value
-    // https://w3c.github.io/webdriver-bidi/#data-types-protocolValue-LocalValue
-    case 'date': {
-      return {
-        unserializableValue: `new Date(Date.parse(${JSON.stringify(
-          argumentValue.value
-        )}))`,
-      };
-    }
-    case 'regexp': {
-      return {
-        unserializableValue: `new RegExp(${JSON.stringify(
-          argumentValue.value.pattern
-        )}, ${JSON.stringify(argumentValue.value.flags)})`,
-      };
-    }
-    case 'map': {
-      // TODO(sadym): if non of the nested keys and values has remote
-      // reference, serialize to `unserializableValue` without CDP roundtrip.
-      const keyValueArray = await flattenKeyValuePairs(
-        argumentValue.value,
-        realm
-      );
-      const argEvalResult = await realm.cdpClient.sendCommand(
-        'Runtime.callFunctionOn',
-        {
-          functionDeclaration: String(
-            (...args: Protocol.Runtime.CallArgument[]) => {
-              const result = new Map();
-              for (let i = 0; i < args.length; i += 2) {
-                result.set(args[i], args[i + 1]);
-              }
-              return result;
-            }
-          ),
-          awaitPromise: false,
-          arguments: keyValueArray,
-          returnByValue: false,
-          executionContextId: realm.executionContextId,
-        }
-      );
-      // TODO: release `argEvalResult.result.objectId`  after using.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/375
-      return {objectId: argEvalResult.result.objectId};
-    }
-    case 'object': {
-      // TODO(sadym): if non of the nested keys and values has remote
-      //  reference, serialize to `unserializableValue` without CDP roundtrip.
-      const keyValueArray = await flattenKeyValuePairs(
-        argumentValue.value,
-        realm
-      );
-
-      const argEvalResult = await realm.cdpClient.sendCommand(
-        'Runtime.callFunctionOn',
-        {
-          functionDeclaration: String(
-            (...args: Protocol.Runtime.CallArgument[]) => {
-              const result: Record<
-                string | number | symbol,
-                Protocol.Runtime.CallArgument
-              > = {};
-
-              for (let i = 0; i < args.length; i += 2) {
-                // Key should be either `string`, `number`, or `symbol`.
-                const key = args[i] as string | number | symbol;
-                result[key] = args[i + 1]!;
-              }
-              return result;
-            }
-          ),
-          awaitPromise: false,
-          arguments: keyValueArray,
-          returnByValue: false,
-          executionContextId: realm.executionContextId,
-        }
-      );
-      // TODO: release `argEvalResult.result.objectId`  after using.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/375
-      return {objectId: argEvalResult.result.objectId};
-    }
-    case 'array': {
-      // TODO(sadym): if non of the nested items has remote reference,
-      //  serialize to `unserializableValue` without CDP roundtrip.
-      const args = await flattenValueList(argumentValue.value, realm);
-
-      const argEvalResult = await realm.cdpClient.sendCommand(
-        'Runtime.callFunctionOn',
-        {
-          functionDeclaration: String((...args: unknown[]) => {
-            return args;
-          }),
-          awaitPromise: false,
-          arguments: args,
-          returnByValue: false,
-          executionContextId: realm.executionContextId,
-        }
-      );
-      // TODO: release `argEvalResult.result.objectId`  after using.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/375
-      return {objectId: argEvalResult.result.objectId};
-    }
-    case 'set': {
-      // TODO(sadym): if non of the nested items has remote reference,
-      //  serialize to `unserializableValue` without CDP roundtrip.
-      const args = await flattenValueList(argumentValue.value, realm);
-
-      const argEvalResult = await realm.cdpClient.sendCommand(
-        'Runtime.callFunctionOn',
-        {
-          functionDeclaration: String((...args: unknown[]) => {
-            return new Set(args);
-          }),
-          awaitPromise: false,
-          arguments: args,
-          returnByValue: false,
-          executionContextId: realm.executionContextId,
-        }
-      );
-      // TODO: release `argEvalResult.result.objectId`  after using.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/375
-      return {objectId: argEvalResult.result.objectId};
-    }
-
-    // TODO(sadym): dispose nested objects.
-
-    default:
-      throw new Error(
-        `Value ${JSON.stringify(argumentValue)} is not deserializable.`
-      );
-  }
-}
-
-async function flattenKeyValuePairs(
-  value: CommonDataTypes.MappingLocalValue,
-  realm: Realm
-): Promise<Protocol.Runtime.CallArgument[]> {
-  const keyValueArray: Protocol.Runtime.CallArgument[] = [];
-  for (const pair of value) {
-    const key = pair[0];
-    const value = pair[1];
-
-    let keyArg;
-    if (typeof key === 'string') {
-      // Key is a string.
-      keyArg = {value: key};
-    } else {
-      // Key is a serialized value.
-      keyArg = await deserializeToCdpArg(key, realm);
-    }
-
-    const valueArg = await deserializeToCdpArg(value, realm);
-
-    keyValueArray.push(keyArg);
-    keyValueArray.push(valueArg);
-  }
-  return keyValueArray;
-}
-
-async function flattenValueList(
-  list: CommonDataTypes.ListLocalValue,
-  realm: Realm
-): Promise<Protocol.Runtime.CallArgument[]> {
-  const result: Protocol.Runtime.CallArgument[] = [];
-
-  for (const value of list) {
-    result.push(await deserializeToCdpArg(value, realm));
-  }
-
-  return result;
-}
-
 /**
  * Gets the string representation of an object. This is equivalent to
  * calling toString() on the object value.
@@ -319,6 +65,205 @@ export async function stringifyObject(
 }
 
 export class ScriptEvaluator {
+  async deserializeToCdpArg(
+    argumentValue: Script.ArgumentValue,
+    realm: Realm
+  ): Promise<Protocol.Runtime.CallArgument> {
+    if ('sharedId' in argumentValue) {
+      const [navigableId, rawBackendNodeId] =
+        argumentValue.sharedId.split(SHARED_ID_DIVIDER);
+
+      const backendNodeId = parseInt(rawBackendNodeId ?? '');
+      if (
+        isNaN(backendNodeId) ||
+        backendNodeId === undefined ||
+        navigableId === undefined
+      ) {
+        throw new Message.InvalidArgumentException(
+          `SharedId "${argumentValue.sharedId}" should have format "{navigableId}${SHARED_ID_DIVIDER}{backendNodeId}".`
+        );
+      }
+
+      if (realm.navigableId !== navigableId) {
+        throw new Message.NoSuchNodeException(
+          `SharedId "${argumentValue.sharedId}" belongs to different document. Current document is ${realm.navigableId}.`
+        );
+      }
+
+      try {
+        const obj = await realm.cdpClient.sendCommand('DOM.resolveNode', {
+          backendNodeId,
+          executionContextId: realm.executionContextId,
+        });
+        // TODO(#375): release `obj.object.objectId` after using.
+        return {objectId: obj.object.objectId};
+      } catch (e: any) {
+        // Heuristic to detect "no such node" exception. Based on the  specific
+        // CDP implementation.
+        if (e.code === -32000 && e.message === 'No node with given id found') {
+          throw new Message.NoSuchNodeException(
+            `SharedId "${argumentValue.sharedId}" was not found.`
+          );
+        }
+        throw e;
+      }
+    }
+    if ('handle' in argumentValue) {
+      return {objectId: argumentValue.handle};
+    }
+    switch (argumentValue.type) {
+      // Primitive Protocol Value
+      // https://w3c.github.io/webdriver-bidi/#data-types-protocolValue-primitiveProtocolValue
+      case 'undefined':
+        return {unserializableValue: 'undefined'};
+      case 'null':
+        return {unserializableValue: 'null'};
+      case 'string':
+        return {value: argumentValue.value};
+      case 'number':
+        if (argumentValue.value === 'NaN') {
+          return {unserializableValue: 'NaN'};
+        } else if (argumentValue.value === '-0') {
+          return {unserializableValue: '-0'};
+        } else if (argumentValue.value === 'Infinity') {
+          return {unserializableValue: 'Infinity'};
+        } else if (argumentValue.value === '-Infinity') {
+          return {unserializableValue: '-Infinity'};
+        }
+        return {
+          value: argumentValue.value,
+        };
+      case 'boolean':
+        return {value: Boolean(argumentValue.value)};
+      case 'bigint':
+        return {
+          unserializableValue: `BigInt(${JSON.stringify(argumentValue.value)})`,
+        };
+      case 'date':
+        return {
+          unserializableValue: `new Date(Date.parse(${JSON.stringify(
+            argumentValue.value
+          )}))`,
+        };
+      case 'regexp':
+        return {
+          unserializableValue: `new RegExp(${JSON.stringify(
+            argumentValue.value.pattern
+          )}, ${JSON.stringify(argumentValue.value.flags)})`,
+        };
+      case 'map': {
+        // TODO(sadym): if non of the nested keys and values has remote
+        // reference, serialize to `unserializableValue` without CDP roundtrip.
+        const keyValueArray = await this.#flattenKeyValuePairs(
+          argumentValue.value,
+          realm
+        );
+        const argEvalResult = await realm.cdpClient.sendCommand(
+          'Runtime.callFunctionOn',
+          {
+            functionDeclaration: String(
+              (...args: Protocol.Runtime.CallArgument[]) => {
+                const result = new Map();
+                for (let i = 0; i < args.length; i += 2) {
+                  result.set(args[i], args[i + 1]);
+                }
+                return result;
+              }
+            ),
+            awaitPromise: false,
+            arguments: keyValueArray,
+            returnByValue: false,
+            executionContextId: realm.executionContextId,
+          }
+        );
+        // TODO(#375): release `argEvalResult.result.objectId` after using.
+        return {objectId: argEvalResult.result.objectId};
+      }
+      case 'object': {
+        // TODO(sadym): if non of the nested keys and values has remote
+        //  reference, serialize to `unserializableValue` without CDP roundtrip.
+        const keyValueArray = await this.#flattenKeyValuePairs(
+          argumentValue.value,
+          realm
+        );
+
+        const argEvalResult = await realm.cdpClient.sendCommand(
+          'Runtime.callFunctionOn',
+          {
+            functionDeclaration: String(
+              (...args: Protocol.Runtime.CallArgument[]) => {
+                const result: Record<
+                  string | number | symbol,
+                  Protocol.Runtime.CallArgument
+                > = {};
+
+                for (let i = 0; i < args.length; i += 2) {
+                  // Key should be either `string`, `number`, or `symbol`.
+                  const key = args[i] as string | number | symbol;
+                  result[key] = args[i + 1]!;
+                }
+                return result;
+              }
+            ),
+            awaitPromise: false,
+            arguments: keyValueArray,
+            returnByValue: false,
+            executionContextId: realm.executionContextId,
+          }
+        );
+        // TODO(#375): release `argEvalResult.result.objectId` after using.
+        return {objectId: argEvalResult.result.objectId};
+      }
+      case 'array': {
+        // TODO(sadym): if non of the nested items has remote reference,
+        //  serialize to `unserializableValue` without CDP roundtrip.
+        const args = await this.#flattenValueList(argumentValue.value, realm);
+
+        const argEvalResult = await realm.cdpClient.sendCommand(
+          'Runtime.callFunctionOn',
+          {
+            functionDeclaration: String((...args: unknown[]) => {
+              return args;
+            }),
+            awaitPromise: false,
+            arguments: args,
+            returnByValue: false,
+            executionContextId: realm.executionContextId,
+          }
+        );
+        // TODO (#375): release `argEvalResult.result.objectId` after using.
+        return {objectId: argEvalResult.result.objectId};
+      }
+      case 'set': {
+        // TODO(sadym): if none of the nested items has a remote reference,
+        // serialize to `unserializableValue` without CDP roundtrip.
+        const args = await this.#flattenValueList(argumentValue.value, realm);
+
+        const argEvalResult = await realm.cdpClient.sendCommand(
+          'Runtime.callFunctionOn',
+          {
+            functionDeclaration: String((...args: unknown[]) => {
+              return new Set(args);
+            }),
+            awaitPromise: false,
+            arguments: args,
+            returnByValue: false,
+            executionContextId: realm.executionContextId,
+          }
+        );
+        // TODO (#375): release `argEvalResult.result.objectId` after using.
+        return {objectId: argEvalResult.result.objectId};
+      }
+
+      // TODO(#375): dispose of nested objects.
+
+      default:
+        throw new Error(
+          `Value ${JSON.stringify(argumentValue)} is not deserializable.`
+        );
+    }
+  }
+
   /**
    * Serializes a given CDP object into BiDi, keeping references in the
    * target's `globalThis`.
@@ -344,6 +289,43 @@ export class ScriptEvaluator {
     return realm.cdpToBidiValue(cdpWebDriverValue, resultOwnership);
   }
 
+  async scriptEvaluate(
+    realm: Realm,
+    expression: string,
+    awaitPromise: boolean,
+    resultOwnership: Script.OwnershipModel
+  ): Promise<Script.ScriptResult> {
+    const cdpEvaluateResult = await realm.cdpClient.sendCommand(
+      'Runtime.evaluate',
+      {
+        contextId: realm.executionContextId,
+        expression,
+        awaitPromise,
+        generateWebDriverValue: true,
+      }
+    );
+
+    if (cdpEvaluateResult.exceptionDetails) {
+      // Serialize exception details.
+      return {
+        exceptionDetails: await this.#serializeCdpExceptionDetails(
+          cdpEvaluateResult.exceptionDetails,
+          EVALUATE_STACKTRACE_LINE_OFFSET,
+          resultOwnership,
+          realm
+        ),
+        type: 'exception',
+        realm: realm.realmId,
+      };
+    }
+
+    return {
+      type: 'success',
+      result: await realm.cdpToBidiValue(cdpEvaluateResult, resultOwnership),
+      realm: realm.realmId,
+    };
+  }
+
   async callFunction(
     realm: Realm,
     functionDeclaration: string,
@@ -359,11 +341,11 @@ export class ScriptEvaluator {
         return f.apply(deserializedThis, deserializedArgs);
       }}`;
 
-    const thisAndArgumentsList = [await deserializeToCdpArg(_this, realm)];
+    const thisAndArgumentsList = [await this.deserializeToCdpArg(_this, realm)];
     thisAndArgumentsList.push(
       ...(await Promise.all(
         _arguments.map(async (a) => {
-          return deserializeToCdpArg(a, realm);
+          return this.deserializeToCdpArg(a, realm);
         })
       ))
     );
@@ -419,6 +401,45 @@ export class ScriptEvaluator {
     };
   }
 
+  async #flattenKeyValuePairs(
+    value: CommonDataTypes.MappingLocalValue,
+    realm: Realm
+  ): Promise<Protocol.Runtime.CallArgument[]> {
+    const keyValueArray: Protocol.Runtime.CallArgument[] = [];
+    for (const pair of value) {
+      const key = pair[0];
+      const value = pair[1];
+
+      let keyArg;
+      if (typeof key === 'string') {
+        // Key is a string.
+        keyArg = {value: key};
+      } else {
+        // Key is a serialized value.
+        keyArg = await this.deserializeToCdpArg(key, realm);
+      }
+
+      const valueArg = await this.deserializeToCdpArg(value, realm);
+
+      keyValueArray.push(keyArg);
+      keyValueArray.push(valueArg);
+    }
+    return keyValueArray;
+  }
+
+  async #flattenValueList(
+    list: CommonDataTypes.ListLocalValue,
+    realm: Realm
+  ): Promise<Protocol.Runtime.CallArgument[]> {
+    const result: Protocol.Runtime.CallArgument[] = [];
+
+    for (const value of list) {
+      result.push(await this.deserializeToCdpArg(value, realm));
+    }
+
+    return result;
+  }
+
   async #serializeCdpExceptionDetails(
     cdpExceptionDetails: Protocol.Runtime.ExceptionDetails,
     lineOffset: number,
@@ -455,43 +476,6 @@ export class ScriptEvaluator {
         callFrames: callFrames || [],
       },
       text: text || cdpExceptionDetails.text,
-    };
-  }
-
-  async scriptEvaluate(
-    realm: Realm,
-    expression: string,
-    awaitPromise: boolean,
-    resultOwnership: Script.OwnershipModel
-  ): Promise<Script.ScriptResult> {
-    const cdpEvaluateResult = await realm.cdpClient.sendCommand(
-      'Runtime.evaluate',
-      {
-        contextId: realm.executionContextId,
-        expression,
-        awaitPromise,
-        generateWebDriverValue: true,
-      }
-    );
-
-    if (cdpEvaluateResult.exceptionDetails) {
-      // Serialize exception details.
-      return {
-        exceptionDetails: await this.#serializeCdpExceptionDetails(
-          cdpEvaluateResult.exceptionDetails,
-          EVALUATE_STACKTRACE_LINE_OFFSET,
-          resultOwnership,
-          realm
-        ),
-        type: 'exception',
-        realm: realm.realmId,
-      };
-    }
-
-    return {
-      type: 'success',
-      result: await realm.cdpToBidiValue(cdpEvaluateResult, resultOwnership),
-      realm: realm.realmId,
     };
   }
 }


### PR DESCRIPTION
In preparation for the introduction of the binding mechanism.

- 1) move public methods to the top, and private methods to the bottom of the class, for readability
- 2) move a few methods to within ScriptEvaluator, because we will need to use `this` to access the to be introduced event manager member variable

This is intended to reduce diff noise in the main PR (#319).

Furthermore, remove unnecessary switch case braces.

This is a no-op.

Bug: #294