### PR TITLE
ci(headless): use new headless instead of old headless

### DIFF
--- a/runWPT.sh
+++ b/runWPT.sh
@@ -63,7 +63,7 @@ if [ -z ${WPT_METADATA+x} ]; then
 fi
 
 if [[ "$HEADLESS" == "true" ]]; then
-  log "Running WPT in headless mode..."
+  log "Running WPT in new headless mode..."
 else
   log "Running WPT in headful mode..."
 fi

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -54,7 +54,7 @@ function parseArguments(): {
   });
 
   parser.add_argument('--headless', {
-    help: 'Sets if browser should run in headless or headful mode. Default is true.',
+    help: 'Sets if browser should run in new headless (default) or headful mode.',
     default: true,
   });
 
@@ -112,7 +112,9 @@ async function onNewBidiConnectionOpen(
   );
   // See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
   const chromeArguments = [
-    ...(headless ? ['--headless', '--hide-scrollbars', '--mute-audio'] : []),
+    ...(headless
+      ? ['--headless=new', '--hide-scrollbars', '--mute-audio']
+      : []),
     // keep-sorted start
     '--disable-component-update',
     '--disable-default-apps',


### PR DESCRIPTION
Closes: #949

I chose to completely replace old headless. Is there any use for it anymore?

Alternatively we could support all of them. That would require changing more files. And would pose the question whether we would want another CI config (new headless x old headless).