### PR TITLE
pre-commit: explicitly exclude wpt/ directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@
 #
 # Apply all pre-commit hooks to all files:
 #   $ pre-commit run --all-files
+exclude: '^wpt'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
This is needed when creating PRs that fully include the WPT repository (e.g. with `git subtree`) for debugging purposes such as #818, otherwise the pre-commit github action times out due to the numerous amount of files in the WPT repository.