### PR TITLE
chore: add concurrency options to workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     strategy:

--- a/.github/workflows/generate-wpt-report.yml
+++ b/.github/workflows/generate-wpt-report.yml
@@ -13,6 +13,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   wpt:
     environment:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   wpt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
so that GitHub actions can cancel the runs for outdated commits.
See https://docs.github.com/en/actions/using-jobs/using-concurrency