### PR TITLE
Uniformly use runWPT.sh everywhere in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,21 +37,20 @@ jobs:
         run: pip install -r tests/requirements.txt
       - name: Run E2E tests
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.head == 'headful' }}
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: >
-          VERBOSE=true
-          DEBUG=*
-          CHROME_BIN="${{ env.chromium_binary }}"
           xvfb-run --auto-servernum
           npm run e2e-${{ matrix.head }}
+        # For verbose logging, set `DEBUG: 'bidiMapper:mapperDebug:*'` and `VERBOSE: true`.
+        env:
+          BROWSER_BIN: ${{ env.chromium_binary }}
       - name: Run E2E tests
         if: ${{ matrix.os == 'macos-latest' || (matrix.os == 'ubuntu-latest' && matrix.head == 'headless') }}
-        timeout-minutes: 15
-        run: >
-          VERBOSE=true
-          DEBUG=*
-          CHROME_BIN="${{ env.chromium_binary }}"
-          npm run e2e-${{ matrix.head }}
+        timeout-minutes: 20
+        run: npm run e2e-${{ matrix.head }}
+        # For verbose logging, set `DEBUG: 'bidiMapper:mapperDebug:*'` and `VERBOSE: true`.
+        env:
+          BROWSER_BIN: ${{ env.chromium_binary }}
       - name: Upload artifacts
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
@@ -63,3 +62,4 @@ jobs:
 env:
   DEBUG: bidiServer:log
   FORCE_COLOR: 3
+  PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/generate-wpt-report.yml
+++ b/.github/workflows/generate-wpt-report.yml
@@ -45,20 +45,12 @@ jobs:
         working-directory: wpt
       - name: Install Chromium
         run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
-      - name: Run tests
-        run: >
-          ./wpt/wpt run
-          --binary-arg="--headless=new"
-          --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
-          --webdriver-arg="--log-path=out/chromedriver.log"
-          --webdriver-arg="--verbose"
-          --binary "${{ env.chromium_binary }}"
-          --install-webdriver --channel=dev --yes
-          --manifest MANIFEST.json
-          --metadata wpt-metadata/chromedriver/headless
-          --log-wptreport out/wptreport-chromedriver.json
-          chrome
-          webdriver/tests/bidi/
+      - name: Run WPT tests
+        run: ./runWPT.sh webdriver/tests/bidi/
+        env:
+          BROWSER_BIN: ${{ env.chromium_binary }}
+          CHROMEDRIVER: true
+          WPT_REPORT: out/wptreport.json
       - name: Generate HTML test report
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
@@ -93,3 +85,4 @@ jobs:
 env:
   DEBUG: bidiServer:log
   FORCE_COLOR: 3
+  PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -37,3 +37,4 @@ jobs:
 
 env:
   FORCE_COLOR: 3
+  PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/wpt-chromedriver.yml
+++ b/.github/workflows/wpt-chromedriver.yml
@@ -37,28 +37,21 @@ jobs:
         working-directory: wpt
       - name: Install Chromium
         run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
-      - name: Run tests
-        timeout-minutes: 20
-        run: >
-          ./wpt/wpt run
-          --binary-arg="--headless=new"
-          --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
-          --webdriver-arg="--log-path=out/chromedriver.log"
-          --webdriver-arg="--verbose"
-          --binary "${{ env.chromium_binary }}"
-          --install-webdriver --channel=dev --yes
-          --manifest MANIFEST.json
-          --metadata wpt-metadata/chromedriver/headless
-          --log-wptreport out/wptreport-chromedriver.json
-          chrome
-          webdriver/tests/bidi/
+      - name: Run WPT tests
+        timeout-minutes: 30
+        # For verbose logging, add --log-mach - --log-mach-level info
+        run: ./runWPT.sh webdriver/tests/bidi/
+        env:
+          BROWSER_BIN: ${{ env.chromium_binary }}
+          CHROMEDRIVER: true
+          WPT_REPORT: out/wptreport.json
       - name: Generate HTML test report
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
         run: >
           node test-report/htmlWptReport.mjs
-          out/wptreport-chromedriver.json
-          out/wptreport-chromedriver.html
+          out/wptreport.json
+          out/wptreport.html
       - name: Update expectations
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
@@ -67,7 +60,7 @@ jobs:
           --product chromium
           --manifest MANIFEST.json
           --metadata wpt-metadata/chromedriver/headless
-          out/wptreport-chromedriver.json
+          out/wptreport.json
       - name: Upload expectations
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
@@ -86,3 +79,4 @@ jobs:
 env:
   DEBUG: bidiServer:log
   FORCE_COLOR: 3
