### PR TITLE
Re-enable `browsing_context/navigate/error.py`

### DIFF
--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,6 +1,0 @@
-[error.py]
-  [test_invalid_address[port\]]
-    disabled: https://github.com/GoogleChromeLabs/chromium-bidi/issues/463
-
-  [test_invalid_address[host\]]
-    disabled: https://github.com/GoogleChromeLabs/chromium-bidi/issues/463


### PR DESCRIPTION
[Re-enable browsing_context/navigate/error.py](https://github.com/GoogleChromeLabs/chromium-bidi/pull/757/commits/448ada1ab793fc847b4e57dfef5615d7fb81da0c) 

It does not appear to be flaky anymore.

`wpt run` flags for debugging: https://web-platform-tests.org/running-tests/command-line-arguments.html?highlight=rerun#debugging

Closes: #463