### PR TITLE
fix: suppress error for Target closed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,7 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-extraneous-class': 'warn',
-    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -16,7 +16,7 @@
  */
 
 import {EventEmitter} from '../utils/EventEmitter.js';
-import {LoggerFn} from '../utils/log.js';
+import {LogType, LoggerFn} from '../utils/log.js';
 import type {Message} from '../protocol/protocol.js';
 import {ProcessingQueue} from '../utils/processingQueue.js';
 
@@ -41,7 +41,9 @@ export class BidiServer extends EventEmitter<BidiServerEvents> {
   #logger?: LoggerFn;
 
   #handleIncomingMessage = (message: Message.RawCommandRequest) => {
-    this.#commandProcessor.processCommand(message);
+    void this.#commandProcessor.processCommand(message).catch((error) => {
+      this.#logger?.(LogType.system, error);
+    });
   };
 
   #processOutgoingMessage = async (messageEntry: OutgoingBidiMessage) => {
@@ -67,7 +69,6 @@ export class BidiServer extends EventEmitter<BidiServerEvents> {
     this.#realmStorage = new RealmStorage();
     this.#messageQueue = new ProcessingQueue<OutgoingBidiMessage>(
       this.#processOutgoingMessage,
-      () => Promise.resolve(),
       this.#logger
     );
     this.#transport = bidiTransport;

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -397,7 +397,8 @@ export class BrowsingContextImpl {
             : undefined,
           this.#cdpTarget.cdpSessionId,
           this.#cdpTarget.cdpClient,
-          this.#eventManager
+          this.#eventManager,
+          this.#logger
         );
 
         if (params.context.auxData.isDefault) {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -131,7 +131,8 @@ export class BrowsingContextProcessor {
         .sendCommand('Runtime.runIfWaitingForDebugger')
         .then(() =>
           parentSessionCdpClient.sendCommand('Target.detachFromTarget', params)
-        );
+        )
+        .catch((error) => this.#logger?.(LogType.system, error));
       return;
     }
 

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -106,7 +106,10 @@ export class CdpConnection {
 
       const messageStr = JSON.stringify(messageObj);
       const messagePretty = JSON.stringify(messageObj, null, 2);
-      this.#transport.sendMessage(messageStr);
+      void this.#transport.sendMessage(messageStr)?.catch((error) => {
+        this.#log('error', error);
+        this.#transport.close();
+      });
       this.#log('sent ▸', messagePretty);
     });
   }

--- a/src/utils/processingQueue.spec.ts
+++ b/src/utils/processingQueue.spec.ts
@@ -53,8 +53,8 @@ describe('ProcessingQueue', () => {
   it('rejects should not stop processing', async () => {
     const error = new Error('Processor reject');
     const processor = sinon.stub().returns(Promise.reject(error));
-    const mycatch = sinon.spy();
-    const queue = new ProcessingQueue<number>(processor, mycatch);
+    const logger = sinon.spy();
+    const queue = new ProcessingQueue<number>(processor, logger);
     const deferred1 = new Deferred<number>();
     const deferred2 = new Deferred<number>();
 
@@ -69,7 +69,7 @@ describe('ProcessingQueue', () => {
     sinon.assert.calledOnceWithExactly(processor, 2);
 
     // Assert `_catch` was called for waiting entry and processor call.
-    const processedValues = mycatch.getCalls().map((c) => c.firstArg);
+    const processedValues = logger.getCalls().map((c) => c.args[2]);
     expect(processedValues).to.deep.equal([1, error]);
   });
 

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -18,7 +18,6 @@
 import {LogType, LoggerFn} from './log.js';
 
 export class ProcessingQueue<T> {
-  readonly #catch: (error: unknown) => Promise<void>;
   readonly #logger?: LoggerFn;
   readonly #processor: (arg: T) => Promise<void>;
   readonly #queue: Promise<T>[] = [];
@@ -26,12 +25,7 @@ export class ProcessingQueue<T> {
   // Flag to keep only 1 active processor.
   #isProcessing = false;
 
-  constructor(
-    processor: (arg: T) => Promise<void>,
-    _catch: (error: unknown) => Promise<void> = () => Promise.resolve(),
-    logger?: LoggerFn
-  ) {
-    this.#catch = _catch;
+  constructor(processor: (arg: T) => Promise<void>, logger?: LoggerFn) {
     this.#processor = processor;
     this.#logger = logger;
   }
@@ -54,7 +48,6 @@ export class ProcessingQueue<T> {
           .then((entry) => this.#processor(entry))
           .catch((e) => {
             this.#logger?.(LogType.system, 'Event was not processed:', e);
-            this.#catch(e);
           });
       }
     }


### PR DESCRIPTION
We saw that in our (Puppeteer) test we never close the page. [Action](https://github.com/puppeteer/puppeteer/actions/runs/4936034522/jobs/8823137946?pr=10121). 
For some of our test that don't require a browser, this open -> close happens too fast so the initialization never succeeded and Mapper throws Unhandled Errors.

This PR is an attempt to fix it, but can't verify as test pass locally.