### PR TITLE
fix: screenshots failing when setViewport is used

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -582,9 +582,14 @@ export class BrowsingContextImpl {
     let clip: Protocol.DOM.Rect;
 
     if (this.isTopLevelContext()) {
-      clip = (
-        await this.#cdpTarget.cdpClient.sendCommand('Page.getLayoutMetrics')
-      ).cssContentSize;
+      const {cssContentSize, cssLayoutViewport} =
+        await this.#cdpTarget.cdpClient.sendCommand('Page.getLayoutMetrics');
+      clip = {
+        x: cssContentSize.x,
+        y: cssContentSize.y,
+        width: cssLayoutViewport.clientWidth,
+        height: cssLayoutViewport.clientHeight,
+      };
     } else {
       const {
         result: {value: iframeDocRect},


### PR DESCRIPTION
The image was capturing empty parts if the content was overflowing.
Image has 200 boxes
![image](https://github.com/GoogleChromeLabs/chromium-bidi/assets/34244704/0a13c891-a9f7-4dd5-9da7-aa95ea99c0ae)
