### PR TITLE
chore: implement injection framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1425,6 +1425,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.0.0.tgz",
@@ -1554,6 +1566,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.0.0.tgz",
@@ -1592,6 +1616,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1691,6 +1727,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -4276,6 +4324,21 @@
         }
       }
     },
+    "node_modules/gts/node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/gts/node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
@@ -4347,6 +4410,21 @@
         }
       }
     },
+    "node_modules/gts/node_modules/@typescript-eslint/type-utils/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/gts/node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
@@ -4385,6 +4463,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/gts/node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/gts/node_modules/@typescript-eslint/utils": {
@@ -4444,6 +4537,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/gts/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/gts/node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -7896,18 +7995,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-api-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.13.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7936,27 +8023,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "dev": true
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "node_modules/tunnel": {

--- a/src/utils/decorators.spec.ts
+++ b/src/utils/decorators.spec.ts
@@ -1,0 +1,544 @@
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as chai from 'chai';
+
+import {feed, eat, pantry} from './decorators.js';
+
+const expect = chai.expect;
+
+const SymbolSym = Symbol('symbol');
+const SymbolSym2 = Symbol('symbol2');
+
+declare module './decorators.js' {
+  interface InjectableRegistry {
+    [SymbolSym]: symbol;
+    [SymbolSym2]: symbol;
+  }
+}
+
+describe('Decorators', () => {
+  describe('inject: field, provides: field, consumes: field', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+
+        @feed
+        readonly b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should work out of order', () => {
+      class A {
+        @feed
+        readonly b = new B();
+
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should not work with constructors', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value: symbol;
+
+        @feed
+        readonly b: B;
+
+        constructor() {
+          this.value = Symbol();
+          this.b = new B();
+        }
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(undefined);
+    });
+
+    it('should not descend modifications', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+
+        @feed
+        readonly b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      // @ts-expect-error We are trying to do something bad here.
+      a.value = Symbol();
+      expect(a.b.value).not.equals(a.value);
+    });
+
+    it('should not reinject', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+
+        @feed
+        readonly b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      // @ts-expect-error We are trying to do something bad here.
+      a.b = new B();
+      expect(a.b.value).equals(undefined);
+    });
+  });
+
+  describe('inject: setter/getter, provides: getter, consumes: setter', () => {
+    it('should work with injected setters', () => {
+      class A {
+        @pantry(Number)
+        get value() {
+          return 5;
+        }
+
+        internalB?: B;
+        @feed
+        set b(value: B) {
+          this.internalB = value;
+        }
+      }
+
+      class B {
+        internalValue?: number;
+        @eat(Number)
+        set value(value: number) {
+          this.internalValue = value;
+        }
+      }
+
+      const a = new A();
+      expect(a.internalB).equals(undefined);
+
+      const b = new B();
+      expect(b.internalValue).equals(undefined);
+
+      a.b = b;
+      expect(a.internalB).equals(b);
+      expect(b.internalValue).equals(a.value);
+    });
+
+    it('should work with injected getters', () => {
+      class A {
+        @pantry(Number)
+        get value() {
+          return 5;
+        }
+
+        @feed
+        get b() {
+          return new B();
+        }
+      }
+
+      class B {
+        internalValue?: number;
+        @eat(Number)
+        set value(value: number) {
+          this.internalValue = value;
+        }
+      }
+
+      const a = new A();
+      expect(a.b.internalValue).equals(a.value);
+    });
+  });
+
+  describe('inject: accessor, provides: accessor, consumes: accessor', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should work out of order', () => {
+      class A {
+        @feed
+        accessor b = new B();
+
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should work with constructors', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value: symbol;
+
+        @feed
+        accessor b: B;
+
+        constructor() {
+          this.value = Symbol();
+          this.b = new B();
+        }
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should descend modifications', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      a.value = Symbol();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should reinject', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      a.b = new B();
+      expect(a.b.value).equals(a.value);
+    });
+  });
+
+  describe('inject: field, provides: accessor, consumes: accessor', () => {
+    it('should not work out of order in constructor', () => {
+      class A {
+        @feed
+        accessor b: B;
+
+        @pantry(SymbolSym)
+        readonly value: symbol;
+
+        constructor() {
+          this.b = new B();
+          this.value = Symbol();
+        }
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(undefined);
+    });
+  });
+
+  it('should work with multiple', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+      @pantry(SymbolSym2)
+      accessor value2 = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor value!: symbol;
+      @eat(SymbolSym2)
+      accessor value2!: symbol;
+    }
+
+    const a = new A();
+    expect(a.b.value).equals(a.value);
+    expect(a.b.value2).equals(a.value2);
+  });
+
+  it('should work with private properties', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor #value = Symbol();
+
+      get value(): symbol {
+        return this.#value;
+      }
+
+      @feed
+      accessor #b = new B();
+
+      get b(): B {
+        return this.#b;
+      }
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor #value!: symbol;
+
+      get value(): symbol {
+        return this.#value;
+      }
+    }
+
+    const a = new A();
+    expect(a.b.value).equals(a.value);
+  });
+
+  it('should work with consumer setter', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      set value(value: symbol) {
+        this.value2 = value;
+      }
+
+      value2!: symbol;
+    }
+
+    const a = new A();
+    expect(a.b.value2).equals(a.value);
+  });
+
+  it('should work not have properties before constructor is used', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor value!: symbol;
+
+      accessor value2: symbol;
+
+      constructor() {
+        this.value2 = this.value;
+      }
+    }
+
+    const a = new A();
+    expect(a.b.value2).equals(undefined);
+  });
+
+  describe('nesting', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        @pantry(SymbolSym)
+        accessor bValue!: symbol;
+
+        @feed
+        accessor c = new C();
+      }
+
+      class C {
+        @eat(SymbolSym)
+        accessor cValue!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.bValue).equals(a.value);
+      expect(a.b.c.cValue).equals(a.value);
+
+      a.value = Symbol();
+      expect(a.b.bValue).equals(a.value);
+      expect(a.b.c.cValue).equals(a.value);
+    });
+
+    it('should work deeply', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @feed
+        accessor c = new C();
+      }
+
+      class C {
+        @feed
+        accessor d = new D();
+      }
+
+      class D {
+        @eat(SymbolSym)
+        accessor dValue!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.c.d.dValue).equals(a.value);
+
+      a.value = Symbol();
+      expect(a.b.c.d.dValue).equals(a.value);
+    });
+  });
+
+  it('should work with multiple consumers', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor bValue!: symbol;
+
+      @eat(SymbolSym)
+      accessor bValue2!: symbol;
+    }
+
+    const a = new A();
+    expect(a.b.bValue).equals(a.value);
+    expect(a.b.bValue2).equals(a.value);
+
+    a.value = Symbol();
+    expect(a.b.bValue).equals(a.value);
+    expect(a.b.bValue2).equals(a.value);
+  });
+
+  describe('Required', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+        @pantry(SymbolSym2)
+        accessor value2 = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor bValue!: symbol;
+
+        @feed
+        accessor c = new C();
+      }
+
+      class C {
+        @eat(SymbolSym)
+        accessor cValue!: symbol;
+
+        @eat(SymbolSym2)
+        accessor cValue2!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.bValue).equals(a.value);
+      expect(a.b.c.cValue).equals(a.value);
+      expect(a.b.c.cValue2).equals(a.value2);
+    });
+  });
+});

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,0 +1,395 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ClassMemberDecoratorContext<This, Value> =
+  | ClassGetterDecoratorContext<This, Value>
+  | ClassSetterDecoratorContext<This, Value>
+  | ClassFieldDecoratorContext<This, Value>
+  | ClassAccessorDecoratorContext<This, Value>;
+
+type InjectableKey =
+  | (abstract new (...args: any[]) => any)
+  | keyof InjectableRegistry;
+
+type ValueOf<Marker extends InjectableKey> =
+  Marker extends keyof InjectableRegistry
+    ? InjectableRegistry[Marker]
+    : Marker extends abstract new (...args: any[]) => any
+    ? InstanceType<Marker>
+    : never;
+
+/**
+ * Augment this to register your injectables.
+ *
+ * For example,
+ *
+ * ```ts
+ * const LoggerSym = Symbol('symbol');
+ *
+ * declare module './path/to/decorators.js' {
+ *  interface InjectableRegistry {
+ *    [LoggerSym]: Logger;
+ *   }
+ * }
+ * ```
+ */
+export interface InjectableRegistry {}
+
+type Consumer = {
+  getters: Map<InjectableKey, () => any>;
+  fields: Map<string | symbol, object>;
+};
+
+type Provider = Map<
+  InjectableKey,
+  [(value: any) => void, ...((value: any) => void)[]]
+>;
+
+const STATES = new WeakMap<
+  abstract new (...args: unknown[]) => unknown,
+  {
+    consumers?: WeakMap<object, Consumer>;
+    providers?: WeakMap<object, Provider>;
+  }
+>();
+
+function getInjectorState(object: object) {
+  const Class = object.constructor as abstract new (
+    ...args: unknown[]
+  ) => unknown;
+  let state = STATES.get(Class);
+  if (!state) {
+    state = {};
+    STATES.set(Class, state);
+  }
+  return state;
+}
+
+function getOrCreateProvider(object: object) {
+  const state = getInjectorState(object);
+  state.providers ??= new WeakMap();
+
+  const providers = state.providers;
+  let provider = providers.get(object);
+  if (!provider) {
+    provider = new Map();
+    providers.set(object, provider);
+  }
+  return provider;
+}
+
+function getProvider(object: object) {
+  const state = getInjectorState(object);
+  state.providers ??= new WeakMap();
+
+  const providers = state.providers;
+  return providers.get(object);
+}
+
+function getOrCreateConsumers(object: object) {
+  const state = getInjectorState(object);
+  state.consumers ??= new WeakMap();
+
+  const consumers = state.consumers;
+  let consumer = consumers.get(object);
+  if (!consumer) {
+    consumer = {getters: new Map(), fields: new Map()};
+    consumers.set(object, consumer);
+  }
+  return consumer;
+}
+
+function getConsumers(object: object) {
+  const state = getInjectorState(object);
+  state.consumers ??= new WeakMap();
+
+  const consumers = state.consumers;
+  return consumers.get(object);
+}
+
+/**
+ * Injects the decorated member with objects associated with the given symbols.
+ *
+ * Before injecting a given symbol, make sure it's registered with
+ * {@link InjectableRegistry}.
+ */
+export function feed(
+  target: any,
+  context: ClassMemberDecoratorContext<object, object>
+): any {
+  let consumers: Consumer;
+  context.addInitializer(function initializer() {
+    consumers = getOrCreateConsumers(this);
+  });
+
+  const getCachedKeys = memoize(getInjectableKeys);
+
+  switch (context.kind) {
+    case 'accessor':
+      return {
+        set(this: object, value?: object) {
+          return target.set.call(this, inject(value));
+        },
+        init: inject,
+      };
+    case 'field':
+      return inject;
+    case 'setter':
+      return function set(this: object, value?: object) {
+        return target.call(this, inject(value));
+      };
+    case 'getter':
+      return function get(this: object) {
+        return inject(target.call(this));
+      };
+  }
+
+  function inject(object?: object) {
+    if (object !== undefined) {
+      consumers.fields.set(context.name, object);
+      const keys = getCachedKeys(object);
+      const provider = getProvider(object);
+      if (provider !== undefined) {
+        for (const key of provider.keys()) {
+          keys.add(key);
+        }
+        for (const mark of keys) {
+          const get = consumers.getters.get(mark);
+          if (get !== undefined) {
+            const setters = provider.get(mark)!;
+            if (setters !== undefined) {
+              for (const set of setters) {
+                set(get());
+              }
+            }
+          }
+        }
+      }
+    }
+    return object;
+  }
+}
+
+/**
+ * Declares a member as an object provider for the given symbol.
+ *
+ * Before injecting a given symbol, make sure it's registered with
+ * {@link InjectableRegistry}.
+ */
+export function pantry<Marker extends InjectableKey>(mark: Marker) {
+  return <
+    Interface,
+    Value = ValueOf<Marker> extends Interface ? Interface : ValueOf<Marker>,
+  >(
+    target: any,
+    context: ClassMemberDecoratorContext<object, Value>
+  ): any => {
+    let consumers: Consumer;
+    context.addInitializer(function initializer() {
+      consumers = getOrCreateConsumers(this);
+      switch (context.kind) {
+        case 'getter':
+          consumers.getters.set(mark, context.access.get.bind(undefined, this));
+          break;
+        default:
+      }
+    });
+
+    switch (context.kind) {
+      case 'accessor':
+        return {
+          set(this: object, value: Value) {
+            return target.set.call(this, reinject(consumers, mark, value));
+          },
+          init(this: object, initialValue: Value) {
+            consumers.getters.set(
+              mark,
+              context.access.get.bind(undefined, this)
+            );
+            return reinject(consumers, mark, initialValue);
+          },
+        };
+      case 'field':
+        return function init(this: object, initialValue: Value) {
+          consumers.getters.set(mark, context.access.get.bind(undefined, this));
+          return reinject(consumers, mark, initialValue);
+        };
+      case 'getter':
+        break;
+      default:
+        throw new Error(`Cannot decorate ${context.kind}`);
+    }
+  };
+}
+
+/**
+ * Declares a member as an object consumer for the given symbol.
+ *
+ * Before injecting a given symbol, make sure it's registered with
+ * {@link InjectableRegistry}.
+ */
+export function eat<Marker extends InjectableKey>(mark: Marker) {
+  return <
+    Interface,
+    Value = ValueOf<Marker> extends Interface ? Interface : ValueOf<Marker>,
+  >(
+    _: unknown,
+    context: ClassMemberDecoratorContext<object, Value>
+  ): any => {
+    context.addInitializer(function initializer() {
+      const provider = getOrCreateProvider(this);
+      switch (context.kind) {
+        case 'field':
+        case 'setter':
+        case 'accessor': {
+          const setters = provider.get(mark) ?? [() => {}];
+          setters.push(memoize(context.access.set.bind(undefined, this)));
+          provider.set(mark, setters);
+          break;
+        }
+        default:
+          throw new Error(`Cannot decorate ${context.kind}`);
+      }
+    });
+  };
+}
+
+/**
+ * For testing only! Injects a given object with a provided set of injectables.
+ *
+ * This must not be used to "skip" constructor arguments in favor of injection.
+ *
+ * For example, if you need to inject a `Logger` module into some class, do
+ *
+ * ```ts
+ * class A {
+ *  @pantry(LoggerSym)
+ *  #logger: Logger
+ *
+ *  constructor(logger: Logger) {
+ *    this.#logger = logger;
+ *  }
+ * }
+ *
+ * const a = new A(new Logger());
+ * ```
+ *
+ * Do not do
+ *
+ * ```ts
+ * class A {
+ *  @eat(LoggerSym)
+ *  #logger: Logger
+ *
+ *  constructor(logger: Logger) {
+ *    this.#logger = logger;
+ *  }
+ * }
+ *
+ * const a = inject(new A());
+ * ```
+ *
+ * If you need to pass some object to some descendent, you should declare
+ * the object on the root class, even if it's not used by the root class.
+ *
+ */
+export function inject<
+  T extends object,
+  Injectables extends Partial<InjectableRegistry> | Set<object>,
+>(object: T, injectables: Injectables): T {
+  const provider = getProvider(object);
+  if (provider !== undefined) {
+    if (injectables instanceof Set) {
+      for (const object of injectables) {
+        const setters = provider.get(object.constructor);
+        if (setters !== undefined) {
+          for (const set of setters) {
+            set(object);
+          }
+        }
+      }
+    } else {
+      for (const mark of Object.getOwnPropertySymbols(
+        injectables
+      ) as (keyof InjectableRegistry)[]) {
+        const setters = provider.get(mark);
+        if (setters !== undefined) {
+          for (const set of setters) {
+            set(injectables[mark]);
+          }
+        }
+      }
+    }
+  }
+  return object;
+}
+
+function reinject<
+  Marker extends InjectableKey,
+  Interface,
+  Value = ValueOf<Marker> extends Interface ? Interface : ValueOf<Marker>,
+>(consumer: Consumer, mark: Marker, value: Value) {
+  for (const object of consumer.fields.values()) {
+    // SAFETY: Being in consumer.field implies this object has a provider.
+    const provider = getProvider(object)!;
+    const setters = provider.get(mark);
+    if (setters !== undefined) {
+      for (const set of setters) {
+        set(value);
+      }
+    }
+  }
+  return value;
+}
+
+function getInjectableKeys(source: object) {
+  const keys = new Set<InjectableKey>();
+  const consumer = getConsumers(source);
+  if (consumer !== undefined) {
+    for (const child of consumer.fields.values()) {
+      for (const key of getInjectableKeys(child)) {
+        keys.add(key);
+      }
+      const provider = getProvider(child);
+      if (provider !== undefined) {
+        for (const mark of provider.keys()) {
+          keys.add(mark);
+        }
+      }
+    }
+    const provider = getOrCreateProvider(source);
+    for (const mark of keys) {
+      const setters = provider.get(mark) ?? [() => {}];
+      setters[0] = memoize(reinject.bind(undefined, consumer, mark));
+      provider.set(mark, setters);
+    }
+  }
+  return keys;
+}
+
+function memoize<T, U>(fn: (value: T) => U) {
+  let lastValue: {value: T} | undefined = undefined;
+  let lastResult: U | undefined = undefined;
+  return (value: T) => {
+    if (lastValue === undefined || value !== lastValue.value) {
+      lastResult = fn(value);
+      lastValue = {value};
+    }
+    return lastResult as U;
+  };
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "ESNext",
+    "target": "ES2022",
     "useUnknownInCatchVariables": true
   }
 }