+  PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/wpt-mapper.yml
+++ b/.github/workflows/wpt-mapper.yml
@@ -16,13 +16,8 @@ jobs:
       # workflows produce artifacts.
       fail-fast: false
       matrix:
-        include:
-          - head: headful
-            headless_command_prefix: xvfb-run --auto-servernum
-            wpt_headless_argument: --webdriver-arg="--headless=false"
-          - head: headless
-            headless_command_prefix: ''
-            wpt_headless_argument: --webdriver-arg="--headless=true"
+        os: [ubuntu-latest]
+        head: [headful, headless]
     name: ${{ matrix.head }}
     steps:
       - name: Checkout
@@ -50,28 +45,33 @@ jobs:
         working-directory: wpt
       - name: Install Chromium
         run: echo "chromium_binary=$(npx @puppeteer/browsers install chromium@latest | cut -f 2 -d' ')" >> $GITHUB_ENV
-      - name: Run tests
-        timeout-minutes: 20
+      - name: Run WPT tests
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.head == 'headful' }}
+        timeout-minutes: 30
         # For verbose logging, add --log-mach - --log-mach-level info
         run: >
-          ${{ matrix.headless_command_prefix }}
-          ./wpt/wpt run
-          --webdriver-binary runBiDiServer.sh
-          ${{ matrix.wpt_headless_argument }}
-          --binary "${{ env.chromium_binary }}"
-          --manifest MANIFEST.json
-          --metadata wpt-metadata/mapper/${{ matrix.head }}
-          --log-wptreport out/wptreport-mapper.json
-          --timeout-multiplier 8
-          chrome
-          webdriver/tests/bidi/
+          xvfb-run --auto-servernum
+          ./runWPT.sh webdriver/tests/bidi/
+        env:
+          BROWSER_BIN: ${{ env.chromium_binary }}
+          HEADLESS: false
+          WPT_REPORT: out/wptreport.json
+      - name: Run WPT tests
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.head == 'headless' }}
+        timeout-minutes: 30
+        # For verbose logging, add --log-mach - --log-mach-level info
+        run: ./runWPT.sh webdriver/tests/bidi/
+        env:
+          BROWSER_BIN: ${{ env.chromium_binary }}
+          HEADLESS: true
+          WPT_REPORT: out/wptreport.json
       - name: Generate HTML test report
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
         run: >
           node test-report/htmlWptReport.mjs
-          out/wptreport-mapper.json
-          out/wptreport-mapper.html
+          out/wptreport.json
+          out/wptreport.html
       - name: Update expectations
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
@@ -80,7 +80,7 @@ jobs:
           --product chromium
           --manifest MANIFEST.json
           --metadata wpt-metadata/mapper/${{ matrix.head }}
-          out/wptreport-mapper.json
+          out/wptreport.json
       - name: Upload expectations
         # Force run task even if the previous tasks failed.
         if: ${{ always() }}
@@ -101,3 +101,4 @@ jobs:
 env:
   DEBUG: bidiServer:log
   FORCE_COLOR: 3
+  PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/README.md
+++ b/README.md
@@ -296,22 +296,22 @@ python wpt make-hosts-file | Out-File $env:SystemRoot\System32\drivers\etc\hosts
 If you are behind a proxy, you also need to make sure the domains above are excluded
 from your proxy lookups.
 
-#### 5. Set `WPT_BROWSER_PATH`
+#### 5. Set `BROWSER_BIN`
 
-Set the `WPT_BROWSER_PATH` environment variable to a Chrome, Edge or Chromium binary to launch.
+Set the `BROWSER_BIN` environment variable to a Chrome, Edge or Chromium binary to launch.
 For example, on macOS:
 
 ```sh
 # Chrome
-export WPT_BROWSER_PATH="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
-export WPT_BROWSER_PATH="/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev"
-export WPT_BROWSER_PATH="/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta"
-export WPT_BROWSER_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-export WPT_BROWSER_PATH="/Applications/Chromium.app/Contents/MacOS/Chromium"
+export BROWSER_BIN="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
+export BROWSER_BIN="/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev"
+export BROWSER_BIN="/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta"
+export BROWSER_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+export BROWSER_BIN="/Applications/Chromium.app/Contents/MacOS/Chromium"
 
 # Edge
-export WPT_BROWSER_PATH="/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary"
-export WPT_BROWSER_PATH="/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+export BROWSER_BIN="/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary"
+export BROWSER_BIN="/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
 ```
 
 ### Run WPT tests
@@ -339,7 +339,7 @@ npm run build --watch
 ```sh
 ./wpt/wpt run \
   --webdriver-binary runBiDiServer.sh \
-  --binary "$WPT_BROWSER_PATH" \
+  --binary "$BROWSER_BIN" \
   --manifest wpt/MANIFEST.json \
   --metadata wpt-metadata/mapper/headless \
   chromium \
@@ -353,7 +353,7 @@ npm run build --watch
 ```sh
 ./wpt/wpt run \
   --webdriver-binary runBiDiServer.sh \
