### PR TITLE
fix: recover `fromCache` change

### DIFF
--- a/src/bidiMapper/domains/network/networkRequest.ts
+++ b/src/bidiMapper/domains/network/networkRequest.ts
@@ -298,7 +298,7 @@ export class NetworkRequest {
           fromCache:
             (this.#responseReceivedEvent.response.fromDiskCache ||
               this.#responseReceivedEvent.response.fromPrefetchCache) ??
-            false,
+            this.#servedFromCache,
           headers: NetworkRequest.#getHeaders(
             this.#responseReceivedEvent.response.headers
           ),


### PR DESCRIPTION
In https://github.com/GoogleChromeLabs/chromium-bidi/pull/764/files#diff-8dae632dd7e595539b5d6e2772f812e44d528c60f7b8e5ec584b4835b3bd8e88R290 
A change was accidentally merged that made the `fromCache` parameter not respect the `Response.servedFromCache` event.