### PR TITLE
chore: remove IEventManager as it provides no value

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -33,7 +33,7 @@ import {BrowserProcessor} from './domains/browser/BrowserProcessor.js';
 import {CdpProcessor} from './domains/cdp/CdpProcessor.js';
 import {BrowsingContextProcessor} from './domains/context/browsingContextProcessor.js';
 import type {BrowsingContextStorage} from './domains/context/browsingContextStorage.js';
-import type {IEventManager} from './domains/events/EventManager.js';
+import type {EventManager} from './domains/events/EventManager.js';
 import {InputProcessor} from './domains/input/InputProcessor.js';
 import {PreloadScriptStorage} from './domains/script/PreloadScriptStorage.js';
 import {ScriptProcessor} from './domains/script/ScriptProcessor.js';
@@ -57,7 +57,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEvents> {
 
   constructor(
     cdpConnection: ICdpConnection,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     selfTargetId: string,
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,

--- a/src/bidiMapper/domains/context/browsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/browsingContextImpl.ts
@@ -28,7 +28,7 @@ import {
 import {Deferred} from '../../../utils/deferred.js';
 import {LogType, type LoggerFn} from '../../../utils/log.js';
 import {inchesFromCm} from '../../../utils/unitConversions.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import {Realm} from '../script/realm.js';
 import type {RealmStorage} from '../script/realmStorage.js';
 import type {Result} from '../../../utils/result.js';
@@ -63,7 +63,7 @@ export class BrowsingContextImpl {
   };
 
   #url = 'about:blank';
-  readonly #eventManager: IEventManager;
+  readonly #eventManager: EventManager;
   readonly #realmStorage: RealmStorage;
   #loaderId?: Protocol.Network.LoaderId;
   #cdpTarget: CdpTarget;
@@ -75,7 +75,7 @@ export class BrowsingContextImpl {
     realmStorage: RealmStorage,
     id: BrowsingContext.BrowsingContext,
     parentId: BrowsingContext.BrowsingContext | null,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
     logger?: LoggerFn
   ) {
@@ -93,7 +93,7 @@ export class BrowsingContextImpl {
     realmStorage: RealmStorage,
     id: BrowsingContext.BrowsingContext,
     parentId: BrowsingContext.BrowsingContext | null,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
     logger?: LoggerFn
   ): BrowsingContextImpl {

--- a/src/bidiMapper/domains/context/browsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/browsingContextProcessor.ts
@@ -24,7 +24,7 @@ import {
   type EmptyResult,
 } from '../../../protocol/protocol.js';
 import {LogType, type LoggerFn} from '../../../utils/log.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import type {RealmStorage} from '../script/realmStorage.js';
 import type {PreloadScriptStorage} from '../script/PreloadScriptStorage.js';
 
@@ -35,7 +35,7 @@ import {CdpTarget} from './cdpTarget.js';
 export class BrowsingContextProcessor {
   readonly #cdpConnection: ICdpConnection;
   readonly #selfTargetId: string;
-  readonly #eventManager: IEventManager;
+  readonly #eventManager: EventManager;
 
   readonly #browsingContextStorage: BrowsingContextStorage;
   readonly #preloadScriptStorage: PreloadScriptStorage;
@@ -46,7 +46,7 @@ export class BrowsingContextProcessor {
   constructor(
     cdpConnection: ICdpConnection,
     selfTargetId: string,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,
     preloadScriptStorage: PreloadScriptStorage,

--- a/src/bidiMapper/domains/context/cdpTarget.ts
+++ b/src/bidiMapper/domains/context/cdpTarget.ts
@@ -20,7 +20,7 @@ import type Protocol from 'devtools-protocol';
 
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import {Deferred} from '../../../utils/deferred.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import {LogManager} from '../log/logManager.js';
 import {NetworkManager} from '../network/NetworkManager.js';
 import type {ChannelProxy} from '../script/channelProxy.js';
@@ -32,7 +32,7 @@ export class CdpTarget {
   readonly #targetId: Protocol.Target.TargetID;
   readonly #cdpClient: ICdpClient;
   readonly #cdpSessionId: Protocol.Target.SessionID;
-  readonly #eventManager: IEventManager;
+  readonly #eventManager: EventManager;
   readonly #preloadScriptStorage: PreloadScriptStorage;
 
   readonly #targetUnblocked = new Deferred<Result<void>>();
@@ -42,7 +42,7 @@ export class CdpTarget {
     cdpClient: ICdpClient,
     cdpSessionId: Protocol.Target.SessionID,
     realmStorage: RealmStorage,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     preloadScriptStorage: PreloadScriptStorage
   ): CdpTarget {
     const cdpTarget = new CdpTarget(
@@ -69,7 +69,7 @@ export class CdpTarget {
     targetId: Protocol.Target.TargetID,
     cdpClient: ICdpClient,
     cdpSessionId: Protocol.Target.SessionID,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     preloadScriptStorage: PreloadScriptStorage
   ) {
     this.#targetId = targetId;

--- a/src/bidiMapper/domains/events/EventManager.ts
+++ b/src/bidiMapper/domains/events/EventManager.ts
@@ -55,31 +55,6 @@ class EventWrapper {
   }
 }
 
-export interface IEventManager {
-  registerEvent(
-    event: ChromiumBidi.Event,
-    contextId: BrowsingContext.BrowsingContext | null
-  ): void;
-
-  registerPromiseEvent(
-    event: Promise<Result<ChromiumBidi.Event>>,
-    contextId: BrowsingContext.BrowsingContext | null,
-    eventName: ChromiumBidi.EventNames
-  ): void;
-
-  subscribe(
-    events: ChromiumBidi.EventNames[],
-    contextIds: (BrowsingContext.BrowsingContext | null)[],
-    channel: string | null
-  ): Promise<void> | void;
-
-  unsubscribe(
-    events: ChromiumBidi.EventNames[],
-    contextIds: (BrowsingContext.BrowsingContext | null)[],
-    channel: string | null
-  ): Promise<void> | void;
-}
-
 /**
  * Maps event name to a desired buffer length.
  */
@@ -87,7 +62,7 @@ const eventBufferLength: ReadonlyMap<ChromiumBidi.EventNames, number> = new Map(
   [[ChromiumBidi.Log.EventNames.LogEntryAddedEvent, 100]]
 );
 
-export class EventManager implements IEventManager {
+export class EventManager {
   /**
    * Maps event name to a set of contexts where this event already happened.
    * Needed for getting buffered events from all the contexts in case of

--- a/src/bidiMapper/domains/log/logManager.ts
+++ b/src/bidiMapper/domains/log/logManager.ts
@@ -17,7 +17,7 @@
 import type {Protocol} from 'devtools-protocol';
 
 import {ChromiumBidi, Log, Script} from '../../../protocol/protocol.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import type {Realm} from '../script/realm.js';
 import type {RealmStorage} from '../script/realmStorage.js';
 import type {CdpTarget} from '../context/cdpTarget.js';
@@ -54,14 +54,14 @@ function getLogLevel(consoleApiType: string): Log.Level {
 }
 
 export class LogManager {
-  readonly #eventManager: IEventManager;
+  readonly #eventManager: EventManager;
   readonly #realmStorage: RealmStorage;
   readonly #cdpTarget: CdpTarget;
 
   private constructor(
     cdpTarget: CdpTarget,
     realmStorage: RealmStorage,
-    eventManager: IEventManager
+    eventManager: EventManager
   ) {
     this.#cdpTarget = cdpTarget;
     this.#realmStorage = realmStorage;
@@ -71,7 +71,7 @@ export class LogManager {
   static create(
     cdpTarget: CdpTarget,
     realmStorage: RealmStorage,
-    eventManager: IEventManager
+    eventManager: EventManager
   ) {
     const logManager = new LogManager(cdpTarget, realmStorage, eventManager);
 

--- a/src/bidiMapper/domains/network/NetworkManager.ts
+++ b/src/bidiMapper/domains/network/NetworkManager.ts
@@ -23,14 +23,14 @@
 import type Protocol from 'devtools-protocol';
 
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import {DefaultMap} from '../../../utils/DefaultMap.js';
 import type {Network} from '../../../protocol/protocol.js';
 
 import {NetworkRequest} from './networkRequest.js';
 
 export class NetworkManager {
-  readonly #eventManager: IEventManager;
+  readonly #eventManager: EventManager;
 
   /**
    * Map of request ID to NetworkRequest objects. Needed as long as information
@@ -38,7 +38,7 @@ export class NetworkManager {
    */
   readonly #requestMap: DefaultMap<Network.Request, NetworkRequest>;
 
-  private constructor(eventManager: IEventManager) {
+  private constructor(eventManager: EventManager) {
     this.#eventManager = eventManager;
 
     this.#requestMap = new DefaultMap(
@@ -48,7 +48,7 @@ export class NetworkManager {
 
   static create(
     cdpClient: ICdpClient,
-    eventManager: IEventManager
+    eventManager: EventManager
   ): NetworkManager {
     const networkProcessor = new NetworkManager(eventManager);
 

--- a/src/bidiMapper/domains/network/networkRequest.ts
+++ b/src/bidiMapper/domains/network/networkRequest.ts
@@ -23,7 +23,7 @@
 import type Protocol from 'devtools-protocol';
 
 import {Deferred} from '../../../utils/deferred.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import {
   type Network,
   type BrowsingContext,
@@ -46,7 +46,7 @@ export class NetworkRequest {
   #servedFromCache = false;
   #redirectCount = 0;
 
-  #eventManager: IEventManager;
+  #eventManager: EventManager;
 
   #requestWillBeSentEvent?: Protocol.Network.RequestWillBeSentEvent;
   #requestWillBeSentExtraInfoEvent?: Protocol.Network.RequestWillBeSentExtraInfoEvent;
@@ -56,7 +56,7 @@ export class NetworkRequest {
   #beforeRequestSentDeferred = new Deferred<Result<void>>();
   #responseReceivedDeferred = new Deferred<Result<void>>();
 
-  constructor(requestId: Network.Request, eventManager: IEventManager) {
+  constructor(requestId: Network.Request, eventManager: EventManager) {
     this.requestId = requestId;
     this.#eventManager = eventManager;
   }

--- a/src/bidiMapper/domains/script/channelProxy.ts
+++ b/src/bidiMapper/domains/script/channelProxy.ts
@@ -19,7 +19,7 @@
 import {Protocol} from 'devtools-protocol';
 
 import {ChromiumBidi, Script} from '../../../protocol/protocol.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import {uuidv4} from '../../../utils/uuid';
 
 import type {Realm} from './realm.js';
@@ -58,10 +58,7 @@ export class ChannelProxy {
    * Creates a channel proxy in the given realm, initialises listener and
    * returns a handle to `sendMessage` delegate.
    */
-  async init(
-    realm: Realm,
-    eventManager: IEventManager
-  ): Promise<Script.Handle> {
+  async init(realm: Realm, eventManager: EventManager): Promise<Script.Handle> {
     const channelHandle = await ChannelProxy.#createAndGetHandleInRealm(realm);
     const sendMessageHandle = await ChannelProxy.#createSendMessageHandle(
       realm,
@@ -73,7 +70,7 @@ export class ChannelProxy {
   }
 
   /** Gets a ChannelProxy from window and returns its handle. */
-  async startListenerFromWindow(realm: Realm, eventManager: IEventManager) {
+  async startListenerFromWindow(realm: Realm, eventManager: EventManager) {
     const channelHandle = await this.#getHandleFromWindow(realm);
     void this.#startListener(realm, channelHandle, eventManager);
   }
@@ -172,7 +169,7 @@ export class ChannelProxy {
   async #startListener(
     realm: Realm,
     channelHandle: Script.Handle,
-    eventManager: IEventManager
+    eventManager: EventManager
   ) {
     // TODO(#294): Remove this loop after the realm is destroyed.
     // Rely on the CDP throwing exception in such a case.

--- a/src/bidiMapper/domains/script/realm.ts
+++ b/src/bidiMapper/domains/script/realm.ts
@@ -25,7 +25,7 @@ import {
   Script,
 } from '../../../protocol/protocol.js';
 import type {BrowsingContextStorage} from '../context/browsingContextStorage.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 import type {ICdpClient} from '../../../cdp/cdpClient.js';
 import {LogType, type LoggerFn} from '../../../utils/log.js';
 
@@ -43,7 +43,7 @@ export class Realm {
   readonly #origin: string;
   readonly #type: Script.RealmType;
   readonly #cdpClient: ICdpClient;
-  readonly #eventManager: IEventManager;
+  readonly #eventManager: EventManager;
   readonly sandbox?: string;
   readonly #logger?: LoggerFn;
 
@@ -57,7 +57,7 @@ export class Realm {
     type: Script.RealmType,
     sandbox: string | undefined,
     cdpClient: ICdpClient,
-    eventManager: IEventManager,
+    eventManager: EventManager,
     logger?: LoggerFn
   ) {
     this.#realmId = realmId;

--- a/src/bidiMapper/domains/session/SessionProcessor.ts
+++ b/src/bidiMapper/domains/session/SessionProcessor.ts
@@ -20,12 +20,12 @@ import type {
   EmptyResult,
   Session,
 } from '../../../protocol/protocol.js';
-import type {IEventManager} from '../events/EventManager.js';
+import type {EventManager} from '../events/EventManager.js';
 
 export class SessionProcessor {
-  #eventManager: IEventManager;
+  #eventManager: EventManager;
 
-  constructor(eventManager: IEventManager) {
+  constructor(eventManager: EventManager) {
     this.#eventManager = eventManager;
   }
 
@@ -33,11 +33,11 @@ export class SessionProcessor {
     return {ready: false, message: 'already connected'};
   }
 
-  async subscribe(
+  subscribe(
     params: Session.SubscriptionRequest,
     channel: string | null = null
-  ): Promise<EmptyResult> {
-    await this.#eventManager.subscribe(
+  ): EmptyResult {
+    this.#eventManager.subscribe(
       params.events as ChromiumBidi.EventNames[],
       params.contexts ?? [null],
       channel
@@ -45,11 +45,11 @@ export class SessionProcessor {
     return {};
   }
 
-  async unsubscribe(
+  unsubscribe(
     params: Session.SubscriptionRequest,
     channel: string | null = null
-  ): Promise<EmptyResult> {
-    await this.#eventManager.unsubscribe(
+  ): EmptyResult {
+    this.#eventManager.unsubscribe(
       params.events as ChromiumBidi.EventNames[],
       params.contexts ?? [null],
       channel


### PR DESCRIPTION
`EventManager` is internal class we should pass it instead of Interface as that way it improves the IDE, and remove an else unused interface