### PR TITLE
Restore non-ASCII characters where applicable, ensuring they get escaped during minification

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -33,6 +33,10 @@ export default {
       // without webcrypto exposes globally.
       ignore: ['crypto'],
     }),
-    terser(),
+    terser({
+      format: {
+        ascii_only: true,
+      },
+    }),
   ],
 };

--- a/src/bidiServer/bidiServerRunner.ts
+++ b/src/bidiServer/bidiServerRunner.ts
@@ -23,8 +23,8 @@ import type {ITransport} from '../utils/transport.js';
 
 const log = debug('bidiServer:log');
 const debugInternal = debug('bidiServer:internal');
-const debugSend = debug('bidiServer:SEND >');
-const debugRecv = debug('bidiServer:RECV <');
+const debugSend = debug('bidiServer:SEND ▸');
+const debugRecv = debug('bidiServer:RECV ◂');
 
 function getHttpRequestPayload(request: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/bidiServer/mapperServer.ts
+++ b/src/bidiServer/mapperServer.ts
@@ -134,7 +134,7 @@ export class MapperServer {
         messages: unknown[];
       };
 
-      // BiDi traffic is logged in `bidiServer:SEND >`
+      // BiDi traffic is logged in `bidiServer:SEND ▸`
       if (debugMessage.logType === LogType.bidi) {
         return;
       }

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -121,7 +121,7 @@ function createBidiServer(selfTargetId: string) {
 
     constructor() {
       window.onBidiMessage = (messageStr: string) => {
-        log(LogType.bidi, 'received <', messageStr);
+        log(LogType.bidi, 'received ◂', messageStr);
         let messageObject: Message.RawCommandRequest;
         try {
           messageObject = WindowBidiTransport.#parseBidiMessage(messageStr);
@@ -146,7 +146,7 @@ function createBidiServer(selfTargetId: string) {
     sendMessage(message: Message.OutgoingMessage) {
       const messageStr = JSON.stringify(message);
       window.sendBidiResponse(messageStr);
-      log(LogType.bidi, 'sent >', messageStr);
+      log(LogType.bidi, 'sent ▸', messageStr);
     }
 
     close() {

--- a/src/cdp/cdpConnection.ts
+++ b/src/cdp/cdpConnection.ts
@@ -110,14 +110,14 @@ export class CdpConnection implements ICdpConnection {
         this.#logger?.('error', error);
         this.#transport.close();
       });
-      this.#logger?.('sent >', JSON.stringify(cdpMessage, null, 2));
+      this.#logger?.('sent ▸', JSON.stringify(cdpMessage, null, 2));
     });
   }
 
   #onMessage = (message: string) => {
     const messageParsed: CdpMessage<any> = JSON.parse(message);
     const messagePretty = JSON.stringify(messageParsed, null, 2);
-    this.#logger?.('received <', messagePretty);
+    this.#logger?.('received ◂', messagePretty);
 
     // Update client map if a session is attached or detached.
     // Listen for these events on every session.


### PR DESCRIPTION
```
$ npm run build; npx is-ascii-safe-cli lib/iife/mapperTab.js

> chromium-bidi@0.4.12 build
> wireit

🏃 [tsc] Running command "tsc --build src/tsconfig.json --pretty"
✅ [tsc] Executed successfully
🏃 [rollup] Running command "rollup -c"

lib/cjs/bidiTab/bidiTab.js → lib/iife/mapperTab.js...
created lib/iife/mapperTab.js in 1.2s
✅ [rollup] Executed successfully
✅ [build] No command to execute
1 file(s) are ASCII-safe.
```

Bug: #858