### PR TITLE
Fix type for `EmptyResult`

### DIFF
--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -51,7 +51,7 @@ export type BiDiMethod =
   | 'session.unsubscribe';
 // keep-sorted end
 
-export type EmptyResult = Record<string, never>;
+export type EmptyResult = Record<never, never>;
 export type EmptyResultWithCommandId = {id: number} | EmptyResult;
 
 export namespace Message {


### PR DESCRIPTION
The `Record<string,never>` brakes the Type checking (example `'error' in object` that will always be resolved as the `EmpyResult` type which is not true.

This still allows us to give it value of `{}` [Sandbox Example](https://www.typescriptlang.org/play?#code/C4TwDgpgBAogTnA9nAKuaBeKBvAUFKCBZALigGdg4BLAOwHMAafKagEzNoFcBbAIyK4AvrlyhIsHmFBoJWAEoQAxsjYAeSjQaMotCADciAPlEB6U1AASiQ3Cg2i9vgCtlwVsADk5KAEMANgDuviA+8Eio6LjmUADCABa+DNDAiFCKKnDqmnRMugbG0RbWtrqIgU6uSu7UPnyIwPFQ4hA+lNT+-rgAZly01dSItM2twAAUiC5uZDBSMuhQAD6wxJGQAJR4BNTdY55EEZ6sw5NVwJssBCq05Ij+EAB0-oj0E1PVD+zrLCIiuEA)