### PR TITLE
hotfix: fix test_serialization: include children in assertion

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -16,7 +16,7 @@
 import copy
 
 import pytest
-from anys import ANY_STR
+from anys import ANY_LIST, ANY_STR
 from test_helpers import (ANY_SHARED_ID, execute_command, goto_url,
                           read_JSON_message, send_JSON_command, subscribe)
 
@@ -502,6 +502,7 @@ async def test_serialization_nested_node(websocket, context_id, html,
             "localName": "div",
             "namespaceURI": "http://www.w3.org/1999/xhtml",
             "childNodeCount": 2,
+            "children": ANY_LIST,
             "attributes": {
                 "some_attr_name": "some_attr_value"
             },


### PR DESCRIPTION
Fixes e.g. https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/4929488274/jobs/8809183115, which is failing at HEAD (due to `chromium@latest` in CI).