-  --binary "$WPT_BROWSER_PATH" \
+  --binary "$BROWSER_BIN" \
   --manifest wpt/MANIFEST.json \
   --metadata wpt-metadata/mapper/headless \
   --log-wptreport wptreport.json \

--- a/runBiDiServer.sh
+++ b/runBiDiServer.sh
@@ -8,7 +8,7 @@ log() {
 }
 
 usage() {
-  log "Usage: [CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [HEADLESS=<true | false>] [PORT=8080] $0 [--headless=<true | false>]"
+  log "Usage: [CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [DEBUG_COLORS=<yes | no>] [HEADLESS=<true | false>] [LOG_DIR=logs] [NODE_OPTIONS=--unhandled-rejections=strict] [PORT=8080] $0 [--headless=<true | false>]"
   log
   log "The --headless flag takes precedence over the HEADLESS environment variable."
 }
@@ -21,17 +21,15 @@ fi
 # The chrome release channel to use: `stable`, `beta`, `canary`, `dev`.
 readonly CHANNEL="${CHANNEL:-dev}"
 
-# Options from npm 'debug' package.
-readonly DEBUG="${DEBUG:-*}"
+# Options from npm 'debug' package. DEBUG= (empty) is allowed, hence no colon below.
+readonly DEBUG="${DEBUG-*}"
 readonly DEBUG_COLORS="${DEBUG_COLORS:-yes}"
 
 # Whether to start the server in headless or headful mode.
 readonly HEADLESS="${HEADLESS:-true}"
 
-# The directory wherein to store logs.
+# The directory and file wherein to store BiDi logs.
 readonly LOG_DIR="${LOG_DIR:-logs}"
-
-# The file to which to write BiDi logs.
 readonly LOG_FILE="$LOG_DIR/$(date '+%Y-%m-%d-%H-%M-%S').log"
 
 # Node.JS options
@@ -40,15 +38,13 @@ readonly NODE_OPTIONS="${NODE_OPTIONS:---unhandled-rejections=strict}"
 # The port on which to start the BiDi server.
 readonly PORT="${PORT:-8080}"
 
-log "Starting BiDi Server..."
+log "Starting BiDi Server with DEBUG='$DEBUG'..."
 
-# Go to the project root folder.
 (cd "$(dirname "$0")/" && \
-# Create a folder to store logs.
 mkdir -p "$LOG_DIR" && \
 env \
 DEBUG="$DEBUG" \
 DEBUG_COLORS="$DEBUG_COLORS" \
 NODE_OPTIONS="$NODE_OPTIONS" \
 PORT="$PORT" \
-node lib/cjs/bidiServer/index.js --channel="$CHANNEL" --headless="$HEADLESS" "$@" 2>&1 | tee -a "$LOG_FILE")
+node lib/cjs/bidiServer/index.js --channel "$CHANNEL" --headless "$HEADLESS" "$@" 2>&1 | tee -a "$LOG_FILE")

