### PR TITLE
rollup: use nodePolyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "prettier": "2.8.8",
         "rimraf": "5.0.0",
         "rollup": "3.21.3",
+        "rollup-plugin-polyfill-node": "^0.12.0",
         "sinon": "15.0.4",
         "source-map-support": "0.5.21",
         "terser": "5.17.1",
@@ -976,6 +977,28 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
+      "integrity": "sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -6522,6 +6545,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-polyfill-node": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
+      "integrity": "sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-inject": "^5.0.1"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -8334,6 +8369,17 @@
             "brace-expansion": "^2.0.1"
           }
         }
+      }
+    },
+    "@rollup/plugin-inject": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
+      "integrity": "sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.27.0"
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -12347,6 +12393,15 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-polyfill-node": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
+      "integrity": "sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==",
+      "dev": true,
+      "requires": {
+        "@rollup/plugin-inject": "^5.0.1"
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "prettier": "2.8.8",
     "rimraf": "5.0.0",
     "rollup": "3.21.3",
+    "rollup-plugin-polyfill-node": "0.12.0",
     "sinon": "15.0.4",
     "source-map-support": "0.5.21",
     "terser": "5.17.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import nodePolyfills from 'rollup-plugin-polyfill-node';
 import commonjs from '@rollup/plugin-commonjs';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
@@ -29,5 +30,5 @@ export default {
       crypto: 'crypto',
     },
   },
-  plugins: [nodeResolve(), commonjs(), terser()],
+  plugins: [nodePolyfills(), nodeResolve(), commonjs(), terser()],
 };


### PR DESCRIPTION
This is necessary to address the following warning from rollup:

(!) Missing shims for Node.js built-ins
Creating a browser bundle that depends on "crypto". You might need to include https://github.com/FredKSchott/rollup-plugin-polyfill-node