### PR TITLE
Remove unneeded files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     }
   },
   "files": [
-    "lib"
+    "lib",
+    "!lib/**/*.spec.*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Spec files are not necessary.

Bug: #727
Closes: #727
Docs: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files
Test: `npm publish --dry-run`