--- a/runWPT.sh
+++ b/runWPT.sh
@@ -8,13 +8,19 @@ log() {
 }
 
 usage() {
-  log "Usage: [HEADLESS=<true | false>] [UPDATE_EXPECTATIONS=<true | false>] $0 [webdriver/tests/bidi/[...]]"
+  log "Usage: [CHROMEDRIVER=<true | false>] [HEADLESS=<true | false>] [UPDATE_EXPECTATIONS=<true | false>] $0 [webdriver/tests/bidi/[...]]"
 }
 
 if [[ $# -gt 0 && ("$1" == "-h" || "$1" == "--help") ]]; then
   usage
   exit 0
 fi
+
+# The path to the browser binary.
+readonly BROWSER_BIN="${BROWSER_BIN:-/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev}"
+
+# Whether to use Chromedriver with mapper.
+readonly CHROMEDRIVER="${CHROMEDRIVER:-false}"
 
 # Whether to start the server in headless or headful mode.
 readonly HEADLESS="${HEADLESS:-true}"
@@ -23,13 +29,13 @@ readonly HEADLESS="${HEADLESS:-true}"
 readonly MANIFEST="${MANIFEST:-MANIFEST.json}"
 
 # The browser product to test.
-readonly PRODUCT="${PRODUCT:-chromium}"
+readonly PRODUCT="${PRODUCT:-chrome}"
+
+# Multiplier relative to standard test timeout to use.
+readonly TIMEOUT_MULTIPLIER="${TIMEOUT_MULTIPLIER:-8}"
 
 # Whether to update the WPT expectations after running the tests.
-readonly UPDATE_EXPECTATIONS="${UPDATE_EXPECTATIONS:-true}"
-
-# The path to the browser binary.
-readonly WPT_BROWSER_PATH="${WPT_BROWSER_PATH:-/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev}"
+readonly UPDATE_EXPECTATIONS="${UPDATE_EXPECTATIONS:-false}"
 
 # The path to the WPT report file.
 readonly WPT_REPORT="${WPT_REPORT:-wptreport.json}"
@@ -37,11 +43,16 @@ readonly WPT_REPORT="${WPT_REPORT:-wptreport.json}"
 # Only set WPT_METADATA if it's not already set.
 if [ -z ${WPT_METADATA+x} ]; then
   # The path to the WPT metadata directory.
-  if [[ "$HEADLESS" == "true" ]]; then
-    readonly WPT_METADATA="wpt-metadata/mapper/headless"
+  if [[ "$CHROMEDRIVER" == "true" ]]; then
+    readonly WPT_METADATA="wpt-metadata/chromedriver/headless"
   else
-    readonly WPT_METADATA="wpt-metadata/mapper/headful"
+    if [[ "$HEADLESS" == "true" ]]; then
+      readonly WPT_METADATA="wpt-metadata/mapper/headless"
+    else
+      readonly WPT_METADATA="wpt-metadata/mapper/headful"
+    fi
   fi
+
 fi
 
 if [[ "$HEADLESS" == "true" ]]; then
@@ -50,18 +61,37 @@ else
   log "Running WPT in headful mode..."
 fi
 
-# Go to the project root folder.
-(cd "$(dirname "$0")/" && \
-./wpt/wpt run \
-  --binary "$WPT_BROWSER_PATH" \
-  --webdriver-binary runBiDiServer.sh \
-  --webdriver-arg="--headless=$HEADLESS" \
-  --log-wptreport "$WPT_REPORT" \
-  --manifest "$MANIFEST" \
-  --metadata "$WPT_METADATA" \
-  --timeout-multiplier 8 \
-  "$PRODUCT" \
-  "$@")
+declare -a WPT_RUN_ARGS=(
+  --binary "$BROWSER_BIN"
+  --webdriver-binary runBiDiServer.sh
+  --webdriver-arg="--headless=$HEADLESS"
+  --log-wptreport "$WPT_REPORT"
+  --manifest "$MANIFEST"
+  --metadata "$WPT_METADATA"
+  --timeout-multiplier "$TIMEOUT_MULTIPLIER"
+)
+
+if [[ "$CHROMEDRIVER" == "true" ]]; then
+  log "Using Chromedriver with mapper..."
+  WPT_RUN_ARGS+=(
+    --binary-arg="--headless=new"
+    --install-webdriver
+    --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js"
+    --webdriver-arg="--log-path=out/chromedriver.log"
+    --webdriver-arg="--verbose"
+    --channel=dev
+    --yes
+  )
+else
+  log "Using pure mapper..."
+fi
+
+WPT_RUN_ARGS+=(
+  "$PRODUCT"
+  "$@"
+)
+
+(cd "$(dirname "$0")/" && ./wpt/wpt run "${WPT_RUN_ARGS[@]}")
 
 if [[ "$UPDATE_EXPECTATIONS" == "true" ]]; then
   log "Updating WPT expectations..."
@@ -78,6 +108,6 @@ fi
 # Run with locally built Chromium and Chromedriver, after
 # `autoninja -C out/Default chrome chromedriver`:
 #
-#   --binary "$WPT_BROWSER_PATH" \
+#   --binary "$BROWSER_BIN" \
 #   --webdriver-binary /path/to/chromium/src/out/Default/chromedriver \
-#   --webdriver-arg="--bidi-mapper-path=$PWD/lib/iife/mapperTab.js" \
+#   --webdriver-arg="--bidi-mapper-path=lib/iife/mapperTab.js" \

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -132,7 +132,7 @@ async function onNewBidiConnectionOpen(
   ];
 
   const executablePath =
-    process.env['CHROME_BIN'] ??
+    process.env['BROWSER_BIN'] ??
     computeSystemExecutablePath({
       browser: Browser.CHROME,
       channel: chromeChannel ?? ChromeReleaseChannel.DEV,


### PR DESCRIPTION
And do a bunch of CI standardization and cleanup:

- add CHROMEDRIVER variable to runWPT.sh
- do not update expectations by default
- expose --timeout-multiplier as a variable
- github actions: simplify matrix
- github actions: use env: construct
- pip: set PIP_DISABLE_PIP_VERSION_CHECK=1 to reduce log noise in CI
- rename WPT_BROWSER_PATH / CHROME_BIN -> BROWSER_BIN for simplicity