### PR TITLE
fix: create targets in the background

### DIFF
--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -256,12 +256,14 @@ export class BrowsingContextProcessor {
         result = await browserCdpClient.sendCommand('Target.createTarget', {
           url: 'about:blank',
           newWindow: false,
+          background: true,
         });
         break;
       case BrowsingContext.CreateType.Window:
         result = await browserCdpClient.sendCommand('Target.createTarget', {
           url: 'about:blank',
           newWindow: true,
+          background: true,
         });
         break;
     }


### PR DESCRIPTION
As required by the current spec: https://w3c.github.io/webdriver-bidi/#command-browsingContext-create:~:text=This%20must%20be%20done%20without%20invoking%20the%20focusing%20steps%20for%20the%20created%20browsing%20context.