### PR TITLE
feat: add fragmentNavigated event

### DIFF
--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -428,10 +428,11 @@ describe('SubscriptionManager', () => {
   describe('unroll events', () => {
     it('all Browsing Context events', () => {
       expect(unrollEvents([BrowsingContext.AllEvents])).to.deep.equal([
-        BrowsingContext.EventNames.LoadEvent,
-        BrowsingContext.EventNames.DomContentLoadedEvent,
         BrowsingContext.EventNames.ContextCreatedEvent,
         BrowsingContext.EventNames.ContextDestroyedEvent,
+        BrowsingContext.EventNames.DomContentLoadedEvent,
+        BrowsingContext.EventNames.FragmentNavigated,
+        BrowsingContext.EventNames.LoadEvent,
       ]);
     });
 

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -799,10 +799,10 @@ export namespace Script {
   };
 
   export enum EventNames {
-    // keep-sorted start;
+    // keep-sorted start
     MessageEvent = 'script.message',
     RealmCreated = 'script.realmCreated',
-    // keep-sorted end;
+    // keep-sorted end
   }
 
   export const AllEvents = 'script';
@@ -828,6 +828,7 @@ export namespace BrowsingContext {
     | ContextCreatedEvent
     | ContextDestroyedEvent
     | DomContentLoadedEvent
+    | FragmentNavigatedEvent
     | LoadEvent;
 
   export type Navigation = string;
@@ -1001,11 +1002,19 @@ export namespace BrowsingContext {
     BrowsingContext.Info
   >;
 
+  export type FragmentNavigatedEvent = EventResponse<
+    EventNames.FragmentNavigated,
+    BrowsingContext.NavigationInfo
+  >;
+
   export enum EventNames {
-    LoadEvent = 'browsingContext.load',
-    DomContentLoadedEvent = 'browsingContext.domContentLoaded',
+    // keep-sorted start
     ContextCreatedEvent = 'browsingContext.contextCreated',
     ContextDestroyedEvent = 'browsingContext.contextDestroyed',
+    DomContentLoadedEvent = 'browsingContext.domContentLoaded',
+    FragmentNavigated = 'browsingContext.fragmentNavigated',
+    LoadEvent = 'browsingContext.load',
+    // keep-sorted end
   }
 
   export const AllEvents = 'browsingContext';

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -922,3 +922,37 @@ async def test_browsingContext_ignoreCache(websocket, context_id, ignoreCache):
         "id": id,
         "result": {},
     }
+
+
+@pytest.mark.asyncio
+async def test_browsingContext_fragmentNavigated_event(websocket, context_id,
+                                                       html):
+    url = html()
+
+    await subscribe(websocket, ["browsingContext.fragmentNavigated"])
+
+    await send_JSON_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "context": context_id,
+                "url": url,
+                "wait": "complete",
+            }
+        })
+
+    response = await read_JSON_message(websocket)
+    assert response == {
+        "method": "browsingContext.fragmentNavigated",
+        "params": {
+            "context": context_id,
+            "navigation": ANY_STR,
+            "timestamp": ANY_TIMESTAMP,
+            "url": url,
+        }
+    }
+
+    navigation = await read_JSON_message(websocket)
+
+    assert navigation['result']['navigation'] == response['params'][
+        'navigation']


### PR DESCRIPTION
Unblocks `waitForNavigation` in Puppeteer.

After talking with @sadym-chromium we should only give navigation to the initial request (document request).
But all CDP requests triggered by initial parsing of the document have the LoaderId set, so we relay on requestId matching the loaderId.