### PR TITLE
chore: remove global crypto

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -25,9 +25,14 @@ export default {
     file: 'lib/iife/mapperTab.js',
     sourcemap: true,
     format: 'iife',
-    globals: {
-      crypto: 'crypto',
-    },
   },
-  plugins: [nodeResolve(), commonjs(), terser()],
+  plugins: [
+    nodeResolve(),
+    commonjs({
+      // `crypto` is only imported in the uuid polyfill for Node versions
+      // without webcrypto exposes globally.
+      ignore: ['crypto'],
+    }),
+    terser(),
+  ],
 };


### PR DESCRIPTION
Checks which crypto module to use. Possible environments are:
1) browser in a secure context
2) browser in a insecure context
3) node with the webcrypto enabled (--experimental-global-webcrypto)
4) node with the webcrypto disabled (current LTS)