### PR TITLE
`browsingContext.print`: use `shrinkToFit` parameter

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -502,7 +502,7 @@ export class BrowsingContextImpl {
       landscape: params.orientation === 'landscape',
       pageRanges: params.pageRanges?.join(',') ?? '',
       scale: params.scale,
-      // TODO(#518): Use `shrinkToFit`.
+      preferCSSPageSize: !params.shrinkToFit,
     };
 
     if (params.margin?.bottom) {


### PR DESCRIPTION
The CDP equivalent is `preferCSSPageSize`, it is the negation of `shrinkToFit`.

We can also observe this in [webdriver classic][1].

[1]: https://source.chromium.org/chromium/chromium/src/+/main:chrome/test/chromedriver/window_commands.cc;l=2287;drc=90ebbc5baf7104797970c7cfa5b22689f6f904c1

Bug: #518
Docs: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF