### PR TITLE
feat: make the BiDi+ events less "chatty"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ CdpSendCommandCommand = {
 }
 
 CdpSendCommandParameters = {
-   cdpMethod: text,
-   cdpParams: any,
-   cdpSession?: text,
+   method: text,
+   params: any,
+   cession?: text,
 }
 
 CdpSendCommandResult = {
    result: any,
-   cdpSession: text,
+   session: text,
 }
 ```
 
@@ -58,24 +58,24 @@ CdpGetSessionParameters = {
 }
 
 CdpGetSessionResult = {
-   cdpSession: text,
+   session: text,
 }
 ```
 
 The command returns the default CDP session for the selected browsing context.
 
-### Event `cdp.eventReceived`
+### Events `cdp`
 
 ```cddl
 CdpEventReceivedEvent = {
-   method: "cdp.eventReceived",
-   params: ScriptEvaluateParameters,
+   method: "cdp.<CDP Event Name>",
+   params: CdpEventReceivedParameters,
 }
 
 CdpEventReceivedParameters = {
-   cdpMethod: text,
-   cdpParams: any,
-   cdpSession: string,
+   event: text,
+   params: any,
+   session: string,
 }
 ```
 

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -535,27 +535,29 @@ export class BrowsingContextProcessor {
     return ['page', 'iframe'].includes(target.type);
   }
 
-  async process_cdp_sendCommand(params: CDP.SendCommandParams) {
-    const client = params.cdpSession
-      ? this.#cdpConnection.getCdpClient(params.cdpSession)
+  async process_cdp_sendCommand(
+    params: CDP.SendCommandParams
+  ): Promise<CDP.SendCommandResult> {
+    const client = params.session
+      ? this.#cdpConnection.getCdpClient(params.session)
       : this.#cdpConnection.browserClient();
     const sendCdpCommandResult = await client.sendCommand(
-      params.cdpMethod,
-      params.cdpParams
+      params.method,
+      params.params
     );
     return {
       result: sendCdpCommandResult,
-      cdpSession: params.cdpSession,
+      session: params.session,
     };
   }
 
-  process_cdp_getSession(params: CDP.GetSessionParams) {
+  process_cdp_getSession(params: CDP.GetSessionParams): CDP.GetSessionResult {
     const context = params.context;
     const sessionId =
       this.#browsingContextStorage.getContext(context).cdpTarget.cdpSessionId;
     if (sessionId === undefined) {
-      return {result: {cdpSession: null}};
+      return {result: {session: null}};
     }
-    return {result: {cdpSession: sessionId}};
+    return {result: {session: sessionId}};
   }
 }

--- a/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.spec.ts
@@ -20,7 +20,6 @@ import * as sinon from 'sinon';
 
 import {
   BrowsingContext,
-  CDP,
   type CommonDataTypes,
   Log,
   Network,
@@ -436,12 +435,6 @@ describe('SubscriptionManager', () => {
       ]);
     });
 
