### PR TITLE
ci: only use "wpt run --processes" in CI

### DIFF
--- a/runWPT.sh
+++ b/runWPT.sh
@@ -86,7 +86,7 @@ if [[ "$VERBOSE" == "true" ]]; then
     --log-mach -
     --log-mach-level info
   )
-elif [[ "$HEADLESS" == "true" ]]; then
+elif [[ "$CI" == "true" && "$HEADLESS" == "true" ]]; then
   # Parallelization is flaky in headful mode.
   case "$(uname -s)" in
     Darwin*) WPT_RUN_ARGS+=(--processes "$(sysctl -n hw.physicalcpu)");;


### PR DESCRIPTION
When regenerating WPT tests locally, `--processes` is quite flaky. Connections keep closing and stack traces keep being printed.

Local builds should default to not running in parallel, which is better for debugging and stability.

CI will keep using the flag for speed/performance reasons, as the job currently takes 10min on average instead of 20min.

Bug: #876