### PR TITLE
pre-commit: add caching to github action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Set up node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - uses: google/wireit@setup-github-actions-caching/v1
       - run: npm ci
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
- npm cache
- wireit cache

This shaves a few seconds off the pre-commit action, and makes the file
consistent with the other ones in our repository.