### PR TITLE
fix: expand viewport validation tests

### DIFF
--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -18,8 +18,8 @@ from test_helpers import execute_command, goto_url
 
 
 @pytest.mark.asyncio
-async def test_set_viewport(websocket, context_id):
-    await goto_url(websocket, context_id, "about:blank")
+async def test_set_viewport(websocket, context_id, html):
+    await goto_url(websocket, context_id, html())
 
     await execute_command(
         websocket, {
@@ -56,8 +56,19 @@ async def test_set_viewport(websocket, context_id):
 
 
 @pytest.mark.asyncio
-async def test_set_viewport_unsupported(websocket, context_id):
-    await goto_url(websocket, context_id, "about:blank")
+@pytest.mark.parametrize("width,height", [
+    (300, 10000001),
+    (10000001, 300),
+    (10000001, 10000001),
+],
+                         ids=[
+                             "very big height",
+                             "very big width",
+                             "very big width and height",
+                         ])
+async def test_set_viewport_unsupported(websocket, context_id, html, width,
+                                        height):
+    await goto_url(websocket, context_id, html())
 
     with pytest.raises(Exception) as exception_info:
         # https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:content/browser/devtools/protocol/emulation_handler.cc;l=232;drc=1890f3f74c8100eb1a3e945d34d6fd576d2a9061
@@ -67,8 +78,8 @@ async def test_set_viewport_unsupported(websocket, context_id):
                 "params": {
                     "context": context_id,
                     "viewport": {
-                        "width": 10000001,
-                        "height": 10000001,
+                        "width": width,
+                        "height": height,
                     }
                 }
             })
@@ -77,3 +88,36 @@ async def test_set_viewport_unsupported(websocket, context_id):
         "error": "unsupported operation",
         "message": "Provided viewport dimensions are not supported"
     } == exception_info.value.args[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("width,height", [
+    (300, -20),
+    (-20, 300),
+    (-20, -20),
+],
+                         ids=[
+                             "negative height",
+                             "negative width",
+                             "negative width and height",
+                         ])
+async def test_set_viewport_negative(websocket, context_id, html, width,
+                                     height):
+    await goto_url(websocket, context_id, html())
+
+    with pytest.raises(Exception) as exception_info:
+        await execute_command(
+            websocket, {
+                "method": "browsingContext.setViewport",
+                "params": {
+                    "context": context_id,
+                    "viewport": {
+                        "width": width,
+                        "height": height,
+                    }
+                }
+            })
+
+    assert "invalid argument" == exception_info.value.args[0]["error"]
+    assert "Number must be greater than or equal to 0" in exception_info.value.args[
+        0]["message"]

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -88,36 +88,3 @@ async def test_set_viewport_unsupported(websocket, context_id, html, width,
         "error": "unsupported operation",
         "message": "Provided viewport dimensions are not supported"
     } == exception_info.value.args[0]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("width,height", [
-    (300, -20),
-    (-20, 300),
-    (-20, -20),
-],
-                         ids=[
-                             "negative height",
-                             "negative width",
-                             "negative width and height",
-                         ])
-async def test_set_viewport_negative(websocket, context_id, html, width,
-                                     height):
-    await goto_url(websocket, context_id, html())
-
-    with pytest.raises(Exception) as exception_info:
-        await execute_command(
-            websocket, {
-                "method": "browsingContext.setViewport",
-                "params": {
-                    "context": context_id,
-                    "viewport": {
-                        "width": width,
-                        "height": height,
-                    }
-                }
-            })
-
-    assert "invalid argument" == exception_info.value.args[0]["error"]
-    assert "Number must be greater than or equal to 0" in exception_info.value.args[
-        0]["message"]


### PR DESCRIPTION
These are not intended to be exhaustive; for that, we rely on WPT.

Bug: #868