### PR TITLE
pre-commit: add prettier v2.8.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,8 @@ repos:
     rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
+        additional_dependencies:
+          - prettier@2.8.8
   - repo: https://github.com/google/yapf
     rev: v0.32.0
     hooks:

--- a/test-report/htmlWptReportFormatter.mjs
+++ b/test-report/htmlWptReportFormatter.mjs
@@ -171,10 +171,8 @@ function generateSubtestReport(subtest) {
           subtest.status === 'PASS' ? 'pass' : 'fail'
         }">
           ${escapeHtml(subtest.name ?? subtest.path)} ${
-            subtest.message
-              ? `<br /><small>${escapeHtml(subtest.message)}</small>`
-              : ''
-          }
+    subtest.message ? `<br /><small>${escapeHtml(subtest.message)}</small>` : ''
+  }
           <span class="stat"><b>${escapeHtml(subtest.status)}</b></span>
         </p>
       </div>`;


### PR DESCRIPTION
v3.0.0-alpha* behaves differently than v2.8.8. Since we use v2.8.8 in package.json (via `npm run prettier` / `npm run format`), we should be consistent in pre-commit, otherwise formatting behaviors may differ.

The `additional_dependencies` workaround comes from https://github.com/pre-commit/mirrors-prettier/issues/29#issuecomment-1332667344 and it is needed because of
https://github.com/pre-commit/mirrors-prettier/issues/29. An upstream bug is available at
https://github.com/pre-commit/mirrors-prettier/pull/39