### PR TITLE
Remove `self.` from TypeScript code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,10 +97,15 @@ repos:
         files: \.js$|\.cjs$|\.mjs$|\.ts$|\.py$
         args: [--negate, --multiline]
       - id: check-chai-describe-it-only
-        name: check chai describe/it only
+        name: check chai describe & it `.only()`
         entry: '\b(it|describe)\.only\('
         language: pygrep
         files: \.spec\.ts$
+      - id: node-self
+        name: check nodejs `self.`
+        entry: '\bself\.'
+        language: pygrep
+        files: \.ts$
   - repo: https://github.com/google/keep-sorted
     rev: v0.1.1
     hooks:

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -32,7 +32,7 @@ export function uuidv4(): `${string}-${string}-${string}-${string}-${string}` {
   }
 
   const randomValues = new Uint8Array(16);
-  self.crypto.getRandomValues(randomValues);
+  crypto.getRandomValues(randomValues);
 
   // Set version (4) and variant (RFC4122) bits.
   randomValues[6] = (randomValues[6]! & 0x0f) | 0x40;


### PR DESCRIPTION
Verified the pre-commit hook works:

```
check nodejs `self.`.....................................................Failed
- hook id: node-self
- exit code: 1

src/utils/uuid.ts:35:  self.crypto.getRandomValues(randomValues);
```

Follow-up-of: https://github.com/GoogleChromeLabs/chromium-bidi/pull/753