### PR TITLE
Use `NoSuchNodeException` instead of `InvalidArgumentException`

### DIFF
--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -249,8 +249,8 @@ export class ScriptEvaluator {
         backendNodeId === undefined ||
         navigableId === undefined
       ) {
-        throw new Message.InvalidArgumentException(
-          `SharedId "${argumentValue.sharedId}" should have format "{navigableId}${SHARED_ID_DIVIDER}{backendNodeId}".`
+        throw new Message.NoSuchNodeException(
+          `SharedId "${argumentValue.sharedId}" was not found.`
         );
       }
 


### PR DESCRIPTION
`InvalidArgumentException` is not spec-compliant for deserializing; it states to use `NoSuchNodeException` if the Node cannot be found (e.g. an invalid sharedId will yield no Node). It should be also opaque whether a given `sharedId` fails to get a Node. See https://w3c.github.io/webdriver-bidi/#:~:text=To%20deserialize%20shared%20reference