### PR TITLE
chore: use common prefix for debug

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
         run: >
           xvfb-run --auto-servernum
           npm run e2e-${{ matrix.head }}
-        # For verbose logging, set `DEBUG: 'bidiMapper:mapperDebug:*'` and `VERBOSE: true`.
+        # For verbose logging, set `DEBUG: 'bidi:mapper:debug:*'` and `VERBOSE: true`.
         env:
           BROWSER_BIN: ${{ steps.browser.outputs.executablePath }}
           VERBOSE: ${{ github.event.inputs.verbose }}
@@ -66,7 +66,7 @@ jobs:
         if: matrix.os == 'macos-latest' || (matrix.os == 'ubuntu-latest' && matrix.head == 'headless')
         timeout-minutes: 20
         run: npm run e2e-${{ matrix.head }}
-        # For verbose logging, set `DEBUG: 'bidiMapper:mapperDebug:*'` and `VERBOSE: true`.
+        # For verbose logging, set `DEBUG: 'bidi:mapper:debug:*'` and `VERBOSE: true`.
         env:
           BROWSER_BIN: ${{ steps.browser.outputs.executablePath }}
           VERBOSE: ${{ github.event.inputs.verbose }}
@@ -78,6 +78,6 @@ jobs:
           path: logs
 
 env:
-  DEBUG: 'bidiServer:log,bidiMapper:mapperDebug:*'
+  DEBUG: 'bidi:server:info,bidi:mapper:debug:*'
   FORCE_COLOR: 3
   PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -187,6 +187,6 @@ jobs:
             out
 
 env:
-  DEBUG: 'bidiServer:log,bidiMapper:mapperDebug:*'
+  DEBUG: 'bidi:server:info,bidi:mapper:debug:*'
   FORCE_COLOR: 3
   PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ CHANNEL=dev npm run server
 npm run server -- --channel=dev
 ```
 
-Use the CLI argument `--verbose` to have CDP events printed to the console. Note: you have to enable debugging output `bidiMapper:mapperDebug:*` as well.
+Use the CLI argument `--verbose` to have CDP events printed to the console. Note: you have to enable debugging output `bidi:mapper:debug:*` as well.
 
 ```sh
