### PR TITLE
runBiDiServer: make it possible to specify a LOG_FILE

### DIFF
--- a/runBiDiServer.sh
+++ b/runBiDiServer.sh
@@ -30,7 +30,7 @@ readonly HEADLESS="${HEADLESS:-true}"
 
 # The directory and file wherein to store BiDi logs.
 readonly LOG_DIR="${LOG_DIR:-logs}"
-readonly LOG_FILE="$LOG_DIR/$(date '+%Y-%m-%d-%H-%M-%S').log"
+readonly LOG_FILE="${LOG_FILE:-$LOG_DIR/$(date '+%Y-%m-%d-%H-%M-%S').log}"
 
 # Node.JS options
 readonly NODE_OPTIONS="${NODE_OPTIONS:---unhandled-rejections=strict}"


### PR DESCRIPTION
Use case: have a predictable log filename, instead of a non-deterministic one based on time/date.