### PR TITLE
chore: vscode: remove auto format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-  "[python]": {
-    "editor.formatOnSave": true,
-    "editor.formatOnType": true
-  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },


### PR DESCRIPTION
This is needed to avoid formatting WPT files (thus avoiding adding noise) when submitting upstream PRs.