### PR TITLE
eslint: add consistent-generic-constructors rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     // Some rules use 'warn' in order to ease local development iteration.
     // keep-sorted start
     "@typescript-eslint/explicit-member-accessibility": ["warn", {accessibility: 'no-public'}],
+    '@typescript-eslint/consistent-generic-constructors': 'warn',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-extraneous-class': 'warn',

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -44,7 +44,7 @@ export class BrowsingContextImpl {
   readonly #contextId: string;
   readonly #parentId: string | null;
   readonly #eventManager: IEventManager;
-  readonly #children: Map<string, BrowsingContextImpl> = new Map();
+  readonly #children = new Map<string, BrowsingContextImpl>();
   readonly #realmStorage: RealmStorage;
 
   #url = 'about:blank';

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -95,21 +95,21 @@ export class EventManager implements IEventManager {
    * Needed for getting buffered events from all the contexts in case of
    * subscripting to all contexts.
    */
-  #eventToContextsMap: Map<
+  #eventToContextsMap = new Map<
     string,
     Set<CommonDataTypes.BrowsingContext | null>
-  > = new Map();
+  >();
   /**
    * Maps `eventName` + `browsingContext` to buffer. Used to get buffered events
    * during subscription. Channel-agnostic.
    */
-  #eventBuffers: Map<string, Buffer<EventWrapper>> = new Map();
+  #eventBuffers = new Map<string, Buffer<EventWrapper>>();
   /**
    * Maps `eventName` + `browsingContext` + `channel` to last sent event id.
    * Used to avoid sending duplicated events when user
    * subscribes -> unsubscribes -> subscribes.
    */
-  #lastMessageSent: Map<string, number> = new Map();
+  #lastMessageSent = new Map<string, number>();
   #subscriptionManager: SubscriptionManager;
   #bidiServer: BidiServer;
   #isNetworkDomainEnabled: boolean;

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -75,13 +75,13 @@ export class SubscriptionManager {
   // BrowsingContext `null` means the event has subscription across all the
   // browsing contexts.
   // Channel `null` means no `channel` should be added.
-  #channelToContextToEventMap: Map<
+  #channelToContextToEventMap = new Map<
     string | null,
     Map<
       CommonDataTypes.BrowsingContext | null,
       Map<Session.SubscribeParametersEvent, number>
     >
-  > = new Map();
+  >();
   #browsingContextStorage: BrowsingContextStorage;
 
   constructor(browsingContextStorage: BrowsingContextStorage) {

--- a/src/bidiMapper/domains/script/realmStorage.ts
+++ b/src/bidiMapper/domains/script/realmStorage.ts
@@ -34,7 +34,7 @@ type RealmFilter = {
 export class RealmStorage {
   /** Tracks handles and their realms sent to the client. */
   readonly #knownHandlesToRealm = new Map<string, string>();
-  readonly #realmMap: Map<string, Realm> = new Map();
+  readonly #realmMap = new Map<string, Realm>();
 
   get knownHandlesToRealm() {
     return this.#knownHandlesToRealm;

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -34,8 +34,8 @@ export class CdpConnection {
   readonly #transport: ITransport;
   readonly #browserCdpClient: CdpClient;
   /** Map from session ID to CdpClient. */
-  readonly #sessionCdpClients: Map<string, CdpClient> = new Map();
-  readonly #commandCallbacks: Map<number, CdpCallbacks> = new Map();
+  readonly #sessionCdpClients = new Map<string, CdpClient>();
+  readonly #commandCallbacks = new Map<number, CdpCallbacks>();
   readonly #log: (...messages: unknown[]) => void;
 
   #nextId = 0;


### PR DESCRIPTION
Currently our codebase is adopting a mixed style. Make it uniform to increase readability.