### PR TITLE
Release 0.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chromium-bidi",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chromium-bidi",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromium-bidi",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "An implementation of the WebDriver BiDi protocol for Chromium implemented as a JavaScript layer translating between BiDi and CDP, running inside a Chrome tab.",
   "scripts": {
     "build": "wireit",


### PR DESCRIPTION
Unblocks use of `reload` in Puppeteer.