### PR TITLE
prefactor browsing context classes and add all children method

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -83,8 +83,6 @@ export class BrowsingContextImpl {
     this.#eventManager = eventManager;
     this.#browsingContextStorage = browsingContextStorage;
     this.#logger = logger;
-
-    this.#initListeners();
   }
 
   static create(
@@ -105,6 +103,8 @@ export class BrowsingContextImpl {
       browsingContextStorage,
       logger
     );
+
+    context.#initListeners();
 
     browsingContextStorage.addContext(context);
     if (!context.isTopLevelContext()) {

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -108,7 +108,7 @@ export class BrowsingContextImpl {
 
     browsingContextStorage.addContext(context);
     if (!context.isTopLevelContext()) {
-      browsingContextStorage.getContext(context.parentId!).addChild(context.id);
+      context.parent!.addChild(context.id);
     }
 
     eventManager.registerEvent(
@@ -138,8 +138,7 @@ export class BrowsingContextImpl {
 
     // Remove context from the parent.
     if (!this.isTopLevelContext()) {
-      const parent = this.#browsingContextStorage.getContext(this.parentId!);
-      parent.#children.delete(this.id);
+      this.parent!.#children.delete(this.id);
     }
 
     this.#eventManager.registerEvent(
@@ -160,6 +159,14 @@ export class BrowsingContextImpl {
   /** Returns the parent context ID. */
   get parentId(): CommonDataTypes.BrowsingContext | null {
     return this.#parentId;
+  }
+
+  /** Returns the parent context. */
+  get parent(): BrowsingContextImpl | null {
+    if (this.parentId === null) {
+      return null;
+    }
+    return this.#browsingContextStorage.getContext(this.parentId);
   }
 
   /** Returns all direct children contexts. */

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -130,7 +130,7 @@ export class BrowsingContextImpl {
   }
 
   delete() {
-    this.#deleteChildren();
+    this.#deleteAllChildren();
 
     this.#realmStorage.deleteRealms({
       browsingContextId: this.id,
@@ -180,7 +180,7 @@ export class BrowsingContextImpl {
     this.#children.add(childId);
   }
 
-  #deleteChildren() {
+  #deleteAllChildren() {
     this.directChildren.map((child) => child.delete());
   }
 
@@ -279,7 +279,7 @@ export class BrowsingContextImpl {
         // At the point the page is initialized, all the nested iframes from the
         // previous page are detached and realms are destroyed.
         // Remove children from context.
-        this.#deleteChildren();
+        this.#deleteAllChildren();
       }
     );
 

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -175,6 +175,13 @@ export class BrowsingContextImpl {
       this.#browsingContextStorage.getContext(id)
     );
   }
+
+  /** Returns all children contexts, flattened. */
+  get allChildren(): BrowsingContextImpl[] {
+    const children = this.directChildren;
+    return children.concat(...children.map((child) => child.allChildren));
+  }
+
   /**
    * Returns true if this is a top-level context.
    * This is the case whenever the parent context ID is null.

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -29,7 +29,9 @@ export class BrowsingContextStorage {
 
   /** Gets all top-level contexts, i.e. those with no parent. */
   getTopLevelContexts(): BrowsingContextImpl[] {
-    return this.getAllContexts().filter((c) => c.isTopLevelContext());
+    return this.getAllContexts().filter((context) =>
+      context.isTopLevelContext()
+    );
   }
 
   /** Gets all contexts. */
@@ -38,16 +40,18 @@ export class BrowsingContextStorage {
   }
 
   /** Deletes the context with the given ID. */
-  deleteContext(contextId: CommonDataTypes.BrowsingContext) {
+  deleteContextById(contextId: CommonDataTypes.BrowsingContext) {
     this.#contexts.delete(contextId);
   }
 
-  /** Adds the given context. */
+  /** Deletes the given context. */
+  deleteContext(context: BrowsingContextImpl) {
+    this.#contexts.delete(context.contextId);
+  }
+
+  /** Tracks the given context. */
   addContext(context: BrowsingContextImpl) {
     this.#contexts.set(context.contextId, context);
-    if (!context.isTopLevelContext()) {
-      this.getContext(context.parentId!).addChild(context);
-    }
   }
 
   /** Returns true whether there is an existing context with the given ID. */
@@ -75,6 +79,17 @@ export class BrowsingContextStorage {
       return contextId;
     }
     return this.findTopLevelContextId(parentId);
+  }
+
+  /** Returns the top-level context of the given context, if any. */
+  findTopLevelContext(
+    contextId: CommonDataTypes.BrowsingContext | null
+  ): BrowsingContextImpl | null | undefined {
+    const topLevelContextId = this.findTopLevelContextId(contextId);
+    if (topLevelContextId === null) {
+      return null;
+    }
+    return this.findContext(topLevelContextId);
   }
 
   /** Gets the context with the given ID, if any, otherwise throws. */

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -40,52 +40,52 @@ export class BrowsingContextStorage {
   }
 
   /** Deletes the context with the given ID. */
-  deleteContextById(contextId: CommonDataTypes.BrowsingContext) {
-    this.#contexts.delete(contextId);
+  deleteContextById(id: CommonDataTypes.BrowsingContext) {
+    this.#contexts.delete(id);
   }
 
   /** Deletes the given context. */
   deleteContext(context: BrowsingContextImpl) {
-    this.#contexts.delete(context.contextId);
+    this.#contexts.delete(context.id);
   }
 
   /** Tracks the given context. */
   addContext(context: BrowsingContextImpl) {
-    this.#contexts.set(context.contextId, context);
+    this.#contexts.set(context.id, context);
   }
 
   /** Returns true whether there is an existing context with the given ID. */
-  hasContext(contextId: CommonDataTypes.BrowsingContext): boolean {
-    return this.#contexts.has(contextId);
+  hasContext(id: CommonDataTypes.BrowsingContext): boolean {
+    return this.#contexts.has(id);
   }
 
   /** Gets the context with the given ID, if any. */
   findContext(
-    contextId: CommonDataTypes.BrowsingContext
+    id: CommonDataTypes.BrowsingContext
   ): BrowsingContextImpl | undefined {
-    return this.#contexts.get(contextId);
+    return this.#contexts.get(id);
   }
 
   /** Returns the top-level context ID of the given context, if any. */
   findTopLevelContextId(
-    contextId: CommonDataTypes.BrowsingContext | null
+    id: CommonDataTypes.BrowsingContext | null
   ): CommonDataTypes.BrowsingContext | null {
-    if (contextId === null) {
+    if (id === null) {
       return null;
     }
-    const maybeContext = this.findContext(contextId);
+    const maybeContext = this.findContext(id);
     const parentId = maybeContext?.parentId ?? null;
     if (parentId === null) {
-      return contextId;
+      return id;
     }
     return this.findTopLevelContextId(parentId);
   }
 
   /** Returns the top-level context of the given context, if any. */
   findTopLevelContext(
-    contextId: CommonDataTypes.BrowsingContext | null
+    id: CommonDataTypes.BrowsingContext | null
   ): BrowsingContextImpl | null | undefined {
-    const topLevelContextId = this.findTopLevelContextId(contextId);
+    const topLevelContextId = this.findTopLevelContextId(id);
     if (topLevelContextId === null) {
       return null;
     }
@@ -93,10 +93,10 @@ export class BrowsingContextStorage {
   }
 
   /** Gets the context with the given ID, if any, otherwise throws. */
-  getContext(contextId: CommonDataTypes.BrowsingContext): BrowsingContextImpl {
-    const result = this.findContext(contextId);
+  getContext(id: CommonDataTypes.BrowsingContext): BrowsingContextImpl {
+    const result = this.findContext(id);
     if (result === undefined) {
-      throw new Message.NoSuchFrameException(`Context ${contextId} not found`);
+      throw new Message.NoSuchFrameException(`Context ${id} not found`);
     }
     return result;
   }


### PR DESCRIPTION
The main purpose of this PR is to add `allChildren()` (flattened), but I did some prefactoring as well.

The main benefit now is that `BrowsingContextImpl` is now only stored in the storage. It's not duplicated in the `Impl` class itself via children. This makes it easier to maintain it / reason about it.