### PR TITLE
Remove "open-pull-requests-limit" from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,19 +9,15 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
   - package-ecosystem: pip
     directory: examples/
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
   - package-ecosystem: pip
     directory: tests/
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 1


### PR DESCRIPTION
With a cadence of monthly updates, restricting the PR limits to 1 proves to be too restrictive. The default is 5.

Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit