### PR TITLE
fix: Network Module clogging Processing Queue

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -140,7 +140,7 @@ export class BrowsingContextImpl {
     return this.#loaderId;
   }
 
-  delete() {
+  dispose() {
     this.#deleteAllChildren();
 
     this.#realmStorage.deleteRealms({
@@ -217,7 +217,7 @@ export class BrowsingContextImpl {
   }
 
   #deleteAllChildren() {
-    this.directChildren.map((child) => child.delete());
+    this.directChildren.map((child) => child.dispose());
   }
 
   get #defaultRealm(): Realm {

--- a/src/bidiMapper/domains/input/InputStateManager.ts
+++ b/src/bidiMapper/domains/input/InputStateManager.ts
@@ -35,7 +35,7 @@ export class InputStateManager {
     return state;
   }
 
-  delete(context: BrowsingContextImpl) {
+  dispose(context: BrowsingContextImpl) {
     this.#states.delete(context);
   }
 }

--- a/src/bidiMapper/domains/network/networkRequest.ts
+++ b/src/bidiMapper/domains/network/networkRequest.ts
@@ -40,7 +40,7 @@ export class NetworkRequest {
    * The identifier for a request resulting from a redirect matches that of the
    * request that initiated it.
    */
-  requestId: Network.Request;
+  readonly requestId: Network.Request;
 
   #servedFromCache = false;
   #redirectCount = 0;
@@ -155,6 +155,12 @@ export class NetworkRequest {
       },
       this.#requestWillBeSentEvent?.frameId ?? null
     );
+  }
+
+  dispose() {
+    const error = new Error('Network processor detached');
+    this.#responseReceivedDeferred.reject(error);
+    this.#beforeRequestSentDeferred.reject(error);
   }
 
   #getBaseEventParams(): Network.BaseParameters {

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -321,7 +321,7 @@ export class Realm {
     return ScriptEvaluator.stringifyObject(cdpObject, this);
   }
 
-  delete() {
+  dispose() {
     this.#eventManager.registerEvent(
       {
         method: ChromiumBidi.Script.EventNames.RealmDestroyed,

--- a/src/bidiMapper/domains/script/realmStorage.ts
+++ b/src/bidiMapper/domains/script/realmStorage.ts
@@ -116,7 +116,7 @@ export class RealmStorage {
   /** Deletes all realms that match the given filter. */
   deleteRealms(filter: RealmFilter) {
     this.findRealms(filter).map((realm) => {
-      realm.delete();
+      realm.dispose();
       this.#realmMap.delete(realm.realmId);
       Array.from(this.knownHandlesToRealm.entries())
         .filter(([, r]) => r === realm.realmId)

--- a/src/cdp/cdpClient.ts
+++ b/src/cdp/cdpClient.ts
@@ -30,6 +30,16 @@ export class CloseError extends Error {}
 
 export interface ICdpClient extends EventEmitter<CdpEvents> {
   /**
+   * Unique session identifier.
+   */
+  sessionId: string | undefined;
+
+  /**
+   * Get the default browser client (no sessionId)
+   */
+  browserClient(): ICdpClient;
+
+  /**
    * Provides an unique way to detect if an error was caused by the closure of a
    * Target or Session.
    *
@@ -60,6 +70,14 @@ export class CdpClient extends EventEmitter<CdpEvents> implements ICdpClient {
     super();
     this.#cdpConnection = cdpConnection;
     this.#sessionId = sessionId;
+  }
+
+  get sessionId(): string | undefined {
+    return this.#sessionId;
+  }
+
+  browserClient(): ICdpClient {
+    return this.#cdpConnection.browserClient();
   }
 
   sendCommand<CdpMethod extends keyof ProtocolMapping.Commands>(

--- a/src/utils/EventEmitter.spec.ts
+++ b/src/utils/EventEmitter.spec.ts
@@ -115,4 +115,32 @@ describe('EventEmitter', () => {
       expect(listener.firstCall.args[0]).to.equal(data);
     });
   });
+
+  describe('removeAllListeners', () => {
+    it('for different events', () => {
+      const listener1 = sinon.spy();
+      const listener2 = sinon.spy();
+      const listener3 = sinon.spy();
+      emitter.on('foo', listener1).on('foo', listener2).on('bar', listener3);
+      emitter.removeAllListeners();
+
+      emitter.emit('foo', undefined);
+      expect(listener1.callCount).to.equal(0);
+      expect(listener2.callCount).to.equal(0);
+      expect(listener3.callCount).to.equal(0);
+    });
+
+    it('for a single event', () => {
+      const listener1 = sinon.spy();
+      const listener2 = sinon.spy();
+      const listener3 = sinon.spy();
+      emitter.on('foo', listener1).on('foo', listener2).on('bar', listener3);
+      emitter.removeAllListeners('bar');
+
+      emitter.emit('foo', undefined);
+      expect(listener1.callCount).to.equal(1);
+      expect(listener2.callCount).to.equal(1);
+      expect(listener3.callCount).to.equal(0);
+    });
+  });
 });

--- a/src/utils/EventEmitter.ts
+++ b/src/utils/EventEmitter.ts
@@ -77,4 +77,19 @@ export class EventEmitter<Events extends Record<EventType, unknown>> {
   emit<Key extends keyof Events>(event: Key, eventData: Events[Key]): void {
     this.#emitter.emit(event, eventData);
   }
+
+  /**
+   * Removes all listeners. If given an event argument, it will remove only
+   * listeners for that event.
+   * @param event - the event to remove listeners for.
+   * @returns `this` to enable you to chain method calls.
+   */
+  removeAllListeners(event?: EventType): this {
+    if (event) {
+      this.#emitter.all.delete(event);
+    } else {
+      this.#emitter.all.clear();
+    }
+    return this;
+  }
 }


### PR DESCRIPTION
Recently we changed to use `Page.close` (#939) which does not destroy the target immediately.
In puppeteer some times we test timeouts of `1ms` which the command is send and failed on Puppeteer end (never awaited). The problem is we try close the page, but not forcing lets the navigation starting and some NetworkEvents to be sent though CDP, but due to being deferred they never resolve and the ProcessingQueue stops working.