### PR TITLE
feat(print): throw unsupported operation when content area is empty

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -831,9 +831,8 @@ export class BrowsingContextImpl {
         'invalid print parameters: content area is empty'
       ) {
         throw new UnsupportedOperationException(error.message);
-      } else {
-        throw error;
       }
+      throw error;
     }
   }
 

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -826,7 +826,10 @@ export class BrowsingContextImpl {
       };
     } catch (error: any) {
       // Effectively zero dimensions.
-      if (error.message === 'invalid print parameters: content area is empty') {
+      if (
+        (error as Error).message ===
+        'invalid print parameters: content area is empty'
+      ) {
         throw new UnsupportedOperationException(error.message);
       } else {
         throw error;

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -816,14 +816,22 @@ export class BrowsingContextImpl {
       cdpParams.preferCSSPageSize = !params.shrinkToFit;
     }
 
-    const result = await this.#cdpTarget.cdpClient.sendCommand(
-      'Page.printToPDF',
-      cdpParams
-    );
-
-    return {
-      data: result.data,
-    };
+    try {
+      const result = await this.#cdpTarget.cdpClient.sendCommand(
+        'Page.printToPDF',
+        cdpParams
+      );
+      return {
+        data: result.data,
+      };
+    } catch (error: any) {
+      // Effectively zero dimensions.
+      if (error.message === 'invalid print parameters: content area is empty') {
+        throw new UnsupportedOperationException(error.message);
+      } else {
+        throw error;
+      }
+    }
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
Bug: #518
Spec: https://github.com/w3c/webdriver-bidi/issues/473
WPT: https://github.com/web-platform-tests/wpt/pull/40872