-    it('all CDP events', () => {
-      expect(unrollEvents([CDP.AllEvents])).to.deep.equal([
-        CDP.EventNames.EventReceivedEvent,
-      ]);
-    });
-
     it('all Log events', () => {
       expect(unrollEvents([Log.AllEvents])).to.deep.equal([
         Log.EventNames.LogEntryAddedEvent,
@@ -466,29 +459,15 @@ describe('SubscriptionManager', () => {
     });
 
     it('discrete events', () => {
-      expect(
-        unrollEvents([
-          CDP.EventNames.EventReceivedEvent,
-          Log.EventNames.LogEntryAddedEvent,
-        ])
-      ).to.deep.equal([
-        CDP.EventNames.EventReceivedEvent,
+      expect(unrollEvents([Log.EventNames.LogEntryAddedEvent])).to.deep.equal([
         Log.EventNames.LogEntryAddedEvent,
       ]);
     });
 
     it('all and discrete events', () => {
       expect(
-        unrollEvents([
-          CDP.AllEvents,
-          CDP.EventNames.EventReceivedEvent,
-          Log.EventNames.LogEntryAddedEvent,
-        ])
-      ).to.deep.equal([
-        CDP.EventNames.EventReceivedEvent,
-        CDP.EventNames.EventReceivedEvent,
-        Log.EventNames.LogEntryAddedEvent,
-      ]);
+        unrollEvents([Log.AllEvents, Log.EventNames.LogEntryAddedEvent])
+      ).to.deep.equal([Log.EventNames.LogEntryAddedEvent]);
     });
   });
 });

--- a/src/bidiMapper/domains/events/SubscriptionManager.ts
+++ b/src/bidiMapper/domains/events/SubscriptionManager.ts
@@ -17,7 +17,6 @@
 
 import {
   BrowsingContext,
-  CDP,
   type CommonDataTypes,
   Log,
   Message,
@@ -43,31 +42,34 @@ export function cartesianProduct(...a: any[][]) {
 export function unrollEvents(
   events: Session.SubscriptionRequestEvent[]
 ): Session.SubscriptionRequestEvent[] {
-  const allEvents: Session.SubscriptionRequestEvent[] = [];
+  const allEvents = new Set<Session.SubscriptionRequestEvent>();
+
+  function addEvents(events: string[]) {
+    for (const event of events) {
+      allEvents.add(event as Session.SubscriptionRequestEvent);
+    }
+  }
 
   for (const event of events) {
     switch (event) {
       case BrowsingContext.AllEvents:
-        allEvents.push(...Object.values(BrowsingContext.EventNames));
-        break;
-      case CDP.AllEvents:
-        allEvents.push(...Object.values(CDP.EventNames));
+        addEvents(Object.values(BrowsingContext.EventNames));
         break;
       case Log.AllEvents:
-        allEvents.push(...Object.values(Log.EventNames));
+        addEvents(Object.values(Log.EventNames));
         break;
       case Network.AllEvents:
-        allEvents.push(...Object.values(Network.EventNames));
+        addEvents(Object.values(Network.EventNames));
         break;
       case Script.AllEvents:
-        allEvents.push(...Object.values(Script.EventNames));
+        addEvents(Object.values(Script.EventNames));
         break;
       default:
-        allEvents.push(event);
+        allEvents.add(event);
     }
   }
 
-  return allEvents;
+  return [...allEvents.values()];
 }
 
 export class SubscriptionManager {
@@ -154,12 +156,6 @@ export class SubscriptionManager {
 
     if (event === BrowsingContext.AllEvents) {
       Object.values(BrowsingContext.EventNames).map((specificEvent) =>
-        this.subscribe(specificEvent, contextId, channel)
-      );
-      return;
-    }
-    if (event === CDP.AllEvents) {
-      Object.values(CDP.EventNames).map((specificEvent) =>
         this.subscribe(specificEvent, contextId, channel)
       );
       return;

--- a/src/cdp/cdpClient.ts
+++ b/src/cdp/cdpClient.ts
@@ -47,7 +47,7 @@ export interface ICdpClient extends EventEmitter<CdpEvents> {
    */
   sendCommand<CdpMethod extends keyof ProtocolMapping.Commands>(
     method: CdpMethod,
-    ...params: ProtocolMapping.Commands[CdpMethod]['paramsType']
+    params?: ProtocolMapping.Commands[CdpMethod]['paramsType'][0]
   ): Promise<ProtocolMapping.Commands[CdpMethod]['returnType']>;
 }
 

--- a/src/protocol/protocol.ts
+++ b/src/protocol/protocol.ts
@@ -1230,14 +1230,17 @@ export namespace CDP {
     params: SendCommandParams;
   };
 
-  export type SendCommandParams = {
-    cdpMethod: keyof ProtocolMapping.Commands;
-    cdpParams: object;
-    cdpSession?: string;
+  export type SendCommandParams<
+    Command extends keyof ProtocolMapping.Commands = keyof ProtocolMapping.Commands
+  > = {
+    method: Command;
+    params?: ProtocolMapping.Commands[Command]['paramsType'][0];
+    session?: string;
   };
 
   export type SendCommandResult = {
     result: ProtocolMapping.Commands[keyof ProtocolMapping.Commands]['returnType'];
+    session?: string;
   };
 
   export type GetSessionCommand = {
@@ -1249,24 +1252,19 @@ export namespace CDP {
     context: CommonDataTypes.BrowsingContext;
   };
 
-  export type GetSessionResult = {result: {cdpSession: string}};
+  export type GetSessionResult = {result: {session: string | null}};
 
-  export type EventReceivedEvent = EventResponse<
-    EventNames.EventReceivedEvent,
-    EventReceivedParams
-  >;
+  export type EventReceivedEvent = EventResponse<EventNames, CDPEventParams>;
 
-  export type EventReceivedParams = {
-    cdpMethod: keyof ProtocolMapping.Commands;
-    cdpParams: object;
-    cdpSession: string;
+  export type CDPEventParams<
+    EventName extends keyof ProtocolMapping.Events = keyof ProtocolMapping.Events
+  > = {
+    event: EventName;
+    params: ProtocolMapping.Events[EventName];
+    session: string;
   };
 
-  export const AllEvents = 'cdp';
-
-  export enum EventNames {
-    EventReceivedEvent = 'cdp.eventReceived',
-  }
+  export type EventNames = `cdp.${keyof ProtocolMapping.Events}`;
 }
 
 /** @see https://w3c.github.io/webdriver-bidi/#module-session */
@@ -1294,9 +1292,9 @@ export namespace Session {
 
   export type SubscriptionRequestEvent =
     // keep-sorted start
+    | CDP.EventNames
     | Message.EventNames
     | typeof BrowsingContext.AllEvents
-    | typeof CDP.AllEvents
     | typeof Log.AllEvents
     | typeof Network.AllEvents
     | typeof Script.AllEvents;

--- a/tests/screenshot/test_screenshot.py
+++ b/tests/screenshot/test_screenshot.py
@@ -71,21 +71,21 @@ async def test_screenshot(websocket, context_id, png_filename):
                 "context": context_id
             }
         })
-        session_id = command_result["cdpSession"]
+        session_id = command_result["session"]
 
         # Set a fixed viewport to make the test deterministic.
         await execute_command(
             websocket, {
                 "method": "cdp.sendCommand",
                 "params": {
-                    "cdpMethod": "Emulation.setDeviceMetricsOverride",
-                    "cdpParams": {
+                    "method": "Emulation.setDeviceMetricsOverride",
+                    "params": {
                         "width": 200,
                         "height": 200,
                         "deviceScaleFactor": 1.0,
                         "mobile": False,
                     },
-                    "cdpSession": session_id
+                    "session": session_id
                 }
             })
 
@@ -123,21 +123,21 @@ async def test_screenshot_oopif(websocket, context_id, html, iframe):
             "context": context_id
         }
     })
-    session_id = command_result["cdpSession"]
+    session_id = command_result["session"]
 
     # Set a fixed viewport to make the test deterministic.
     await execute_command(
         websocket, {
             "method": "cdp.sendCommand",
             "params": {
-                "cdpMethod": "Emulation.setDeviceMetricsOverride",
-                "cdpParams": {
+                "method": "Emulation.setDeviceMetricsOverride",
+                "params": {
                     "width": 200,
                     "height": 200,
                     "deviceScaleFactor": 1.0,
                     "mobile": False,
                 },
-                "cdpSession": session_id
+                "session": session_id
             }
         })
 

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -27,8 +27,8 @@ async def test_cdp_sendCommand_commandResultReturned(websocket):
         websocket, {
             "method": "cdp.sendCommand",
             "params": {
-                "cdpMethod": "Target.getTargets",
-                "cdpParams": {}
+                "method": "Target.getTargets",
+                "params": {}
             }
         })
 
@@ -36,8 +36,8 @@ async def test_cdp_sendCommand_commandResultReturned(websocket):
 
 
 @pytest.mark.asyncio
-async def test_cdp_subscribeCdpEvents_cdpEventReceived(websocket, context_id):
-    await subscribe(websocket, "cdp.eventReceived")
+async def test_cdp_subscribeCdpEvents_cdpEvent(websocket, context_id):
+    await subscribe(websocket, "cdp.Runtime.consoleAPICalled")
 
     command_result = await execute_command(websocket, {
         "method": "cdp.getSession",
@@ -46,27 +46,27 @@ async def test_cdp_subscribeCdpEvents_cdpEventReceived(websocket, context_id):
         }
     })
 
-    session_id = command_result["cdpSession"]
+    session_id = command_result["session"]
 
     await send_JSON_command(
         websocket, {
             "method": "cdp.sendCommand",
             "params": {
-                "cdpMethod": "Runtime.evaluate",
-                "cdpParams": {
+                "method": "Runtime.evaluate",
+                "params": {
                     "expression": "console.log(1)",
                 },
-                "cdpSession": session_id
+                "session": session_id
             }
         })
 
     resp = await read_JSON_message(websocket)
 
     assert {
-        "method": "cdp.eventReceived",
+        "method": "cdp.Runtime.consoleAPICalled",
         "params": {
-            "cdpMethod": "Runtime.consoleAPICalled",
-            "cdpParams": {
+            "event": "Runtime.consoleAPICalled",
+            "params": {
                 "type": "log",
                 "args": [{
                     "type": "number",
@@ -77,54 +77,6 @@ async def test_cdp_subscribeCdpEvents_cdpEventReceived(websocket, context_id):
                 "timestamp": ANY_TIMESTAMP,
                 "stackTrace": ANY
             },
-            "cdpSession": session_id
-        }
-    } == resp
-
-
-@pytest.mark.asyncio
-async def test_cdp_subscribeToAllCdpEvents_cdpEventReceived(
-        websocket, context_id):
-    await subscribe(websocket, "cdp")
-
-    command_result = await execute_command(websocket, {
-        "method": "cdp.getSession",
-        "params": {
-            "context": context_id
-        }
-    })
-
-    session_id = command_result["cdpSession"]
-
-    await send_JSON_command(
-        websocket, {
-            "method": "cdp.sendCommand",
-            "params": {
-                "cdpMethod": "Runtime.evaluate",
-                "cdpParams": {
-                    "expression": "console.log(1)",
-                },
-                "cdpSession": session_id
-            }
-        })
-
-    resp = await read_JSON_message(websocket)
-
-    assert {
-        "method": "cdp.eventReceived",
-        "params": {
-            "cdpMethod": "Runtime.consoleAPICalled",
-            "cdpParams": {
-                "type": "log",
-                "args": [{
-                    "type": "number",
-                    "value": 1,
-                    "description": "1"
-                }],
-                "executionContextId": ANY_INT,
-                "timestamp": ANY_TIMESTAMP,
-                "stackTrace": ANY
-            },
-            "cdpSession": session_id
+            "session": session_id
         }
     } == resp

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -94,7 +94,7 @@ async def test_network_specific_context_subscription_does_not_enable_cdp_network
     new_context_id = await create_context()
 
     # Subscribe to all CDP events.
-    await subscribe(websocket, "cdp")
+    await subscribe(websocket, "cdp.Network.requestWillBeSent")
 
     command_id = await send_JSON_command(
         websocket, {
@@ -108,10 +108,10 @@ async def test_network_specific_context_subscription_does_not_enable_cdp_network
     resp = await read_JSON_message(websocket)
     while "id" not in resp:
         # Assert CDP events are not from Network.
-        assert resp["method"] == "cdp.eventReceived"
-        assert not resp["params"]["cdpMethod"].startswith("Network"), \
+        assert resp["method"].startswith("cdp")
+        assert not resp["params"]["event"].startswith("Network"), \
             "There should be no `Network` cdp events, but was " \
-            f"`{ resp['params']['cdpMethod'] }` "
+            f"`{ resp['params']['event'] }` "
         resp = await read_JSON_message(websocket)
 
     assert resp == AnyExtending({"id": command_id})

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -510,7 +510,7 @@ async def test_unsubscribeIsAtomic(websocket, context_id, iframe_id):
                 "params": {
                     "events": [
                         "log.entryAdded",
-                        "cdp.eventReceived",  # This event is not subscribed.
+                        "network.responseCompleted",  # This event is not subscribed.
                     ],
                     "contexts": [context_id]
                 }
@@ -518,8 +518,9 @@ async def test_unsubscribeIsAtomic(websocket, context_id, iframe_id):
 
     assert {
         "error": "invalid argument",
-        "message": AnyContains("Cannot unsubscribe from cdp.eventReceived")
-                   & AnyContains("No subscription found")
+        "message":
+            AnyContains("Cannot unsubscribe from network.responseCompleted")
+            & AnyContains("No subscription found")
     } == exception_info.value.args[0]
 
     await send_JSON_command(


### PR DESCRIPTION
Currently we if we want to get the CDP event we can only pass the `cdp` param. 
That will make all the event from CDP pass though the WebDriver BiDi socket connection.
We want to send only the events that the user is interested for Puppeteer `Tracing.tracingComplete`.
for that I remove the send all `cdp` and replace it with individual `cdp.Tracing.tracingComplete`.
That way only this specific event is send. 

Ref Puppeteer https://github.com/puppeteer/puppeteer/pull/10453 and logs:
![image](https://github.com/GoogleChromeLabs/chromium-bidi/assets/34244704/5f56cde7-77c9-4ac0-976b-62487d34eaa3)


