### PR TITLE
Improve browsing context storage encapsulation

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -18,7 +18,12 @@
 import {Protocol} from 'devtools-protocol';
 
 import {inchesFromCm} from '../../../utils/unitConversions.js';
-import {BrowsingContext, Message, Script} from '../../../protocol/protocol.js';
+import {
+  BrowsingContext,
+  CommonDataTypes,
+  Message,
+  Script,
+} from '../../../protocol/protocol.js';
 import {LoggerFn, LogType} from '../../../utils/log.js';
 import {Deferred} from '../../../utils/deferred.js';
 import {IEventManager} from '../events/EventManager.js';
@@ -30,13 +35,13 @@ import {CdpTarget} from './cdpTarget';
 
 export class BrowsingContextImpl {
   /** The ID of the current context. */
-  readonly #contextId: string;
+  readonly #contextId: CommonDataTypes.BrowsingContext;
 
   /**
    * The ID of the parent context.
    * If null, this is a top-level context.
    */
-  readonly #parentId: string | null;
+  readonly #parentId: CommonDataTypes.BrowsingContext | null;
 
   /**
    * Children contexts.
@@ -69,8 +74,8 @@ export class BrowsingContextImpl {
   private constructor(
     cdpTarget: CdpTarget,
     realmStorage: RealmStorage,
-    contextId: string,
-    parentId: string | null,
+    contextId: CommonDataTypes.BrowsingContext,
+    parentId: CommonDataTypes.BrowsingContext | null,
     eventManager: IEventManager,
     browsingContextStorage: BrowsingContextStorage,
     logger?: LoggerFn
@@ -89,8 +94,8 @@ export class BrowsingContextImpl {
   static create(
     cdpTarget: CdpTarget,
     realmStorage: RealmStorage,
-    contextId: string,
-    parentId: string | null,
+    contextId: CommonDataTypes.BrowsingContext,
+    parentId: CommonDataTypes.BrowsingContext | null,
     eventManager: IEventManager,
     browsingContextStorage: BrowsingContextStorage,
     logger?: LoggerFn
@@ -149,12 +154,12 @@ export class BrowsingContextImpl {
   }
 
   /** Returns the ID of this context. */
-  get contextId(): string {
+  get contextId(): CommonDataTypes.BrowsingContext {
     return this.#contextId;
   }
 
   /** Returns the parent context ID. */
-  get parentId(): string | null {
+  get parentId(): CommonDataTypes.BrowsingContext | null {
     return this.#parentId;
   }
 

--- a/src/bidiMapper/domains/context/browsingContextStorage.spec.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.spec.ts
@@ -30,4 +30,10 @@ describe('BrowsingContextStorage', () => {
     expect(browsingContextStorage.getAllContexts()).to.be.empty;
     expect(browsingContextStorage.getTopLevelContexts()).to.be.empty;
   });
+
+  describe('find top-level context ID', () => {
+    it('top-level context', () => {
+      expect(browsingContextStorage.findTopLevelContextId(null)).to.be.null;
+    });
+  });
 });

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -19,7 +19,7 @@ import {CommonDataTypes, Message} from '../../../protocol/protocol.js';
 
 import {BrowsingContextImpl} from './browsingContextImpl.js';
 
-/** Container class for browsing contexts.  */
+/** Container class for browsing contexts. */
 export class BrowsingContextStorage {
   /** Map from context ID to context implementation. */
   readonly #contexts = new Map<
@@ -38,7 +38,7 @@ export class BrowsingContextStorage {
   }
 
   /** Deletes the context with the given ID. */
-  deleteContext(contextId: string) {
+  deleteContext(contextId: CommonDataTypes.BrowsingContext) {
     this.#contexts.delete(contextId);
   }
 
@@ -51,17 +51,34 @@ export class BrowsingContextStorage {
   }
 
   /** Returns true whether there is an existing context with the given ID. */
-  hasContext(contextId: string): boolean {
+  hasContext(contextId: CommonDataTypes.BrowsingContext): boolean {
     return this.#contexts.has(contextId);
   }
 
   /** Gets the context with the given ID, if any. */
-  findContext(contextId: string): BrowsingContextImpl | undefined {
+  findContext(
+    contextId: CommonDataTypes.BrowsingContext
+  ): BrowsingContextImpl | undefined {
     return this.#contexts.get(contextId);
   }
 
+  /** Returns the top-level context ID of the given context, if any. */
+  findTopLevelContextId(
+    contextId: CommonDataTypes.BrowsingContext | null
+  ): CommonDataTypes.BrowsingContext | null {
+    if (contextId === null) {
+      return null;
+    }
+    const maybeContext = this.findContext(contextId);
+    const parentId = maybeContext?.parentId ?? null;
+    if (parentId === null) {
+      return contextId;
+    }
+    return this.findTopLevelContextId(parentId);
+  }
+
   /** Gets the context with the given ID, if any, otherwise throws. */
-  getContext(contextId: string): BrowsingContextImpl {
+  getContext(contextId: CommonDataTypes.BrowsingContext): BrowsingContextImpl {
     const result = this.findContext(contextId);
     if (result === undefined) {
       throw new Message.NoSuchFrameException(`Context ${contextId} not found`);

--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -21,6 +21,7 @@ import * as sinon from 'sinon';
 import {
   BrowsingContext,
   CDP,
+  CommonDataTypes,
   Log,
   Network,
   Script,
@@ -52,16 +53,22 @@ describe('SubscriptionManager', () => {
   beforeEach(() => {
     const browsingContextStorage: BrowsingContextStorage =
       sinon.createStubInstance(BrowsingContextStorage);
-    browsingContextStorage.findContext = sinon
+    browsingContextStorage.findTopLevelContextId = sinon
       .stub()
-      .callsFake((contextId: string) => {
+      .callsFake((contextId: CommonDataTypes.BrowsingContext) => {
         if (contextId === SOME_NESTED_CONTEXT) {
-          return {parentId: SOME_CONTEXT};
+          return SOME_CONTEXT;
+        }
+        if (contextId === SOME_CONTEXT) {
+          return SOME_CONTEXT;
         }
         if (contextId === ANOTHER_NESTED_CONTEXT) {
-          return {parentId: ANOTHER_CONTEXT};
+          return ANOTHER_CONTEXT;
         }
-        return {parentId: null};
+        if (contextId === ANOTHER_CONTEXT) {
+          return ANOTHER_CONTEXT;
+        }
+        return null;
       });
 
     subscriptionManager = new SubscriptionManager(browsingContextStorage);

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -124,7 +124,8 @@ export class SubscriptionManager {
       return null;
     }
 
-    const maybeTopLevelContextId = this.#findTopLevelContextId(contextId);
+    const maybeTopLevelContextId =
+      this.#browsingContextStorage.findTopLevelContextId(contextId);
 
     // `null` covers global subscription.
     const relevantContexts = [...new Set([null, maybeTopLevelContextId])];
@@ -143,27 +144,13 @@ export class SubscriptionManager {
     return Math.min(...priorities);
   }
 
-  #findTopLevelContextId(
-    contextId: CommonDataTypes.BrowsingContext | null
-  ): CommonDataTypes.BrowsingContext | null {
-    if (contextId === null) {
-      return null;
-    }
-    const maybeContext = this.#browsingContextStorage.findContext(contextId);
-    const parentId = maybeContext?.parentId ?? null;
-    if (parentId !== null) {
-      return this.#findTopLevelContextId(parentId);
-    }
-    return contextId;
-  }
-
   subscribe(
     event: Session.SubscribeParametersEvent,
     contextId: CommonDataTypes.BrowsingContext | null,
     channel: string | null
   ): void {
     // All the subscriptions are handled on the top-level contexts.
-    contextId = this.#findTopLevelContextId(contextId);
+    contextId = this.#browsingContextStorage.findTopLevelContextId(contextId);
 
     if (event === BrowsingContext.AllEvents) {
       Object.values(BrowsingContext.EventNames).map((specificEvent) =>
@@ -261,7 +248,7 @@ export class SubscriptionManager {
     channel: string | null
   ): () => void {
     // All the subscriptions are handled on the top-level contexts.
-    contextId = this.#findTopLevelContextId(contextId);
+    contextId = this.#browsingContextStorage.findTopLevelContextId(contextId);
 
     if (!this.#channelToContextToEventMap.has(channel)) {
       throw new Message.InvalidArgumentException(

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -31,7 +31,7 @@ export class Realm {
   readonly #realmStorage: RealmStorage;
   readonly #browsingContextStorage: BrowsingContextStorage;
   readonly #realmId: Script.Realm;
-  readonly #browsingContextId: string;
+  readonly #browsingContextId: CommonDataTypes.BrowsingContext;
   readonly #executionContextId: Protocol.Runtime.ExecutionContextId;
   readonly #origin: string;
   readonly #type: RealmType;
@@ -46,7 +46,7 @@ export class Realm {
     realmStorage: RealmStorage,
     browsingContextStorage: BrowsingContextStorage,
     realmId: Script.Realm,
-    browsingContextId: string,
+    browsingContextId: CommonDataTypes.BrowsingContext,
     executionContextId: Protocol.Runtime.ExecutionContextId,
     origin: string,
     type: RealmType,
@@ -188,7 +188,7 @@ export class Realm {
     );
   }
 
-  get browsingContextId(): string {
+  get browsingContextId(): CommonDataTypes.BrowsingContext {
     return this.#browsingContextId;
   }
 


### PR DESCRIPTION
- Use CommonDataTypes.BrowsingContext type instead of string
- Move findTopLevelContextId method to Browsing Context Storage