### PR TITLE
chore: small fix

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -291,17 +291,11 @@ export class BrowsingContextImpl {
     };
   }
 
-  #initListeners() {
-    this.#cdpTarget.cdpClient.on(
-      'Target.targetInfoChanged',
-      (params: Protocol.Target.TargetInfoChangedEvent) => {
-        if (this.id !== params.targetInfo.targetId) {
-          return;
-        }
-        this.#url = params.targetInfo.url;
-      }
-    );
+  onTargetInfoChanged(params: Protocol.Target.TargetInfoChangedEvent) {
+    this.#url = params.targetInfo.url;
+  }
 
+  #initListeners() {
     this.#cdpTarget.cdpClient.on(
       'Page.frameNavigated',
       (params: Protocol.Page.FrameNavigatedEvent) => {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -80,6 +80,9 @@ export class BrowsingContextProcessor {
     cdpClient.on('Target.detachedFromTarget', (params) => {
       this.#handleDetachedFromTargetEvent(params);
     });
+    cdpClient.on('Target.targetInfoChanged', (params) => {
+      this.#handleTargetInfoChangedEvent(params);
+    });
 
     cdpClient.on(
       'Page.frameAttached',
@@ -191,6 +194,15 @@ export class BrowsingContextProcessor {
     this.#preloadScriptStorage
       .findPreloadScripts({targetId: contextId})
       .map((preloadScript) => preloadScript.cdpTargetIsGone(contextId));
+  }
+
+  #handleTargetInfoChangedEvent(
+    params: Protocol.Target.TargetInfoChangedEvent
+  ) {
+    const contextId = params.targetInfo.targetId;
+    this.#browsingContextStorage
+      .findContext(contextId)
+      ?.onTargetInfoChanged(params);
   }
 
   async #getRealm(target: Script.Target): Promise<Realm> {

--- a/src/bidiMapper/domains/network/networkRequest.ts
+++ b/src/bidiMapper/domains/network/networkRequest.ts
@@ -172,12 +172,13 @@ export class NetworkRequest {
 
   #getNavigationId(): BrowsingContext.Navigation | null {
     if (
-      !this.#requestWillBeSentEvent?.loaderId ||
+      !this.#requestWillBeSentEvent ||
+      !this.#requestWillBeSentEvent.loaderId ||
       // When we navigate all CDP network events have `loaderId`
       // CDP's `loaderId` and `requestId` match when
       // that request triggered the loading
-      this.#requestWillBeSentEvent?.loaderId !==
-        this.#requestWillBeSentEvent?.requestId
+      this.#requestWillBeSentEvent.loaderId !==
+        this.#requestWillBeSentEvent.requestId
     ) {
       return null;
     }


### PR DESCRIPTION
The `Target.targetInfoChanged` does not have an SessionId as it happens on the top level.
I am was looking into the NavigationStarted (BiDi implementation) event when I notice that.