### PR TITLE
improve Session spec compliance

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -165,7 +165,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEvents> {
   async #process_session_subscribe(
     params: Session.SubscriptionRequest,
     channel: string | null
-  ): Promise<Session.SubscribeResult> {
+  ): Promise<Message.EmptyResult> {
     await this.#eventManager.subscribe(
       params.events,
       params.contexts ?? [null],
@@ -177,7 +177,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEvents> {
   async #process_session_unsubscribe(
     params: Session.SubscriptionRequest,
     channel: string | null
-  ): Promise<Session.UnsubscribeResult> {
+  ): Promise<Message.EmptyResult> {
     await this.#eventManager.unsubscribe(
       params.events,
       params.contexts ?? [null],

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -24,18 +24,20 @@
 
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
-export interface EventResponse<MethodType, ParamsType> {
+interface EventResponse<MethodType, ParamsType> {
   method: MethodType;
   params: ParamsType;
 }
 
-export type BiDiCommand =
+type BiDiCommand =
+  // keep-sorted start
   | BrowsingContext.Command
   | CDP.Command
+  | Input.Command
   | Network.Command
   | Script.Command
-  | Session.Command
-  | Input.Command;
+  | Session.Command;
+// keep-sorted end
 
 export namespace Message {
   export type OutgoingMessage =
@@ -47,7 +49,7 @@ export namespace Message {
     id: number;
     method: BiDiCommand['method'];
     params: BiDiCommand['params'];
-    channel?: string;
+    channel?: Script.Channel;
   };
 
   export type CommandRequest = Pick<RawCommandRequest, 'id'> & BiDiCommand;
@@ -1220,7 +1222,7 @@ export namespace CDP {
 export namespace Session {
   export type Command = StatusCommand | SubscribeCommand | UnsubscribeCommand;
 
-  export type Result = StatusResult | SubscribeResult | UnsubscribeResult;
+  export type Result = StatusResult;
 
   export type StatusCommand = {
     method: 'session.status';
@@ -1258,14 +1260,10 @@ export namespace Session {
     contexts?: CommonDataTypes.BrowsingContext[];
   };
 
-  export type SubscribeResult = Message.EmptyResult;
-
   export type UnsubscribeCommand = {
     method: 'session.unsubscribe';
     params: SubscriptionRequest;
   };
-
-  export type UnsubscribeResult = Message.EmptyResult;
 }
 
 /** @see https://w3c.github.io/webdriver-bidi/#module-input */


### PR DESCRIPTION
Inspired by https://github.com/w3c/webdriver-bidi/pull/439

I wanted to add "NewResult" to the enum but it's not available yet in mapper. So I just made some drive-by refactoring.

Spec: https://w3c.github.io/webdriver-bidi/#module-session