### PR TITLE
fix: use non-force close for BrowsingContext.close

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -353,7 +353,6 @@ export class BrowsingContextImpl {
         this.#url = params.url;
         this.#deferreds.Page.navigatedWithinDocument.resolve(params);
 
-        // TODO: Remove this once History event for BiDi are added
         this.#eventManager.registerEvent(
           {
             method: BrowsingContext.EventNames.FragmentNavigated,
@@ -827,5 +826,9 @@ export class BrowsingContextImpl {
         data: result.data,
       },
     };
+  }
+
+  async close(): Promise<void> {
+    await this.#cdpTarget.cdpClient.sendCommand('Page.close');
   }
 }

--- a/tests/test_browsing_context.py
+++ b/tests/test_browsing_context.py
@@ -429,14 +429,12 @@ async def test_browsingContext_close_browsingContext_closed(
         websocket, context_id):
     await subscribe(websocket, ["browsingContext.contextDestroyed"])
 
-    await send_JSON_command(
-        websocket, {
-            "id": 12,
-            "method": "browsingContext.close",
-            "params": {
-                "context": context_id
-            }
-        })
+    command_id = await send_JSON_command(websocket, {
+        "method": "browsingContext.close",
+        "params": {
+            "context": context_id
+        }
+    })
 
     # Assert "browsingContext.contextCreated" event emitted.
     resp = await read_JSON_message(websocket)
@@ -450,9 +448,8 @@ async def test_browsingContext_close_browsingContext_closed(
         }
     }
 
-    # Assert command done.
     resp = await read_JSON_message(websocket)
-    assert resp == {"id": 12, "result": {}}
+    assert resp == {"id": command_id, "result": {}}
 
     result = await get_tree(websocket)
 

--- a/tests/test_realm.py
+++ b/tests/test_realm.py
@@ -120,14 +120,12 @@ async def test_realm_realmDestroyed_sandbox(websocket, context_id):
             }
         })
 
-    await send_JSON_command(
-        websocket, {
-            "id": 22,
-            "method": "browsingContext.close",
-            "params": {
-                "context": context_id,
-            }
-        })
+    await send_JSON_command(websocket, {
+        "method": "browsingContext.close",
+        "params": {
+            "context": context_id,
+        }
+    })
 
     response = await read_JSON_message(websocket)
 


### PR DESCRIPTION
BiDi defines that we should run the https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable, which tells us to run the unload events.
Should we also provide a way to `force close` in BiDi spec?