### PR TITLE
runWPT.sh: remove set -e

### DIFF
--- a/runWPT.sh
+++ b/runWPT.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC2155
 
-set -euo pipefail
+set -uo pipefail
 
 log() {
   echo "($0) $*"


### PR DESCRIPTION
Otherwise the expectations would never get updated if there's at least one failing WPT test, which defeats the purpose of having the UPDATE_EXPECTATIONS variable in the first place.