### PR TITLE
Fix BrowsingContext re-initialisation race condition

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -282,9 +282,6 @@ export class BrowsingContextImpl {
         // previous page are detached and realms are destroyed.
         // Remove context's children.
         await this.#deleteChildren();
-
-        // Remove all the already created realms.
-        this.#realmStorage.deleteRealms({browsingContextId: this.contextId});
       }
     );
 
@@ -406,6 +403,12 @@ export class BrowsingContextImpl {
         });
       }
     );
+
+    this.#cdpTarget.cdpClient.on('Runtime.executionContextsCleared', () => {
+      this.#realmStorage.deleteRealms({
+        cdpSessionId: this.#cdpTarget.cdpSessionId,
+      });
+    });
   }
 
   #getOrigin(params: Protocol.Runtime.ExecutionContextCreatedEvent) {

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -130,8 +130,8 @@ export class BrowsingContextImpl {
     return this.#loaderId;
   }
 
-  async delete() {
-    await this.#deleteChildren();
+  delete() {
+    this.#deleteChildren();
 
     this.#realmStorage.deleteRealms({
       browsingContextId: this.contextId,
@@ -272,7 +272,7 @@ export class BrowsingContextImpl {
 
     this.#cdpTarget.cdpClient.on(
       'Page.frameNavigated',
-      async (params: Protocol.Page.FrameNavigatedEvent) => {
+      (params: Protocol.Page.FrameNavigatedEvent) => {
         if (this.contextId !== params.frame.id) {
           return;
         }
@@ -281,7 +281,7 @@ export class BrowsingContextImpl {
         // At the point the page is initiated, all the nested iframes from the
         // previous page are detached and realms are destroyed.
         // Remove context's children.
-        await this.#deleteChildren();
+        this.#deleteChildren();
       }
     );
 

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -180,8 +180,8 @@ export class BrowsingContextImpl {
     this.#children.set(child.contextId, child);
   }
 
-  async #deleteChildren() {
-    await Promise.all(this.children.map((child) => child.delete()));
+  #deleteChildren() {
+    this.children.map((child) => child.delete());
   }
 
   get #defaultRealm(): Realm {


### PR DESCRIPTION
The root cause of the #620 was exactly as described @Lightning00Blade. While `Page.frameNavigated` event was fired before `Runtime.executionContextCreated`, as it's async, it's last part with cleaning realms was run after `Runtime.executionContextCreated` handled.

This fix includes 2 parts:
1. Remove all the async event handlers.
2. Rely on the `Runtime.executionContextsCleared` event rather then `Page.frameNavigated` to clean Realms.

Tested manually with Puppeteer and repro script from the https://github.com/puppeteer/puppeteer/issues/10032. Couldn't reproduce with Mapper Tab and therefor couldn't add e2e test.