-DEBUG=bidiMapper:mapperDebug:* npm run server -- --verbose
+DEBUG=bidi:mapper:debug:* npm run server -- --verbose
 ```
 
 or

--- a/src/bidiServer/bidiServerRunner.ts
+++ b/src/bidiServer/bidiServerRunner.ts
@@ -21,10 +21,10 @@ import websocket from 'websocket';
 
 import type {ITransport} from '../utils/transport.js';
 
-const log = debug('bidiServer:log');
-const debugInternal = debug('bidiServer:internal');
-const debugSend = debug('bidiServer:SEND ▸');
-const debugRecv = debug('bidiServer:RECV ◂');
+export const debugInfo = debug('bidi:server:info');
+const debugInternal = debug('bidi:server:internal');
+const debugSend = debug('bidi:server:SEND ▸');
+const debugRecv = debug('bidi:server:RECV ◂');
 
 function getHttpRequestPayload(request: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -117,7 +117,7 @@ export class BidiServerRunner {
       }
     );
     server.listen(bidiPort, () => {
-      log('Server is listening on port', bidiPort);
+      debugInfo('Server is listening on port', bidiPort);
     });
 
     const wsServer: websocket.server = new websocket.server({
@@ -162,7 +162,7 @@ export class BidiServerRunner {
         onBidiConnectionClosed();
       });
 
-      bidiServer.initialise((messageStr) => {
+      bidiServer.initialize((messageStr) => {
         return this.#sendClientMessageStr(messageStr, connection);
       });
     });
@@ -242,7 +242,7 @@ class BidiServer implements ITransport {
     // Intentionally empty.
   }
 
-  initialise(sendBidiMessage: (messageStr: string) => Promise<void>) {
+  initialize(sendBidiMessage: (messageStr: string) => Promise<void>) {
     this.#sendBidiMessage = sendBidiMessage;
   }
 

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -20,7 +20,6 @@ import os from 'os';
 import {mkdtemp} from 'fs/promises';
 
 import argparse from 'argparse';
-import debug from 'debug';
 import {
   launch,
   computeSystemExecutablePath,
@@ -31,11 +30,9 @@ import {
 
 import type {ITransport} from '../utils/transport.js';
 
-import {BidiServerRunner} from './bidiServerRunner.js';
+import {BidiServerRunner, debugInfo} from './bidiServerRunner.js';
 import {MapperServer} from './mapperServer.js';
 import mapperReader from './mapperReader.js';
-
-const log = debug('bidiServer:log');
 
 function parseArguments(): {
   port: number;
@@ -79,7 +76,7 @@ function parseArguments(): {
 
 (() => {
   try {
-    log('Launching BiDi server');
+    debugInfo('Launching BiDi server');
 
     const args = parseArguments();
     const bidiPort = args.port;
@@ -95,9 +92,9 @@ function parseArguments(): {
         verbose
       );
     });
-    log('BiDi server launched');
+    debugInfo('BiDi server launched');
   } catch (e) {
-    log('Error', e);
+    debugInfo('Error', e);
   }
 })();
 

--- a/src/bidiServer/mapperServer.ts
+++ b/src/bidiServer/mapperServer.ts
@@ -24,11 +24,10 @@ import type {CdpClient} from '../cdp/cdpClient.js';
 import {LogType} from '../utils/log.js';
 import {WebSocketTransport} from '../utils/websocketTransport.js';
 
-const debugInternal = debug('bidiMapper:internal');
-const debugLog = debug('bidiMapper:log');
-const mapperDebugLogOthers = debug('bidiMapper:mapperDebug:others');
-
-const bidiMapperMapperDebugPrefix = 'bidiMapper:mapperDebug:';
+const debugInternal = debug('bidi:mapper:internal');
+const debugInfo = debug('bidi:mapper:info');
+const debugMapperDebugOthers = debug('bidi:mapper:debug:others');
+const debugMapperDebugPrefix = 'bidi:mapper:debug:';
 
 export class MapperServer {
   #handlers: ((message: string) => void)[] = [];
@@ -134,8 +133,8 @@ export class MapperServer {
         messages: unknown[];
       };
 
-      // BiDi traffic is logged in `bidiServer:SEND ▸`
-      if (debugMessage.logType === LogType.bidi) {
+      // BiDi traffic is logged in `bidi:server:SEND ▸`
+      if (debugMessage.logType.startsWith(LogType.bidi)) {
         return;
       }
 
@@ -143,7 +142,7 @@ export class MapperServer {
         debugMessage.logType !== undefined &&
         debugMessage.messages !== undefined
       ) {
-        debug(bidiMapperMapperDebugPrefix + debugMessage.logType)(
+        debug(debugMapperDebugPrefix + debugMessage.logType)(
           // No formatter is needed as the messages will be formatted
           // automatically.
           '',
@@ -153,11 +152,11 @@ export class MapperServer {
       }
     } catch {}
     // Fall back to raw log in case of unknown
-    mapperDebugLogOthers(debugMessageStr);
+    debugMapperDebugOthers(debugMessageStr);
   };
 
   #onConsoleAPICalled = (params: Protocol.Runtime.ConsoleAPICalledEvent) => {
-    debugLog(
+    debugInfo(
       'consoleAPICalled %s %O',
       params.type,
       params.args.map((arg) => arg.value)
@@ -167,7 +166,7 @@ export class MapperServer {
   #onRuntimeExceptionThrown = (
     params: Protocol.Runtime.ExceptionThrownEvent
   ) => {
-    debugLog('exceptionThrown', params);
+    debugInfo('exceptionThrown', params);
   };
 
   static async #initMapper(

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -107,12 +107,7 @@ function createCdpConnection() {
     }
   }
 
-  return new CdpConnection(
-    new WindowCdpTransport(),
-    (...messages: unknown[]) => {
-      log(LogType.cdp, ...messages);
-    }
-  );
+  return new CdpConnection(new WindowCdpTransport(), log);
 }
 
 function createBidiServer(selfTargetId: string) {
@@ -121,7 +116,7 @@ function createBidiServer(selfTargetId: string) {
 
     constructor() {
       window.onBidiMessage = (messageStr: string) => {
-        log(LogType.bidi, 'received ◂', messageStr);
+        log(`${LogType.bidi}:RECV ◂`, messageStr);
         let messageObject: Message.RawCommandRequest;
         try {
           messageObject = WindowBidiTransport.#parseBidiMessage(messageStr);
@@ -146,7 +141,7 @@ function createBidiServer(selfTargetId: string) {
     sendMessage(message: Message.OutgoingMessage) {
       const messageStr = JSON.stringify(message);
       window.sendBidiResponse(messageStr);
-      log(LogType.bidi, 'sent ▸', messageStr);
+      log(`${LogType.bidi}:SEND ▸`, messageStr);
     }
 
     close() {

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {LogType} from '../utils/log.js';
+import {type LogPrefix, LogType} from '../utils/log.js';
 
 /** HTML source code for the user-facing Mapper tab. */
 const mapperPageSource =
@@ -64,7 +64,7 @@ export function generatePage() {
   findOrCreateTypeLogContainer(LogType.cdp);
 }
 
-export function log(logType: LogType, ...messages: unknown[]) {
+export function log(logType: LogPrefix, ...messages: unknown[]) {
   // If run not in browser (e.g. unit test), do nothing.
   if (!globalThis.document.documentElement) {
     return;

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -24,4 +24,6 @@ export enum LogType {
   // keep-sorted end
 }
 
-export type LoggerFn = (type: LogType, ...messages: unknown[]) => void;
+export type LogPrefix = LogType | `${LogType}:${string}`;
+
+export type LoggerFn = (type: LogPrefix, ...messages: unknown[]) => void;


### PR DESCRIPTION
As suggested by DEBUG we should have a common prefix for all our  statements, that also remove some clutter around 
`bidiMapper:mapperDebug` that has mapper 2 times.
in the feature we may want to change to something like `crbidi` compare to `bidi` to signify that it's chrome bidi over other bidi package.
CC @thiagowfx 