### PR TITLE
Enable `Network` domain globally

### DIFF
--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -209,6 +209,7 @@ export class EventManager implements IEventManager {
     if (eventName.startsWith(EventManager.#NETWORK_DOMAIN_PREFIX)) {
       // Enable for all the contexts.
       if (contextId === null) {
+        this.#isNetworkDomainEnabled = true;
         await Promise.all(
           this.#bidiServer
             .getBrowsingContextStorage()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,15 +74,24 @@ async def context_id(websocket):
 
 
 @pytest_asyncio.fixture
-async def another_context_id(websocket):
-    """Create a browsing context and return its id."""
-    result = await execute_command(websocket, {
-        "method": "browsingContext.create",
-        "params": {
-            "type": "tab"
-        }
-    })
-    return result['context']
+async def another_context_id(create_context):
+    return await create_context()
+
+
+@pytest_asyncio.fixture
+def create_context(websocket):
+
+    async def _(createType="tab"):
+        """Create a browsing context and return its id."""
+        result = await execute_command(websocket, {
+            "method": "browsingContext.create",
+            "params": {
+                "type": createType
+            }
+        })
+        return result['context']
+
+    return _
 
 
 @pytest_asyncio.fixture

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -116,24 +116,16 @@ async def test_browsingContext_getTree_contextReturned(websocket, context_id):
 
 @pytest.mark.asyncio
 async def test_browsingContext_getTreeWithRoot_contextReturned(
-        websocket, context_id):
-    result = await execute_command(websocket, {
-        "method": "browsingContext.create",
-        "params": {
-            "type": "tab"
-        }
-    })
-    new_context_id = result["context"]
-
+        websocket, context_id, another_context_id):
     result = await get_tree(websocket)
 
     assert len(result['contexts']) == 2
 
-    result = await get_tree(websocket, new_context_id)
+    result = await get_tree(websocket, another_context_id)
 
     assert result == {
         "contexts": [{
-            "context": new_context_id,
+            "context": another_context_id,
             "parent": None,
             "url": "about:blank",
             "children": []

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -116,16 +116,24 @@ async def test_browsingContext_getTree_contextReturned(websocket, context_id):
 
 @pytest.mark.asyncio
 async def test_browsingContext_getTreeWithRoot_contextReturned(
-        websocket, context_id, another_context_id):
+        websocket, context_id):
+    result = await execute_command(websocket, {
+        "method": "browsingContext.create",
+        "params": {
+            "type": "tab"
+        }
+    })
+    new_context_id = result["context"]
+
     result = await get_tree(websocket)
 
     assert len(result['contexts']) == 2
 
-    result = await get_tree(websocket, another_context_id)
+    result = await get_tree(websocket, new_context_id)
 
     assert result == {
         "contexts": [{
-            "context": another_context_id,
+            "context": new_context_id,
             "parent": None,
             "url": "about:blank",
             "children": []

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,7 +16,7 @@
 import itertools
 import json
 
-from anys import ANY_NUMBER, ANY_STR, AnyContains, AnyGT, AnyLT
+from anys import ANY_NUMBER, ANY_STR, AnyContains, AnyGT, AnyLT, AnyWithEntries
 
 _command_counter = itertools.count(1)
 
@@ -135,3 +135,19 @@ async def wait_for_event(websocket, event_method):
         if "method" in event_response and event_response[
                 "method"] == event_method:
             return event_response
+
+
+def AnyExtending(expected):
+    if type(expected) is list:
+        result = []
+        for index, _ in enumerate(expected):
+            result[index] = AnyExtending(expected[index])
+        return result
+
+    if type(expected) is dict:
+        result = {}
+        for key in expected.keys():
+            result[key] = AnyExtending(expected[key])
+        return AnyWithEntries(result)
+
+    return expected

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,9 +14,9 @@
 #  limitations under the License.
 #
 import pytest
-from anys import ANY_DICT, ANY_LIST, ANY_NUMBER, ANY_STR, AnyWithEntries
-from test_helpers import (ANY_TIMESTAMP, execute_command, read_JSON_message,
-                          send_JSON_command, subscribe)
+from anys import ANY_DICT, ANY_LIST, ANY_NUMBER, ANY_STR
+from test_helpers import (ANY_TIMESTAMP, AnyExtending, execute_command,
+                          read_JSON_message, send_JSON_command, subscribe)
 
 
 @pytest.mark.asyncio
@@ -78,9 +78,11 @@ async def test_network_global_subscription_and_new_context(
 
     resp = await read_JSON_message(websocket)
 
-    assert resp == AnyWithEntries({
+    assert resp == AnyExtending({
         "method": "network.beforeRequestSent",
-        "params": AnyWithEntries({"context": new_context_id})
+        "params": {
+            "context": new_context_id
+        }
     })
 
 


### PR DESCRIPTION
When user subscribes to `network` events globally, all new browsing contexts should enable it.