### PR TITLE
eslint: add consistent-type-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,13 +63,14 @@ module.exports = {
     // https://denar90.github.io/eslint.github.io/docs/rules/
     // Some rules use 'warn' in order to ease local development iteration.
     // keep-sorted start
-    "@typescript-eslint/explicit-member-accessibility": ['warn', {accessibility: 'no-public'}],
     '@typescript-eslint/array-type': 'warn',
     '@typescript-eslint/consistent-generic-constructors': 'warn',
     '@typescript-eslint/consistent-type-imports': ['warn', {fixStyle: 'inline-type-imports'}],
+    '@typescript-eslint/explicit-member-accessibility': ['warn', {accessibility: 'no-public'}],
     '@typescript-eslint/no-empty-function': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-extraneous-class': 'warn',
+    '@typescript-eslint/no-import-type-side-effects': "error",
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
     "@typescript-eslint/explicit-member-accessibility": ['warn', {accessibility: 'no-public'}],
     '@typescript-eslint/array-type': 'warn',
     '@typescript-eslint/consistent-generic-constructors': 'warn',
+    '@typescript-eslint/consistent-type-imports': ['warn', {fixStyle: 'inline-type-imports'}],
     '@typescript-eslint/no-empty-function': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-extraneous-class': 'warn',

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -16,16 +16,16 @@
  */
 
 import {EventEmitter} from '../utils/EventEmitter.js';
-import {LogType, LoggerFn} from '../utils/log.js';
+import {LogType, type LoggerFn} from '../utils/log.js';
 import type {Message} from '../protocol/protocol.js';
 import {ProcessingQueue} from '../utils/processingQueue.js';
 import type {ICdpConnection} from '../cdp/cdpConnection.js';
 
-import {BidiParser, CommandProcessor} from './CommandProcessor.js';
-import {BidiTransport} from './BidiTransport.js';
+import {type BidiParser, CommandProcessor} from './CommandProcessor.js';
+import {type BidiTransport} from './BidiTransport.js';
 import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 import {EventManager} from './domains/events/EventManager.js';
-import {OutgoingBidiMessage} from './OutgoingBidiMessage.js';
+import {type OutgoingBidiMessage} from './OutgoingBidiMessage.js';
 import {RealmStorage} from './domains/script/realmStorage.js';
 
 type BidiServerEvents = {

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -22,10 +22,10 @@ import {ProcessingQueue} from '../utils/processingQueue.js';
 import type {ICdpConnection} from '../cdp/cdpConnection.js';
 
 import {type BidiParser, CommandProcessor} from './CommandProcessor.js';
-import {type BidiTransport} from './BidiTransport.js';
+import type {BidiTransport} from './BidiTransport.js';
 import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 import {EventManager} from './domains/events/EventManager.js';
-import {type OutgoingBidiMessage} from './OutgoingBidiMessage.js';
+import type {OutgoingBidiMessage} from './OutgoingBidiMessage.js';
 import {RealmStorage} from './domains/script/realmStorage.js';
 
 type BidiServerEvents = {

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -28,10 +28,10 @@ import {EventEmitter} from '../utils/EventEmitter.js';
 import type {ICdpConnection} from '../cdp/cdpConnection.js';
 
 import {BrowsingContextProcessor} from './domains/context/browsingContextProcessor.js';
-import {type BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
+import type {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 import type {IEventManager} from './domains/events/EventManager.js';
 import {OutgoingBidiMessage} from './OutgoingBidiMessage.js';
-import {type RealmStorage} from './domains/script/realmStorage.js';
+import type {RealmStorage} from './domains/script/realmStorage.js';
 
 type CommandProcessorEvents = {
   response: Promise<OutgoingBidiMessage>;

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -16,22 +16,22 @@
  */
 
 import {
-  BrowsingContext,
-  CDP,
-  Input,
+  type BrowsingContext,
+  type CDP,
+  type Input,
   Message,
-  Script,
-  Session,
+  type Script,
+  type Session,
 } from '../protocol/protocol.js';
-import {LogType, LoggerFn} from '../utils/log.js';
+import {LogType, type LoggerFn} from '../utils/log.js';
 import {EventEmitter} from '../utils/EventEmitter.js';
 import type {ICdpConnection} from '../cdp/cdpConnection.js';
 
 import {BrowsingContextProcessor} from './domains/context/browsingContextProcessor.js';
-import {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
+import {type BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
 import type {IEventManager} from './domains/events/EventManager.js';
 import {OutgoingBidiMessage} from './OutgoingBidiMessage.js';
-import {RealmStorage} from './domains/script/realmStorage.js';
+import {type RealmStorage} from './domains/script/realmStorage.js';
 
 type CommandProcessorEvents = {
   response: Promise<OutgoingBidiMessage>;

--- a/src/bidiMapper/domains/context/PreloadScriptStorage.spec.ts
+++ b/src/bidiMapper/domains/context/PreloadScriptStorage.spec.ts
@@ -20,7 +20,10 @@ import * as sinon from 'sinon';
 import * as uuid from '../../../utils/uuid.js';
 
 import {CdpTarget} from './cdpTarget';
-import {PreloadScriptStorage, CdpPreloadScript} from './PreloadScriptStorage';
+import {
+  PreloadScriptStorage,
+  type CdpPreloadScript,
+} from './PreloadScriptStorage';
 
 const MOCKED_UUID_1 = '00000000-0000-0000-0000-00000000000a';
 const MOCKED_UUID_2 = '00000000-0000-0000-0000-00000000000b';

--- a/src/bidiMapper/domains/context/PreloadScriptStorage.ts
+++ b/src/bidiMapper/domains/context/PreloadScriptStorage.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 import {uuidv4} from '../../../utils/uuid.js';
-import {type CommonDataTypes, type Script} from '../../../protocol/protocol.js';
+import type {CommonDataTypes, Script} from '../../../protocol/protocol.js';
 
-import {type CdpTarget} from './cdpTarget.js';
+import type {CdpTarget} from './cdpTarget.js';
 
 export type BidiPreloadScript = {
   /** BiDi ID, an automatically generated UUID. */

--- a/src/bidiMapper/domains/context/PreloadScriptStorage.ts
+++ b/src/bidiMapper/domains/context/PreloadScriptStorage.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 import {uuidv4} from '../../../utils/uuid.js';
-import {CommonDataTypes, Script} from '../../../protocol/protocol.js';
+import {type CommonDataTypes, type Script} from '../../../protocol/protocol.js';
 
-import {CdpTarget} from './cdpTarget.js';
+import {type CdpTarget} from './cdpTarget.js';
 
 export type BidiPreloadScript = {
   /** BiDi ID, an automatically generated UUID. */

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -15,22 +15,22 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
 import {inchesFromCm} from '../../../utils/unitConversions.js';
 import {
   BrowsingContext,
-  CommonDataTypes,
+  type CommonDataTypes,
   Message,
 } from '../../../protocol/protocol.js';
-import {LoggerFn, LogType} from '../../../utils/log.js';
+import {type LoggerFn, LogType} from '../../../utils/log.js';
 import {Deferred} from '../../../utils/deferred.js';
 import type {IEventManager} from '../events/EventManager.js';
 import {Realm} from '../script/realm.js';
-import {RealmStorage} from '../script/realmStorage.js';
+import {type RealmStorage} from '../script/realmStorage.js';
 
-import {BrowsingContextStorage} from './browsingContextStorage.js';
-import {CdpTarget} from './cdpTarget.js';
+import {type BrowsingContextStorage} from './browsingContextStorage.js';
+import {type CdpTarget} from './cdpTarget.js';
 
 export class BrowsingContextImpl {
   /** The ID of this browsing context. */

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {inchesFromCm} from '../../../utils/unitConversions.js';
 import {
@@ -27,10 +27,10 @@ import {type LoggerFn, LogType} from '../../../utils/log.js';
 import {Deferred} from '../../../utils/deferred.js';
 import type {IEventManager} from '../events/EventManager.js';
 import {Realm} from '../script/realm.js';
-import {type RealmStorage} from '../script/realmStorage.js';
+import type {RealmStorage} from '../script/realmStorage.js';
 
-import {type BrowsingContextStorage} from './browsingContextStorage.js';
-import {type CdpTarget} from './cdpTarget.js';
+import type {BrowsingContextStorage} from './browsingContextStorage.js';
+import type {CdpTarget} from './cdpTarget.js';
 
 export class BrowsingContextImpl {
   /** The ID of this browsing context. */

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -14,33 +14,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
 import {
-  BrowsingContext,
-  CDP,
+  type BrowsingContext,
+  type CDP,
   Input,
   Message,
-  Script,
+  type Script,
 } from '../../../protocol/protocol.js';
-import {LogType, LoggerFn} from '../../../utils/log.js';
+import {LogType, type LoggerFn} from '../../../utils/log.js';
 import type {IEventManager} from '../events/EventManager.js';
-import {Realm} from '../script/realm.js';
-import {RealmStorage} from '../script/realmStorage.js';
-import {ActionOption} from '../input/ActionOption.js';
+import {type Realm} from '../script/realm.js';
+import {type RealmStorage} from '../script/realmStorage.js';
+import {type ActionOption} from '../input/ActionOption.js';
 import {InputStateManager} from '../input/InputStateManager.js';
 import {ActionDispatcher} from '../input/ActionDispatcher.js';
-import {InputState} from '../input/InputState.js';
+import {type InputState} from '../input/InputState.js';
 import type {ICdpConnection} from '../../../cdp/cdpConnection.js';
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 
 import {
-  BidiPreloadScript,
-  CdpPreloadScript,
+  type BidiPreloadScript,
+  type CdpPreloadScript,
   PreloadScriptStorage,
 } from './PreloadScriptStorage.js';
 import {BrowsingContextImpl} from './browsingContextImpl.js';
-import {BrowsingContextStorage} from './browsingContextStorage.js';
+import {type BrowsingContextStorage} from './browsingContextStorage.js';
 import {CdpTarget} from './cdpTarget.js';
 
 export class BrowsingContextProcessor {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -25,12 +25,12 @@ import {
 } from '../../../protocol/protocol.js';
 import {LogType, type LoggerFn} from '../../../utils/log.js';
 import type {IEventManager} from '../events/EventManager.js';
-import {type Realm} from '../script/realm.js';
-import {type RealmStorage} from '../script/realmStorage.js';
-import {type ActionOption} from '../input/ActionOption.js';
+import type {Realm} from '../script/realm.js';
+import type {RealmStorage} from '../script/realmStorage.js';
+import type {ActionOption} from '../input/ActionOption.js';
 import {InputStateManager} from '../input/InputStateManager.js';
 import {ActionDispatcher} from '../input/ActionDispatcher.js';
-import {type InputState} from '../input/InputState.js';
+import type {InputState} from '../input/InputState.js';
 import type {ICdpConnection} from '../../../cdp/cdpConnection.js';
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 
@@ -40,7 +40,7 @@ import {
   PreloadScriptStorage,
 } from './PreloadScriptStorage.js';
 import {BrowsingContextImpl} from './browsingContextImpl.js';
-import {type BrowsingContextStorage} from './browsingContextStorage.js';
+import type {BrowsingContextStorage} from './browsingContextStorage.js';
 import {CdpTarget} from './cdpTarget.js';
 
 export class BrowsingContextProcessor {

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import {CommonDataTypes, Message} from '../../../protocol/protocol.js';
+import {type CommonDataTypes, Message} from '../../../protocol/protocol.js';
 
-import {BrowsingContextImpl} from './browsingContextImpl.js';
+import {type BrowsingContextImpl} from './browsingContextImpl.js';
 
 /** Container class for browsing contexts. */
 export class BrowsingContextStorage {

--- a/src/bidiMapper/domains/context/browsingContextStorage.ts
+++ b/src/bidiMapper/domains/context/browsingContextStorage.ts
@@ -17,7 +17,7 @@
 
 import {type CommonDataTypes, Message} from '../../../protocol/protocol.js';
 
-import {type BrowsingContextImpl} from './browsingContextImpl.js';
+import type {BrowsingContextImpl} from './browsingContextImpl.js';
 
 /** Container class for browsing contexts. */
 export class BrowsingContextStorage {

--- a/src/bidiMapper/domains/context/cdpTarget.ts
+++ b/src/bidiMapper/domains/context/cdpTarget.ts
@@ -19,15 +19,15 @@ import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js'
 
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import {LogManager} from '../log/logManager.js';
-import {type RealmStorage} from '../script/realmStorage.js';
+import type {RealmStorage} from '../script/realmStorage.js';
 import type {IEventManager} from '../events/EventManager.js';
 import {CDP, type Script} from '../../../protocol/protocol.js';
 import {Deferred} from '../../../utils/deferred.js';
 import {NetworkProcessor} from '../network/networkProcessor.js';
 import {type LoggerFn, LogType} from '../../../utils/log.js';
 
-import {type PreloadScriptStorage} from './PreloadScriptStorage.js';
-import {type BrowsingContextStorage} from './browsingContextStorage';
+import type {PreloadScriptStorage} from './PreloadScriptStorage.js';
+import type {BrowsingContextStorage} from './browsingContextStorage';
 
 export class CdpTarget {
   readonly #targetId: string;

--- a/src/bidiMapper/domains/context/cdpTarget.ts
+++ b/src/bidiMapper/domains/context/cdpTarget.ts
@@ -19,15 +19,15 @@ import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js'
 
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import {LogManager} from '../log/logManager.js';
-import {RealmStorage} from '../script/realmStorage.js';
+import {type RealmStorage} from '../script/realmStorage.js';
 import type {IEventManager} from '../events/EventManager.js';
-import {CDP, Script} from '../../../protocol/protocol.js';
+import {CDP, type Script} from '../../../protocol/protocol.js';
 import {Deferred} from '../../../utils/deferred.js';
 import {NetworkProcessor} from '../network/networkProcessor.js';
-import {LoggerFn, LogType} from '../../../utils/log.js';
+import {type LoggerFn, LogType} from '../../../utils/log.js';
 
-import {PreloadScriptStorage} from './PreloadScriptStorage.js';
-import {BrowsingContextStorage} from './browsingContextStorage';
+import {type PreloadScriptStorage} from './PreloadScriptStorage.js';
+import {type BrowsingContextStorage} from './browsingContextStorage';
 
 export class CdpTarget {
   readonly #targetId: string;

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -16,10 +16,10 @@
  */
 
 import {
-  CommonDataTypes,
+  type CommonDataTypes,
   Log,
-  Message,
-  Session,
+  type Message,
+  type Session,
 } from '../../../protocol/protocol.js';
 import type {BidiServer} from '../../BidiServer.js';
 import {Buffer} from '../../../utils/buffer.js';

--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -21,7 +21,7 @@ import * as sinon from 'sinon';
 import {
   BrowsingContext,
   CDP,
-  CommonDataTypes,
+  type CommonDataTypes,
   Log,
   Network,
   Script,

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -18,14 +18,14 @@
 import {
   BrowsingContext,
   CDP,
-  CommonDataTypes,
+  type CommonDataTypes,
   Log,
   Message,
   Network,
   Script,
-  Session,
+  type Session,
 } from '../../../protocol/protocol.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import {type BrowsingContextStorage} from '../context/browsingContextStorage.js';
 
 /**
  * Returns the cartesian product of the given arrays.

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -25,7 +25,7 @@ import {
   Script,
   type Session,
 } from '../../../protocol/protocol.js';
-import {type BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import type {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 
 /**
  * Returns the cartesian product of the given arrays.

--- a/src/bidiMapper/domains/input/ActionDispatcher.ts
+++ b/src/bidiMapper/domains/input/ActionDispatcher.ts
@@ -21,15 +21,11 @@ import {
   Message,
 } from '../../../protocol/protocol.js';
 import {assert} from '../../../utils/assert.js';
-import {type BrowsingContextImpl} from '../context/browsingContextImpl.js';
+import type {BrowsingContextImpl} from '../context/browsingContextImpl.js';
 
-import {type ActionOption} from './ActionOption.js';
-import {
-  type KeySource,
-  type PointerSource,
-  type WheelSource,
-} from './InputSource.js';
-import {type InputState} from './InputState.js';
+import type {ActionOption} from './ActionOption.js';
+import type {KeySource, PointerSource, WheelSource} from './InputSource.js';
+import type {InputState} from './InputState.js';
 import {KeyToKeyCode} from './USKeyboardLayout.js';
 import {getNormalizedKey, getKeyCode, getKeyLocation} from './keyUtils.js';
 

--- a/src/bidiMapper/domains/input/ActionDispatcher.ts
+++ b/src/bidiMapper/domains/input/ActionDispatcher.ts
@@ -15,13 +15,21 @@
  * limitations under the License.
  */
 
-import {CommonDataTypes, Input, Message} from '../../../protocol/protocol.js';
+import {
+  type CommonDataTypes,
+  Input,
+  Message,
+} from '../../../protocol/protocol.js';
 import {assert} from '../../../utils/assert.js';
-import {BrowsingContextImpl} from '../context/browsingContextImpl.js';
+import {type BrowsingContextImpl} from '../context/browsingContextImpl.js';
 
-import {ActionOption} from './ActionOption.js';
-import {KeySource, PointerSource, WheelSource} from './InputSource.js';
-import {InputState} from './InputState.js';
+import {type ActionOption} from './ActionOption.js';
+import {
+  type KeySource,
+  type PointerSource,
+  type WheelSource,
+} from './InputSource.js';
+import {type InputState} from './InputState.js';
 import {KeyToKeyCode} from './USKeyboardLayout.js';
 import {getNormalizedKey, getKeyCode, getKeyLocation} from './keyUtils.js';
 

--- a/src/bidiMapper/domains/input/ActionOption.ts
+++ b/src/bidiMapper/domains/input/ActionOption.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {type Input} from '../../../protocol/protocol.js';
+import type {Input} from '../../../protocol/protocol.js';
 
 export type ActionOption = ActionOptionFor<
   | Input.NoneSourceAction

--- a/src/bidiMapper/domains/input/ActionOption.ts
+++ b/src/bidiMapper/domains/input/ActionOption.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Input} from '../../../protocol/protocol.js';
+import {type Input} from '../../../protocol/protocol.js';
 
 export type ActionOption = ActionOptionFor<
   | Input.NoneSourceAction

--- a/src/bidiMapper/domains/input/InputState.ts
+++ b/src/bidiMapper/domains/input/InputState.ts
@@ -18,11 +18,11 @@
 import {Input, Message} from '../../../protocol/protocol.js';
 import {Mutex} from '../../../utils/Mutex.js';
 
-import {ActionOption} from './ActionOption.js';
+import {type ActionOption} from './ActionOption.js';
 import {
-  InputSource,
+  type InputSource,
   PointerSource,
-  InputSourceFor,
+  type InputSourceFor,
   NoneSource,
   KeySource,
   WheelSource,

--- a/src/bidiMapper/domains/input/InputState.ts
+++ b/src/bidiMapper/domains/input/InputState.ts
@@ -18,7 +18,7 @@
 import {Input, Message} from '../../../protocol/protocol.js';
 import {Mutex} from '../../../utils/Mutex.js';
 
-import {type ActionOption} from './ActionOption.js';
+import type {ActionOption} from './ActionOption.js';
 import {
   type InputSource,
   PointerSource,

--- a/src/bidiMapper/domains/input/InputStateManager.ts
+++ b/src/bidiMapper/domains/input/InputStateManager.ts
@@ -16,7 +16,7 @@
  */
 
 import {assert} from '../../../utils/assert.js';
-import {BrowsingContextImpl} from '../context/browsingContextImpl.js';
+import {type BrowsingContextImpl} from '../context/browsingContextImpl.js';
 
 import {InputState} from './InputState.js';
 

--- a/src/bidiMapper/domains/input/InputStateManager.ts
+++ b/src/bidiMapper/domains/input/InputStateManager.ts
@@ -16,7 +16,7 @@
  */
 
 import {assert} from '../../../utils/assert.js';
-import {type BrowsingContextImpl} from '../context/browsingContextImpl.js';
+import type {BrowsingContextImpl} from '../context/browsingContextImpl.js';
 
 import {InputState} from './InputState.js';
 

--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {
   type CommonDataTypes,
@@ -22,9 +22,9 @@ import {
   type Script,
 } from '../../../protocol/protocol.js';
 import type {IEventManager} from '../events/EventManager.js';
-import {type Realm} from '../script/realm.js';
-import {type RealmStorage} from '../script/realmStorage.js';
-import {type CdpTarget} from '../context/cdpTarget.js';
+import type {Realm} from '../script/realm.js';
+import type {RealmStorage} from '../script/realmStorage.js';
+import type {CdpTarget} from '../context/cdpTarget.js';
 
 import {getRemoteValuesText} from './logHelper.js';
 

--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -14,13 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CommonDataTypes, Log, Script} from '../../../protocol/protocol.js';
+import {
+  type CommonDataTypes,
+  Log,
+  type Script,
+} from '../../../protocol/protocol.js';
 import type {IEventManager} from '../events/EventManager.js';
-import {Realm} from '../script/realm.js';
-import {RealmStorage} from '../script/realmStorage.js';
-import {CdpTarget} from '../context/cdpTarget.js';
+import {type Realm} from '../script/realm.js';
+import {type RealmStorage} from '../script/realmStorage.js';
+import {type CdpTarget} from '../context/cdpTarget.js';
 
 import {getRemoteValuesText} from './logHelper.js';
 

--- a/src/bidiMapper/domains/network/networkProcessor.ts
+++ b/src/bidiMapper/domains/network/networkProcessor.ts
@@ -25,7 +25,7 @@ import type Protocol from 'devtools-protocol';
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import type {IEventManager} from '../events/EventManager.js';
 import {DefaultMap} from '../../../utils/DefaultMap.js';
-import {type Network} from '../../../protocol/protocol.js';
+import type {Network} from '../../../protocol/protocol.js';
 
 import {NetworkRequest} from './networkRequest.js';
 

--- a/src/bidiMapper/domains/network/networkProcessor.ts
+++ b/src/bidiMapper/domains/network/networkProcessor.ts
@@ -20,12 +20,12 @@
  * responsible for processing Network domain events and redirecting events to
  * related `NetworkRequest`.
  */
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import type {IEventManager} from '../events/EventManager.js';
 import {DefaultMap} from '../../../utils/DefaultMap.js';
-import {Network} from '../../../protocol/protocol.js';
+import {type Network} from '../../../protocol/protocol.js';
 
 import {NetworkRequest} from './networkRequest.js';
 

--- a/src/bidiMapper/domains/network/networkRequest.ts
+++ b/src/bidiMapper/domains/network/networkRequest.ts
@@ -20,7 +20,7 @@
  * @fileoverview `NetworkRequest` represents a single network request and keeps
  * track of all the related CDP events.
  */
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 
 import {Deferred} from '../../../utils/deferred.js';
 import type {IEventManager} from '../events/EventManager.js';

--- a/src/bidiMapper/domains/script/channelProxy.ts
+++ b/src/bidiMapper/domains/script/channelProxy.ts
@@ -17,8 +17,10 @@
  */
 
 import {CommonDataTypes, Script} from '../../../protocol/protocol.js';
-import {Realm} from './realm.js';
-import {IEventManager} from '../events/EventManager.js';
+import {type IEventManager} from '../events/EventManager.js';
+
+import {type Realm} from './realm.js';
+
 import Handle = CommonDataTypes.Handle;
 
 /**

--- a/src/bidiMapper/domains/script/channelProxy.ts
+++ b/src/bidiMapper/domains/script/channelProxy.ts
@@ -17,9 +17,9 @@
  */
 
 import {CommonDataTypes, Script} from '../../../protocol/protocol.js';
-import {type IEventManager} from '../events/EventManager.js';
+import type {IEventManager} from '../events/EventManager.js';
 
-import {type Realm} from './realm.js';
+import type {Realm} from './realm.js';
 
 import Handle = CommonDataTypes.Handle;
 

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
-import {type CommonDataTypes, type Script} from '../../../protocol/protocol.js';
-import {type BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import type {CommonDataTypes, Script} from '../../../protocol/protocol.js';
+import type {BrowsingContextStorage} from '../context/browsingContextStorage.js';
 import type {IEventManager} from '../events/EventManager.js';
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import {LogType, type LoggerFn} from '../../../utils/log.js';
 
 import {SHARED_ID_DIVIDER, ScriptEvaluator} from './scriptEvaluator.js';
-import {type RealmStorage} from './realmStorage.js';
+import type {RealmStorage} from './realmStorage.js';
 
 export type RealmType = Script.RealmType;
 

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CommonDataTypes, Script} from '../../../protocol/protocol.js';
-import {BrowsingContextStorage} from '../context/browsingContextStorage.js';
+import {type CommonDataTypes, type Script} from '../../../protocol/protocol.js';
+import {type BrowsingContextStorage} from '../context/browsingContextStorage.js';
 import type {IEventManager} from '../events/EventManager.js';
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
-import {LogType, LoggerFn} from '../../../utils/log.js';
+import {LogType, type LoggerFn} from '../../../utils/log.js';
 
 import {SHARED_ID_DIVIDER, ScriptEvaluator} from './scriptEvaluator.js';
-import {RealmStorage} from './realmStorage.js';
+import {type RealmStorage} from './realmStorage.js';
 
 export type RealmType = Script.RealmType;
 

--- a/src/bidiMapper/domains/script/realmStorage.ts
+++ b/src/bidiMapper/domains/script/realmStorage.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {
   type CommonDataTypes,
@@ -22,7 +22,7 @@ import {
   type Script,
 } from '../../../protocol/protocol.js';
 
-import {type Realm, type RealmType} from './realm.js';
+import type {Realm, RealmType} from './realm.js';
 
 type RealmFilter = {
   realmId?: Script.Realm;

--- a/src/bidiMapper/domains/script/realmStorage.ts
+++ b/src/bidiMapper/domains/script/realmStorage.ts
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CommonDataTypes, Message, Script} from '../../../protocol/protocol.js';
+import {
+  type CommonDataTypes,
+  Message,
+  type Script,
+} from '../../../protocol/protocol.js';
 
-import {Realm, RealmType} from './realm.js';
+import {type Realm, type RealmType} from './realm.js';
 
 type RealmFilter = {
   realmId?: Script.Realm;

--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -14,12 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Protocol} from 'devtools-protocol';
+import {type Protocol} from 'devtools-protocol';
 
-import {CommonDataTypes, Message, Script} from '../../../protocol/protocol.js';
+import {
+  type CommonDataTypes,
+  Message,
+  type Script,
+} from '../../../protocol/protocol.js';
 import type {IEventManager} from '../events/EventManager.js';
 
-import {Realm} from './realm.js';
+import {type Realm} from './realm.js';
 import {ChannelProxy} from './channelProxy.js';
 
 // As `script.evaluate` wraps call into serialization script, `lineNumber`

--- a/src/bidiMapper/domains/script/scriptEvaluator.ts
+++ b/src/bidiMapper/domains/script/scriptEvaluator.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {type Protocol} from 'devtools-protocol';
+import type {Protocol} from 'devtools-protocol';
 
 import {
   type CommonDataTypes,
@@ -23,7 +23,7 @@ import {
 } from '../../../protocol/protocol.js';
 import type {IEventManager} from '../events/EventManager.js';
 
-import {type Realm} from './realm.js';
+import type {Realm} from './realm.js';
 import {ChannelProxy} from './channelProxy.js';
 
 // As `script.evaluate` wraps call into serialization script, `lineNumber`

--- a/src/bidiServer/mapperServer.ts
+++ b/src/bidiServer/mapperServer.ts
@@ -20,7 +20,7 @@ import WebSocket from 'ws';
 import debug from 'debug';
 
 import {CdpConnection} from '../cdp/cdpConnection.js';
-import {type CdpClient} from '../cdp/cdpClient.js';
+import type {CdpClient} from '../cdp/cdpClient.js';
 import {LogType} from '../utils/log.js';
 import {WebSocketTransport} from '../utils/websocketTransport.js';
 

--- a/src/bidiServer/mapperServer.ts
+++ b/src/bidiServer/mapperServer.ts
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-import Protocol from 'devtools-protocol';
+import type Protocol from 'devtools-protocol';
 import WebSocket from 'ws';
 import debug from 'debug';
 
 import {CdpConnection} from '../cdp/cdpConnection.js';
-import {CdpClient} from '../cdp/cdpClient.js';
+import {type CdpClient} from '../cdp/cdpClient.js';
 import {LogType} from '../utils/log.js';
 import {WebSocketTransport} from '../utils/websocketTransport.js';
 

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -19,17 +19,17 @@
 
 import * as Parser from '../protocol-parser/protocol-parser.js';
 import {
-  BrowsingContext,
-  CDP,
-  Input,
+  type BrowsingContext,
+  type CDP,
+  type Input,
   Message,
-  Script,
-  Session,
+  type Script,
+  type Session,
 } from '../protocol/protocol';
 import {
-  BidiParser,
+  type BidiParser,
   BidiServer,
-  BidiTransport,
+  type BidiTransport,
   OutgoingBidiMessage,
 } from '../bidiMapper/bidiMapper.js';
 import {CdpConnection} from '../cdp/cdpConnection.js';

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -19,7 +19,7 @@ import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js'
 import type {ITransport} from '../utils/transport.js';
 
 import {CloseError, CdpClient, type ICdpClient} from './cdpClient.js';
-import {type CdpMessage} from './cdpMessage.js';
+import type {CdpMessage} from './cdpMessage.js';
 
 interface CdpCallbacks {
   resolve: (result: CdpMessage<any>['result']) => void;

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -18,8 +18,8 @@ import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js'
 
 import type {ITransport} from '../utils/transport.js';
 
-import {CloseError, CdpClient, ICdpClient} from './cdpClient.js';
-import {CdpMessage} from './cdpMessage.js';
+import {CloseError, CdpClient, type ICdpClient} from './cdpClient.js';
+import {type CdpMessage} from './cdpMessage.js';
 
 interface CdpCallbacks {
   resolve: (result: CdpMessage<any>['result']) => void;

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -19,7 +19,7 @@
  * @fileoverview Provides parsing and validator for WebDriver BiDi protocol.
  * Parser types should match the `../protocol` types.
  */
-import {ZodType, z as zod} from 'zod';
+import {type ZodType, z as zod} from 'zod';
 
 import {
   BrowsingContext as BrowsingContextTypes,
@@ -27,9 +27,9 @@ import {
   Log as LogTypes,
   CDP as CdpTypes,
   Message as MessageTypes,
-  Session as SessionTypes,
+  type Session as SessionTypes,
   Network as NetworkTypes,
-  CommonDataTypes as CommonDataTypesTypes,
+  type CommonDataTypes as CommonDataTypesTypes,
   Input as InputTypes,
 } from '../protocol/protocol.js';
 

--- a/src/utils/EventEmitter.ts
+++ b/src/utils/EventEmitter.ts
@@ -14,7 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import mitt, {Emitter, EventType, Handler, WildcardHandler} from 'mitt';
+import mitt, {
+  type Emitter,
+  type EventType,
+  type Handler,
+  type WildcardHandler,
+} from 'mitt';
 
 export class EventEmitter<Events extends Record<EventType, unknown>> {
   #emitter: Emitter<Events> = mitt();

--- a/src/utils/processingQueue.ts
+++ b/src/utils/processingQueue.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {LogType, LoggerFn} from './log.js';
+import {LogType, type LoggerFn} from './log.js';
 
 export class ProcessingQueue<T> {
   readonly #logger?: LoggerFn;

--- a/src/utils/websocketTransport.ts
+++ b/src/utils/websocketTransport.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import WebSocket from 'ws';
+import type WebSocket from 'ws';
 
 import type {ITransport} from './transport.js';
 


### PR DESCRIPTION
Prefer to use "import type" when possible.

This allows transpilers to drop imports without knowing the types of the dependencies.

Docs: https://typescript-eslint.io/rules/consistent-type-imports/