### PR TITLE
Treat `platformobject` in a special way.

### DIFF
--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -120,8 +120,15 @@ export class Realm {
     webDriverValue: Protocol.Runtime.WebDriverValue
   ): CommonDataTypes.RemoteValue {
     // This relies on the CDP to implement proper BiDi serialization, except
-    // backendNodeId/sharedId.
+    // backendNodeId/sharedId and `platformobject`.
     const result = webDriverValue as any;
+
+    // Platform object is a special case. It should have only `{type: object}`
+    // without `value` field.
+    if (result.type === 'platformobject') {
+      return {type: 'object'} as CommonDataTypes.RemoteValue;
+    }
+
     const bidiValue = result.value;
     if (bidiValue === undefined) {
       return result;

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -260,6 +260,10 @@ async def test_serialization_deserialization(websocket, context_id,
                           ("new Error('Woops!')", {
                               "type": "error",
                               "handle": ANY_STR
+                          }),
+                          ("new URL('https://example.com')", {
+                              "type": "object",
+                              "handle": ANY_STR
                           })])
 async def test_serialization_function(websocket, context_id, jsString,
                                       excepted_serialized):

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/call_function/result.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/call_function/result.py.ini
@@ -1,6 +1,0 @@
-[result.py]
-  [test_remote_values[new URL('https://example.com')-expected17-True\]]
-    expected: FAIL
-
-  [test_remote_values[new URL('https://example.com')-expected17-False\]]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/evaluate/result.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/evaluate/result.py.ini
@@ -1,3 +1,0 @@
-[result.py]
-  [test_remote_values[new URL('https://example.com')-expected18\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/call_function/result.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/call_function/result.py.ini
@@ -1,6 +1,0 @@
-[result.py]
-  [test_remote_values[new URL('https://example.com')-expected17-True\]]
-    expected: FAIL
-
-  [test_remote_values[new URL('https://example.com')-expected17-False\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/evaluate/result.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/evaluate/result.py.ini
@@ -1,3 +1,0 @@
-[result.py]
-  [test_remote_values[new URL('https://example.com')-expected18\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/call_function/result.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/call_function/result.py.ini
@@ -1,6 +1,0 @@
-[result.py]
-  [test_remote_values[new URL('https://example.com')-expected17-True\]]
-    expected: FAIL
-
-  [test_remote_values[new URL('https://example.com')-expected17-False\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/evaluate/result.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/evaluate/result.py.ini
@@ -1,3 +1,0 @@
-[result.py]
-  [test_remote_values[new URL('https://example.com')-expected18\]]
-    expected: FAIL


### PR DESCRIPTION
According to the serialization algorithm, platform objects should be treated in a special way, and have only `type: "object"` and maybe `handle`.

Related WPT test: [`test_remote_values[new URL('https://example.com')-expected17-True]`](https://wpt.fyi/results/webdriver/tests/bidi/script/call_function/result.py?label=experimental&label=master&aligned)