### PR TITLE
Remove `findTopLevelContext` in favor of class getter

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -190,6 +190,17 @@ export class BrowsingContextImpl {
     return this.#parentId === null;
   }
 
+  get top(): BrowsingContextImpl {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let topContext: BrowsingContextImpl = this;
+    let parent = topContext.parent;
+    while (parent) {
+      topContext = parent;
+      parent = topContext.parent;
+    }
+    return topContext;
+  }
+
   addChild(childId: CommonDataTypes.BrowsingContext) {
     this.#children.add(childId);
   }

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -81,17 +81,6 @@ export class BrowsingContextStorage {
     return this.findTopLevelContextId(parentId);
   }
 
-  /** Returns the top-level context of the given context, if any. */
-  findTopLevelContext(
-    id: CommonDataTypes.BrowsingContext | null
-  ): BrowsingContextImpl | null | undefined {
-    const topLevelContextId = this.findTopLevelContextId(id);
-    if (topLevelContextId === null) {
-      return null;
-    }
-    return this.findContext(topLevelContextId);
-  }
-
   /** Gets the context with the given ID, if any, otherwise throws. */
   getContext(id: CommonDataTypes.BrowsingContext): BrowsingContextImpl {
     const result = this.findContext(id);


### PR DESCRIPTION
Placing `findTopLevelContext` in a class getter improves semantics since it will always exist if the initial context can be obtained.