### PR TITLE
CI: make wpt-mapper use @puppeteer/browsers package

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,9 +27,7 @@ jobs:
       - name: Install and build npm dependencies
         run: npm ci
       - name: Install Chromium
-        run: |
-          # browsers from @puppeteer/browsers
-          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
+        run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/generate-wpt-report.yml
+++ b/.github/workflows/generate-wpt-report.yml
@@ -44,9 +44,7 @@ jobs:
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: wpt
       - name: Install Chromium
-        run: |
-          # browsers from @puppeteer/browsers
-          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
+        run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Run tests
         run: >
           ./wpt/wpt run
@@ -54,7 +52,7 @@ jobs:
           --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
           --webdriver-arg="--log-path=out/chromedriver.log"
           --webdriver-arg="--verbose"
-          --binary ${{ env.chromium_binary }}
+          --binary "${{ env.chromium_binary }}"
           --install-webdriver --channel=dev --yes
           --manifest MANIFEST.json
           --metadata wpt-metadata/chromedriver/headless

--- a/.github/workflows/wpt-chromedriver.yml
+++ b/.github/workflows/wpt-chromedriver.yml
@@ -36,9 +36,7 @@ jobs:
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: wpt
       - name: Install Chromium
-        run: |
-          # browsers from @puppeteer/browsers
-          echo "chromium_binary=$(npx browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
+        run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Run tests
         timeout-minutes: 20
         run: >
@@ -47,7 +45,7 @@ jobs:
           --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
           --webdriver-arg="--log-path=out/chromedriver.log"
           --webdriver-arg="--verbose"
-          --binary ${{ env.chromium_binary }}
+          --binary "${{ env.chromium_binary }}"
           --install-webdriver --channel=dev --yes
           --manifest MANIFEST.json
           --metadata wpt-metadata/chromedriver/headless

--- a/.github/workflows/wpt-mapper.yml
+++ b/.github/workflows/wpt-mapper.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       # Don't cancel workflow in case of one of the actions failed and let all the
-      # workflows produce artefacts.
+      # workflows produce artifacts.
       fail-fast: false
       matrix:
         include:
@@ -48,15 +48,8 @@ jobs:
       - name: Set up hosts
         run: ./wpt make-hosts-file | sudo tee -a /etc/hosts
         working-directory: wpt
-      # TODO: Install a pinned version of Chromium. This may become possible
-      # after https://github.com/web-platform-tests/wpt/issues/28970.
       - name: Install Chromium
-        # This installs dev chrome to `/usr/bin/google-chrome-unstable`.
-        run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-unstable
+        run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
       - name: Run tests
         timeout-minutes: 20
         # For verbose logging, add --log-mach - --log-mach-level info
@@ -65,12 +58,12 @@ jobs:
           ./wpt/wpt run
           --webdriver-binary runBiDiServer.sh
           ${{ matrix.wpt_headless_argument }}
-          --binary /usr/bin/google-chrome-unstable
+          --binary "${{ env.chromium_binary }}"
           --manifest MANIFEST.json
           --metadata wpt-metadata/mapper/${{ matrix.head }}
           --log-wptreport out/wptreport-mapper.json
           --timeout-multiplier 8
-          chromium
+          chrome
           webdriver/tests/bidi/
       - name: Generate HTML test report
         # Force run task even if the previous tasks failed.


### PR DESCRIPTION
All other CI actions already use it, this is the last one left to migrate.