### PR TITLE
Force wpt auto-commit to run when the wpt job fails

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -62,7 +62,7 @@ jobs:
   wpt-auto-commit:
     name: WPT auto-commit expectations
     needs: wpt
-    if: ${{ github.event.inputs.auto-commit == 'true' }}
+    if: ${{ always() && github.event.inputs.auto-commit == 'true' }}
     runs-on: ubuntu-latest
     # Give GITHUB_TOKEN write permission to commit and push.
     # Needed by stefanzweifel/git-auto-commit-action@v4.


### PR DESCRIPTION
We need to add `always()` otherwise the child job never runs on failure (which is exactly when we want it to run!).

Source: https://stackoverflow.com/questions/71430668/how-to-run-a-github-actions-job-on-workflow-failure

This is a small follow-up from https://github.com/GoogleChromeLabs/chromium-bidi/pull/774