### PR DESCRIPTION
This PR implements a decorator-based injection framework for use in Chromium-BiDi. It's expected to replace the parameter hell we've been facing inside the repo.

## Usage

The framework uses three decorators: `@pantry`, `@feed`, and `@eat`.

### Storing

`You` can store things in the `@pantry`:

```ts
class You {
  @pantry(Number)
  #value: number
}
```

`@pantry` takes either a class constructor or a symbol (more on this later).

### Injecting

`You` can `@feed` `Child`.

```ts
class You {
  @pantry(Number)
  #value: number

  @feed([Number])
  #child: Child = new Child()
}

class Child {}
```

### Consuming

`You` can `@eat` from `Parent` anything that `Parent` `@feed`s `You`.

```ts
class Parent {
  @pantry(Number)
  #value: number

  @feed([Number])
  #you: You = new You()
}

class You {
  @eat(Number)
  #value!: number;
}
```

### Deep injection

`You` can `@feed` `Child` anything that `Parent` `@feed`s `You`.

```ts
class Parent {
  @pantry(Number)
  #value: number

  @feed([Number])
  #you: You = new You()
}

class You {
  @feed([Number])
  #child: Child = new Child()
}

class Child {
  @eat(Number)
  #value!: number;
}
```

## Linting

Linting is implemented here: https://github.com/GoogleChromeLabs/chromium-bidi/pull/1150. It's quite comprehensive and any potential "bugs" you may face will be prevented by listening to the lint.

## Symbols

Sometimes it's not possible to use a class name, perhaps because you want an interface rather than a concrete class. For this, we allow symbols. Since the framework is strongly-typed, each symbol needs to be registered with `decorators.js` with its associated type:

```
export interface SomeAbstractInterface {
  // ...
}

export const SomeAbstractInterfaceSym = Symbol('SomeAbstractInterface');

declare module 'path/to/decorators.js' {
  interface InjectableRegistry {
    [SomeAbstractInterfaceSym]: SomeAbstractInterface
  }
}
```


