### PR TITLE
ci: move eslint to become the last step of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,6 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.44.0
-    hooks:
-      - id: eslint
-        files: \.[jt]s$
-        types: [file]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0
     hooks:
@@ -121,3 +115,11 @@ repos:
     rev: v0.1.1
     hooks:
       - id: keep-sorted
+
+  # ESLint is the slowest hook, so put it last.
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.44.0
+    hooks:
+      - id: eslint
+        files: \.[jt]s$
+        types: [file]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
     hooks:
       - id: keep-sorted
 
-  # ESLint is the slowest hook, so put it last.
+  # ESLint is the slowest hook, so keep it last.
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.44.0
     hooks:


### PR DESCRIPTION
Rationale: It is the slowest hook.