### PR TITLE
rollup: add output.globals for crypto module

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
         "tsc"
       ],
       "files": [
-        "lib/cjs/bidiMapper/index.js"
+        "lib/cjs/bidiMapper/index.js",
+        "rollup.config.mjs"
       ],
       "output": [
         "lib/iife/mapperTab.js"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -25,6 +25,9 @@ export default {
     file: 'lib/iife/mapperTab.js',
     sourcemap: true,
     format: 'iife',
+    globals: {
+      crypto: 'crypto',
+    },
   },
   plugins: [nodeResolve(), commonjs(), terser()],
 };


### PR DESCRIPTION
Otherwise the mapper times out. This fixes the following error message in the logs:

	lib/cjs/bidiTab/bidiTab.js → lib/iife/mapperTab.js...
	(!) Missing global variable name
	Use output.globals to specify browser global variable names corresponding to external modules
	crypto (guessing 'require$$0')
	created lib/iife/mapperTab.js in 1s
	✅ [rollup] Executed successfully