### PR TITLE
Misc refactoring in python E2E tests

### DIFF
--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -26,7 +26,6 @@ async def test_browsingContext_subscribeToAllBrowsingContextEvents_eventReceived
     await subscribe(websocket, "browsingContext")
 
     await send_JSON_command(websocket, {
-        "id": 9,
         "method": "browsingContext.create",
         "params": {
             "type": "tab"
@@ -454,15 +453,14 @@ async def test_browsingContext_close_browsingContext_closed(
         websocket, context_id):
     await subscribe(websocket, ["browsingContext.contextDestroyed"])
 
-    # Send command.
-    command = {
-        "id": 12,
-        "method": "browsingContext.close",
-        "params": {
-            "context": context_id
-        }
-    }
-    await send_JSON_command(websocket, command)
+    await send_JSON_command(
+        websocket, {
+            "id": 12,
+            "method": "browsingContext.close",
+            "params": {
+                "context": context_id
+            }
+        })
 
     # Assert "browsingContext.contextCreated" event emitted.
     resp = await read_JSON_message(websocket)
@@ -492,7 +490,7 @@ async def test_browsingContext_navigateWaitNone_navigated(
     await subscribe(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "id": 13,
@@ -547,7 +545,6 @@ async def test_browsingContext_navigateWaitInteractive_navigated(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
 
-    # Send command.
     await send_JSON_command(
         websocket, {
             "id": 14,
@@ -602,7 +599,6 @@ async def test_browsingContext_navigateWaitComplete_navigated(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
 
-    # Send command.
     await send_JSON_command(
         websocket, {
             "id": 15,

--- a/tests/test_log_events.py
+++ b/tests/test_log_events.py
@@ -25,7 +25,7 @@ from test_helpers import (ANY_TIMESTAMP, read_JSON_message, send_JSON_command,
 async def test_log_subscribeToAllLogEvents_logEventReceived(
         websocket, context_id):
     await subscribe(websocket, "log")
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
@@ -45,7 +45,7 @@ async def test_log_subscribeToAllLogEvents_logEventReceived(
 async def test_log_subscribeToLogEntryAddedEvents_logEventReceived(
         websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
@@ -58,7 +58,6 @@ async def test_log_subscribeToLogEntryAddedEvents_logEventReceived(
             }
         })
 
-    # Wait for responses
     await wait_for_event(websocket, "log.entryAdded")
 
 
@@ -66,10 +65,8 @@ async def test_log_subscribeToLogEntryAddedEvents_logEventReceived(
 async def test_consoleLog_textAndArgs(websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
 
-    # Send command.
     await send_JSON_command(
         websocket, {
-            "id": 33,
             "method": "script.evaluate",
             "params": {
                 "expression": "console.log("
@@ -92,10 +89,8 @@ async def test_consoleLog_textAndArgs(websocket, context_id):
             }
         })
 
-    # Wait for responses
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
-    # Assert "log.entryAdded" event emitted.
     assert {
         "method": "log.entryAdded",
         "params": {
@@ -188,7 +183,7 @@ async def test_consoleLog_textAndArgs(websocket, context_id):
 @pytest.mark.asyncio
 async def test_consoleInfo_levelAndMethodAreCorrect(websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
@@ -201,7 +196,6 @@ async def test_consoleInfo_levelAndMethodAreCorrect(websocket, context_id):
             }
         })
 
-    # Wait for responses
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert method "info".
@@ -213,7 +207,7 @@ async def test_consoleInfo_levelAndMethodAreCorrect(websocket, context_id):
 @pytest.mark.asyncio
 async def test_consoleDebug_levelAndMethodAreCorrect(websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
@@ -226,7 +220,6 @@ async def test_consoleDebug_levelAndMethodAreCorrect(websocket, context_id):
             }
         })
 
-    # Wait for responses
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert method "error".
@@ -238,7 +231,7 @@ async def test_consoleDebug_levelAndMethodAreCorrect(websocket, context_id):
 @pytest.mark.asyncio
 async def test_consoleWarn_levelAndMethodAreCorrect(websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
@@ -251,7 +244,6 @@ async def test_consoleWarn_levelAndMethodAreCorrect(websocket, context_id):
             }
         })
 
-    # Wait for responses
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert method "error".
@@ -263,7 +255,7 @@ async def test_consoleWarn_levelAndMethodAreCorrect(websocket, context_id):
 @pytest.mark.asyncio
 async def test_consoleError_levelAndMethodAreCorrect(websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
@@ -276,7 +268,6 @@ async def test_consoleError_levelAndMethodAreCorrect(websocket, context_id):
             }
         })
 
-    # Wait for responses
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
     # Assert method "error".
@@ -302,10 +293,8 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
                     '{\"id\":1,\"font-size\":\"20px\"}, ' \
                     '{\"id\":1,\"font-size\":\"20px\"} EOL'
 
-    # Send command.
     await send_JSON_command(
         websocket, {
-            "id": 55,
             "method": "script.evaluate",
             "params": {
                 "expression": f"console.log('"
@@ -324,7 +313,6 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
             }
         })
 
-    # Wait for responses
     response = await wait_for_event(websocket, "log.entryAdded")
 
     assert response["params"]["text"] == expected_text
@@ -334,22 +322,19 @@ async def test_consoleLog_logEntryAddedFormatOutput(websocket, context_id):
 async def test_exceptionThrown_logEntryAddedEventEmitted(
         websocket, context_id):
     await subscribe(websocket, "log.entryAdded")
-    # Send command.
-    command = {
-        "id": 14,
-        "method": "browsingContext.navigate",
-        "params": {
-            "url": "data:text/html,<script>throw new Error('some error')</script>",
-            "wait": "interactive",
-            "context": context_id
-        }
-    }
-    await send_JSON_command(websocket, command)
 
-    # Wait for responses
+    await send_JSON_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "url": "data:text/html,<script>throw new Error('some error')</script>",
+                "wait": "interactive",
+                "context": context_id
+            }
+        })
+
     event_response = await wait_for_event(websocket, "log.entryAdded")
 
-    # Assert "log.entryAdded" event emitted.
     assert {
         "method": "log.entryAdded",
         "params": {
@@ -377,7 +362,6 @@ async def test_exceptionThrown_logEntryAddedEventEmitted(
 
 @pytest.mark.asyncio
 async def test_buffer_bufferedEventsReturned(websocket, context_id):
-    # Send command.
     await send_JSON_command(
         websocket, {
             "id": 15,

--- a/tests/test_nested_browsing_context.py
+++ b/tests/test_nested_browsing_context.py
@@ -46,7 +46,7 @@ async def test_nestedBrowsingContext_navigateWaitNone_navigated(
     await subscribe(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
-    # Send command.
+
     await send_JSON_command(
         websocket, {
             "id": 13,
@@ -102,7 +102,6 @@ async def test_nestedBrowsingContext_navigateWaitInteractive_navigated(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
 
-    # Send command.
     await send_JSON_command(
         websocket, {
             "id": 14,
@@ -157,7 +156,6 @@ async def test_nestedBrowsingContext_navigateWaitComplete_navigated(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
 
-    # Send command.
     await send_JSON_command(
         websocket, {
             "id": 15,

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -263,7 +263,6 @@ async def test_script_evaluateInteractsWithDom_resultReceived(
         websocket, context_id):
     result = await execute_command(
         websocket, {
-            "id": 32,
             "method": "script.evaluate",
             "params": {
                 "expression": "'!!@@##, ' + window.location.href",

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -53,7 +53,6 @@ async def test_subscribeWithoutContext_subscribesToEventsInAllContexts(
     # Navigate to some page.
     await send_JSON_command(
         websocket, {
-            "id": get_next_command_id(),
             "method": "browsingContext.navigate",
             "params": {
                 "url": "data:text/html,<h2>test</h2>",
@@ -84,7 +83,6 @@ async def test_subscribeWithContext_subscribesToEventsInGivenContext(
     # Navigate to some page.
     await send_JSON_command(
         websocket, {
-            "id": get_next_command_id(),
             "method": "browsingContext.navigate",
             "params": {
                 "url": "data:text/html,<h2>test</h2>",
@@ -107,7 +105,6 @@ async def test_subscribeWithContext_subscribesToEventsInNestedContext(
     # Navigate to some page.
     await send_JSON_command(
         websocket, {
-            "id": get_next_command_id(),
             "method": "browsingContext.navigate",
             "params": {
                 "url": page_with_nested_iframe_url,


### PR DESCRIPTION
- remove redundant comments in E2E tests
- remove unnecessary explicit IDs in BiDi commands
- turn method comments into docstrings
- other miscellaneous changes
- add unit tests and type hints to `AnyExtending`