### PR TITLE
`browsingContext.captureScreenshot`: more spec compliance

### DIFF
--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -36,7 +36,9 @@ def assert_images_equal(img1: Image, img2: Image):
     equal_content = not ImageChops.difference(img1.convert("RGB"),
                                               img2.convert("RGB")).getbbox()
 
-    assert equal_size and equal_alphas and equal_content
+    assert equal_alphas
+    assert equal_size
+    assert equal_content
 
 
 @pytest.mark.asyncio

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,3 +1,0 @@
-[frame.py]
-  [test_iframe]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,5 +1,2 @@
 [frame.py]
   disabled: https://github.com/GoogleChromeLabs/chromium-bidi/issues/514
-
-  [test_iframe]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,2 +1,5 @@
 [frame.py]
   disabled: https://github.com/GoogleChromeLabs/chromium-bidi/issues/514
+
+  [test_iframe]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,3 +1,0 @@
-[frame.py]
-  [test_iframe]
-    expected: FAIL


### PR DESCRIPTION
`browsingContext.captureScreenshot`: more spec compliance

- Stop actively focusing the current tab.
- Use Page.getLayoutMetrics to retrieve the screenshot rect clip
- Pass sensible arguments to the CDP method.

Bug: #514