### PR TITLE
fix: Network Module stuck if ServedFromCache is send

### DIFF
--- a/src/bidiMapper/domains/network/networkProcessor.ts
+++ b/src/bidiMapper/domains/network/networkProcessor.ts
@@ -95,6 +95,15 @@ export class NetworkProcessor {
       }
     );
 
+    cdpClient.on(
+      'Network.requestServedFromCache',
+      (params: Protocol.Network.RequestServedFromCacheEvent) => {
+        networkProcessor
+          .#getOrCreateNetworkRequest(params.requestId)
+          .onServedFromCache();
+      }
+    );
+
     await cdpClient.sendCommand('Network.enable');
 
     return networkProcessor;


### PR DESCRIPTION
It looks like if the network serves from `Memory Cache` a separate event is send that signals that.
That brakes Mapper as the network deferred are never resolved.