### PR TITLE
ci: wpt: exclude tentative tests from report

### DIFF
--- a/tools/wpt-report-builder/builder.mjs
+++ b/tools/wpt-report-builder/builder.mjs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import fs from 'fs';
 
 import {generateReport} from './formatter.mjs';

--- a/tools/wpt-report-builder/formatter.spec.mjs
+++ b/tools/wpt-report-builder/formatter.spec.mjs
@@ -28,6 +28,7 @@ describe('HTML WPT reporter', () => {
   it('should escapeHtml', () => {
     expect(escapeHtml('&<>\'"/')).to.equal('&amp;&lt;&gt;&#39;&quot;&#47;');
   });
+
   describe('flattenSingleTest', () => {
     it('should flatten half passed test', () => {
       expect(
@@ -61,6 +62,7 @@ describe('HTML WPT reporter', () => {
         },
       ]);
     });
+
     it('should flatten test without subtests', () => {
       expect(
         flattenSingleTest({
@@ -79,6 +81,7 @@ describe('HTML WPT reporter', () => {
       ]);
     });
   });
+
   describe('flattenTests', () => {
     it('should flatten tests', () => {
       expect(
@@ -138,7 +141,40 @@ describe('HTML WPT reporter', () => {
         },
       ]);
     });
+
+    it('should exclude tentative tests', () => {
+      expect(
+        flattenTests({
+          results: [
+            {
+              test: '/a/b/c_tentative.py',
+              subtests: [
+                {
+                  name: 'sub_1',
+                  status: 'PASS',
+                },
+              ],
+              status: 'OK',
+            },
+            {
+              test: '/d/e/f.py',
+              subtests: [],
+              status: 'TIMEOUT',
+              message: null,
+            },
+          ],
+        })
+      ).to.deep.equal([
+        {
+          message: null,
+          name: null,
+          path: '/d/e/f.py',
+          status: 'TIMEOUT',
+        },
+      ]);
+    });
   });
+
   describe('groupTests', () => {
     it('should group tests', () => {
       let tests = groupTests([
@@ -173,6 +209,7 @@ describe('HTML WPT reporter', () => {
           status: 'TIMEOUT',
         },
       ]);
+
       expect(tests).to.deep.equal({
         message: null,
         path: '/a',


### PR DESCRIPTION
"Tentative" means a WPT test was written even though consensus was never
reached in the spec whether it will actually take place.

Tentative tests will usually never pass and they are not final.
Since these are not spec finalized, they only add noise to the report.

Once (if ever) consensus is reached upon upstream, the tentative suffix
is removed from the WPT test file, then the tests appear in the report
as usual.

chore: misc changes
test: add unit test
docs: add jsdoc