### PR TITLE
Add workflow_dispatch to WPT workflow

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -7,6 +7,20 @@ on:
   pull_request:
   push:
     branches: 'main'
+  workflow_dispatch:
+    inputs:
+      # TODO(#361): Use.
+      auto-commit:
+        description: Whether to auto-commit WPT expectations
+        default: false
+        required: false
+        type: boolean
+      # TODO(#361): Use.
+      verbose:
+        description: Whether to enable verbose logging
+        default: false
+        required: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This would allow us to manually trigger WPT jobs on-demand.

Potential future use cases:

- manually re-run, with verbose logging
- manually re-run, but only a subset of tests
- manually re-run, and auto-commit WPT expectations

Since this seems to only take effect when it's merged in main, also add one checkbox input which we can use for testing / iteration later on.

This is similar to how chrome for testing does it: https://github.com/GoogleChromeLabs/chrome-for-testing/blob/c0c46b46178cb4aa2d2897496ae902125e8e575b/.github/workflows/build.yml#L24

Bug: #361
Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch