### PR TITLE
Initialise targets created by user action

### DIFF
--- a/src/bidiMapper/domains/context/cdpTarget.ts
+++ b/src/bidiMapper/domains/context/cdpTarget.ts
@@ -125,7 +125,7 @@ export class CdpTarget {
     try {
       // It is not guaranteed the commands can be finished before
       // `Runtime.runIfWaitingForDebugger` is called. However, it is safe to
-      // schedule it.
+      // schedule them.
       const initializationPromises = [];
       // Enable Network domain, if it is enabled globally.
       // TODO: enable Network domain for OOPiF targets.
@@ -208,8 +208,8 @@ export class CdpTarget {
         sandbox
       );
 
-      // TODO: Here can be a race condition with the page script, as the command
-      // above can be finished after ``Runtime.runIfWaitingForDebugger` is
+      // TODO: Here there could be a race condition with the page script, as the command
+      // above can be finished after `Runtime.runIfWaitingForDebugger` is
       // called.
       //
       // Upon attaching to a new target, run preload scripts on each execution

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -57,6 +57,10 @@ export function generatePage() {
   }
   globalThis.document.documentElement.innerHTML = mapperPageSource;
 
+  console.log(
+    'BiDi-CDP Mapper is controlling this tab. Closing or reloading it will stop the BiDi process.'
+  );
+
   // Create main log containers in proper order.
   findOrCreateTypeLogContainer(LogType.system);
   findOrCreateTypeLogContainer(LogType.bidi);


### PR DESCRIPTION
Fix the issue when the target was created via `userGesture`.

Out of scope: race condition in preload script. At the moment script.evaluate is called, the page can already have loaded it's scripts.