### PR TITLE
chore: revert Protocol to Puppeteer's version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "chai-as-promised": "7.1.1",
         "chai-exclude": "2.1.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1134390",
+        "devtools-protocol": "0.0.1107588",
         "eslint": "8.39.0",
         "eslint-config-prettier": "8.8.0",
         "eslint-plugin-import": "2.27.5",
@@ -2414,9 +2414,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1134390",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1134390.tgz",
-      "integrity": "sha512-FrtMt+74zsgzai6N3VN8D7pxnjkBmfaYqLF2oIcKo2/K1AmTPVbRZrFrAkUukZX1PoV8czbV/Cj2lbt1p+MCUQ==",
+      "version": "0.0.1107588",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
+      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
       "dev": true
     },
     "node_modules/diff": {
@@ -9347,9 +9347,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.1134390",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1134390.tgz",
-      "integrity": "sha512-FrtMt+74zsgzai6N3VN8D7pxnjkBmfaYqLF2oIcKo2/K1AmTPVbRZrFrAkUukZX1PoV8czbV/Cj2lbt1p+MCUQ==",
+      "version": "0.0.1107588",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
+      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
       "dev": true
     },
     "diff": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "chai-as-promised": "7.1.1",
     "chai-exclude": "2.1.0",
     "debug": "4.3.4",
-    "devtools-protocol": "0.0.1134390",
+    "devtools-protocol": "0.0.1107588",
     "eslint": "8.39.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-import": "2.27.5",


### PR DESCRIPTION
Building mapper locally (`npm link`) will use it's `node_modules` so we will have two different version of `devtools-protocol` of the Puppeteer side. That makes the Types incompatible with each other. Let's keep them in sync unless that is something that mapper need. 