### PR TITLE
Make deferred don't  raise `Uncaught (in promise)`

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -67,7 +67,7 @@ export class BidiServer extends EventEmitter<BidiServerEvents> {
     this.#realmStorage = new RealmStorage();
     this.#messageQueue = new ProcessingQueue<OutgoingBidiMessage>(
       this.#processOutgoingMessage,
-      undefined,
+      () => Promise.resolve(),
       this.#logger
     );
     this.#transport = bidiTransport;

--- a/src/bidiMapper/OutgoingBidiMessage.ts
+++ b/src/bidiMapper/OutgoingBidiMessage.ts
@@ -33,8 +33,9 @@ export class OutgoingBidiMessage {
     messagePromise: Promise<Message.OutgoingMessage>,
     channel: string | null
   ): Promise<OutgoingBidiMessage> {
-    const message = await messagePromise;
-    return new OutgoingBidiMessage(message, channel);
+    return messagePromise.then(
+      (message) => new OutgoingBidiMessage(message, channel)
+    );
   }
 
   static createResolved(

--- a/src/utils/deferred.spec.ts
+++ b/src/utils/deferred.spec.ts
@@ -21,20 +21,33 @@ import {Deferred} from './deferred.js';
 
 describe('Deferred', () => {
   describe('isFinished', () => {
-    it('resolve', () => {
+    it('resolve', async () => {
       const deferred = new Deferred<string>();
+      const deferredThen = deferred.then((v) => v);
+      deferred.catch((e) => {
+        throw e;
+      });
+
       expect(deferred.isFinished).to.be.false;
 
       deferred.resolve('done');
       expect(deferred.isFinished).to.be.true;
+
+      await expect(deferredThen).to.eventually.equal('done');
     });
 
-    it('reject', () => {
+    it('reject', async () => {
       const deferred = new Deferred<string>();
+      const deferredThen = deferred.then(() => {});
+      const deferredCatch = deferred.catch((e) => e);
+
       expect(deferred.isFinished).to.be.false;
 
-      deferred.reject(new Error('error'));
+      deferred.reject('some error');
       expect(deferred.isFinished).to.be.true;
+
+      await expect(deferredThen).to.eventually.be.rejectedWith('some error');
+      await expect(deferredCatch).to.eventually.equal('some error');
     });
   });
 });

--- a/src/utils/deferred.ts
+++ b/src/utils/deferred.ts
@@ -31,6 +31,9 @@ export class Deferred<T> implements Promise<T> {
       this.#resolve = resolve;
       this.#reject = reject;
     });
+    // Needed to avoid `Uncaught (in promise)`. The promises returned by `then`
+    // and `catch` will be rejected anyway.
+    this.#promise.catch(() => {});
   }
 
   then<TResult1 = T, TResult2 = never>(

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -39,7 +39,7 @@ export class ProcessingQueue<T> {
   add(entry: Promise<T>) {
     this.#queue.push(entry);
     // No need in waiting. Just initialise processor if needed.
-    this.#processIfNeeded();
+    void this.#processIfNeeded();
   }
 
   async #processIfNeeded() {
@@ -55,8 +55,7 @@ export class ProcessingQueue<T> {
           .catch((e) => {
             this.#logger?.(LogType.system, 'Event was not processed:', e);
             this.#catch(e);
-          })
-          .finally();
+          });
       }
     }
 


### PR DESCRIPTION
Closes #528

I didn't find a way to add an auto test for it, but I was able to reproduce the issue manually, and it's gone after the fix.

The following exception is gone:
```
  bidiMapper:log exceptionThrown {
  timestamp: 1681290303299.3938,
  exceptionDetails: {
    exceptionId: 1,
    text: 'Uncaught (in promise)',
    lineNumber: 0,
    columnNumber: 73033,
    scriptId: '6',
    stackTrace: { callFrames: [Array] },
    exception: {
      type: 'object',
      className: 'Object',
      description: 'Object',
      objectId: '-111297914861493100.1.1',
      preview: [Object]
    },
    executionContextId: 1
  }
} +0ms
```