### PR TITLE
chore: implement ESLint rules for injection framework

### DIFF
--- a/.eslintplugin.js
+++ b/.eslintplugin.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @type import("eslint").Rule.RuleModule
+ */
+const noUninitFieldsRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce initialized Pantry fields.',
+      recommended: true,
+    },
+    fixable: 'code',
+  },
+
+  create(context) {
+    const fields = new Map();
+    return {
+      ClassBody(node) {
+        for (const definition of node.body) {
+          if (definition.type === 'PropertyDefinition') {
+            for (const decorator of definition.decorators) {
+              switch (decorator.expression.type) {
+                case 'CallExpression':
+                  if (decorator.expression.callee.name === 'pantry') {
+                    fields.set(definition.key.name, ['pantry', definition]);
+                  }
+                  break;
+                case 'Identifier':
+                  if (decorator.expression.name === 'feed') {
+                    fields.set(definition.key.name, ['feed', definition]);
+                  }
+                  break;
+              }
+            }
+          }
+        }
+      },
+      PropertyDefinition(node) {
+        if (node.value) {
+          return;
+        }
+        for (const decorator of node.decorators) {
+          switch (decorator.expression.type) {
+            case 'CallExpression':
+              if (decorator.expression.callee.name === 'pantry') {
+                context.report({
+                  node: decorator,
+                  message: `Cannot decorate uninitialized field with 'pantry'. Either initialize the field or use 'accessor'.`,
+                });
+              }
+              break;
+            case 'Identifier':
+              if (decorator.expression.name === 'feed') {
+                context.report({
+                  node: decorator,
+                  message: `Cannot decorate uninitialized field with 'feed'. Either initialize the field or use 'accessor'.`,
+                });
+              }
+              break;
+          }
+        }
+      },
+      AssignmentExpression(node) {
+        for (const [field, [decorator, definition]] of fields) {
+          if (
+            node.left.object.type === 'ThisExpression' &&
+            node.left.property.name === field
+          ) {
+            context.report({
+              node,
+              message: `Cannot assign to field '${field}' which was decorated with '${decorator}'. Either initialize the field or use 'accessor'.`,
+              fix(fixer) {
+                return fixer.insertTextBefore(definition.key, 'accessor ');
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+/**
+ * @type import("eslint").Rule.RuleModule
+ */
+const readonlyFieldsRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: "Enforce 'readonly' for 'pantry'/'feed'-decorated fields",
+      recommended: true,
+    },
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      PropertyDefinition(node) {
+        if (node.readonly) {
+          return;
+        }
+        for (const decorator of node.decorators) {
+          for (const name of ['pantry', 'feed', 'eat']) {
+            if (decorator.expression.callee.name === name) {
+              context.report({
+                node: node.key,
+                message: `'${name}'-decorated fields should be marked 'readonly'.`,
+                fix(fixer) {
+                  return fixer.insertTextBefore(node.key, 'readonly ');
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};
+
+/**
+ * @type import("eslint").Rule.RuleModule
+ */
+const definiteFieldsRule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: "Enforce definite fields for 'eat'-decorated fields",
+      recommended: true,
+    },
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      PropertyDefinition(node) {
+        if (node.definite) {
+          return;
+        }
+        for (const decorator of node.decorators) {
+          if (decorator.expression.callee.name === 'eat') {
+            context.report({
+              node: node.key,
+              message: `'eat'-decorated fields should be marked as definite with '!'.`,
+              fix(fixer) {
+                return fixer.insertTextAfter(node.key, '!');
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+module.exports = {
+  rules: {
+    // keep-sorted start
+    'pantry/definite-fields': definiteFieldsRule,
+    'pantry/no-uninit-fields': noUninitFieldsRule,
+    'pantry/readonly-fields': readonlyFieldsRule,
+    // keep-sorted end
+  },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,12 +42,7 @@ module.exports = {
       // keep-sorted end
     ],
   },
-  plugins: [
-    '@typescript-eslint',
-    'import',
-    'mocha',
-    "promise",
-  ],
+  plugins: ['@typescript-eslint', 'import', 'mocha', 'promise', 'local'],
   extends: [
     // keep-sorted start
     'eslint:recommended',
@@ -63,15 +58,20 @@ module.exports = {
   rules: {
     // https://denar90.github.io/eslint.github.io/docs/rules/
     // Some rules use 'warn' in order to ease local development iteration.
-    // keep-sorted start
     '@typescript-eslint/array-type': 'warn',
     '@typescript-eslint/consistent-generic-constructors': 'warn',
-    '@typescript-eslint/consistent-type-imports': ['warn', {fixStyle: 'inline-type-imports'}],
-    '@typescript-eslint/explicit-member-accessibility': ['warn', {accessibility: 'no-public'}],
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      {fixStyle: 'inline-type-imports'},
+    ],
+    '@typescript-eslint/explicit-member-accessibility': [
+      'warn',
+      {accessibility: 'no-public'},
+    ],
     '@typescript-eslint/no-empty-function': 'warn',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-extraneous-class': 'warn',
-    '@typescript-eslint/no-import-type-side-effects': "error",
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
@@ -86,12 +86,16 @@ module.exports = {
     '@typescript-eslint/require-await': 'warn',
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    eqeqeq: 'error',
     'func-names': 'error',
     'import/first': 'error',
     'import/newline-after-import': 'warn',
     'import/no-duplicates': 'error',
     'import/no-unresolved': 'off',
     'import/order': ['warn', {'newlines-between': 'always'}],
+    'local/pantry/definite-fields': 'error',
+    'local/pantry/no-uninit-fields': 'error',
+    'local/pantry/readonly-fields': 'error',
     'mocha/no-mocha-arrows': 'off',
     'mocha/no-setup-in-describe': 'off',
     'no-console': 'warn',
@@ -105,7 +109,5 @@ module.exports = {
     'object-shorthand': 'error',
     'prefer-promise-reject-errors': 'error',
     'prefer-template': 'error',
-    eqeqeq: 'error',
-    // keep-sorted end
   },
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-.eslintrc.js
 .mypy_cache/
 examples/*.html
 lib/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1425,6 +1425,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.0.0.tgz",
@@ -1554,6 +1566,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.0.0.tgz",
@@ -1592,6 +1616,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1691,6 +1727,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -4276,6 +4324,21 @@
         }
       }
     },
+    "node_modules/gts/node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/gts/node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
@@ -4347,6 +4410,21 @@
         }
       }
     },
+    "node_modules/gts/node_modules/@typescript-eslint/type-utils/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/gts/node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
@@ -4385,6 +4463,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/gts/node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/gts/node_modules/@typescript-eslint/utils": {
@@ -4444,6 +4537,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/gts/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/gts/node_modules/write-file-atomic": {
       "version": "4.0.2",
@@ -7896,18 +7995,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-api-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.13.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -7936,27 +8023,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "dev": true
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "node_modules/tunnel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint": "8.46.0",
         "eslint-config-prettier": "8.10.0",
         "eslint-plugin-import": "2.28.0",
+        "eslint-plugin-local": "1.0.0",
         "eslint-plugin-mocha": "10.1.0",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-plugin-promise": "6.1.1",
@@ -3326,6 +3327,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/eslint-plugin-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-local/-/eslint-plugin-local-1.0.0.tgz",
+      "integrity": "sha512-bcwcQnKL/Iw5Vi/F2lG1he5oKD2OGjhsLmrcctkWrWq5TujgiaYb0cj3pZgr3XI54inNVnneOFdAx1daLoYLJQ==",
+      "dev": true
     },
     "node_modules/eslint-plugin-mocha": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "eslint": "8.46.0",
     "eslint-config-prettier": "8.10.0",
     "eslint-plugin-import": "2.28.0",
+    "eslint-plugin-local": "1.0.0",
     "eslint-plugin-mocha": "10.1.0",
     "eslint-plugin-prettier": "5.0.0",
     "eslint-plugin-promise": "6.1.1",

--- a/src/utils/decorators.spec.ts
+++ b/src/utils/decorators.spec.ts
@@ -71,6 +71,7 @@ describe('Decorators', () => {
 
     it('should not work with constructors', () => {
       class A {
+        // eslint-disable-next-line local/pantry/no-uninit-fields
         @pantry(SymbolSym)
         readonly value: symbol;
 
@@ -78,7 +79,9 @@ describe('Decorators', () => {
         readonly b: B;
 
         constructor() {
+          // eslint-disable-next-line local/pantry/no-uninit-fields
           this.value = Symbol();
+          // eslint-disable-next-line local/pantry/no-uninit-fields
           this.b = new B();
         }
       }
@@ -239,7 +242,9 @@ describe('Decorators', () => {
         accessor b: B;
 
         constructor() {
+          // eslint-disable-next-line local/pantry/no-uninit-fields
           this.value = Symbol();
+          // eslint-disable-next-line local/pantry/no-uninit-fields
           this.b = new B();
         }
       }
@@ -298,11 +303,14 @@ describe('Decorators', () => {
         @feed
         accessor b: B;
 
+        // eslint-disable-next-line local/pantry/no-uninit-fields
         @pantry(SymbolSym)
         readonly value: symbol;
 
         constructor() {
+          // eslint-disable-next-line local/pantry/no-uninit-fields
           this.b = new B();
+          // eslint-disable-next-line local/pantry/no-uninit-fields
           this.value = Symbol();
         }
       }

--- a/src/utils/decorators.spec.ts
+++ b/src/utils/decorators.spec.ts
@@ -1,0 +1,544 @@
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as chai from 'chai';
+
+import {feed, eat, pantry} from './decorators.js';
+
+const expect = chai.expect;
+
+const SymbolSym = Symbol('symbol');
+const SymbolSym2 = Symbol('symbol2');
+
+declare module './decorators.js' {
+  interface InjectableRegistry {
+    [SymbolSym]: symbol;
+    [SymbolSym2]: symbol;
+  }
+}
+
+describe('Decorators', () => {
+  describe('inject: field, provides: field, consumes: field', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+
+        @feed
+        readonly b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should work out of order', () => {
+      class A {
+        @feed
+        readonly b = new B();
+
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should not work with constructors', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value: symbol;
+
+        @feed
+        readonly b: B;
+
+        constructor() {
+          this.value = Symbol();
+          this.b = new B();
+        }
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(undefined);
+    });
+
+    it('should not descend modifications', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+
+        @feed
+        readonly b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      // @ts-expect-error We are trying to do something bad here.
+      a.value = Symbol();
+      expect(a.b.value).not.equals(a.value);
+    });
+
+    it('should not reinject', () => {
+      class A {
+        @pantry(SymbolSym)
+        readonly value = Symbol();
+
+        @feed
+        readonly b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        readonly value!: symbol;
+      }
+
+      const a = new A();
+      // @ts-expect-error We are trying to do something bad here.
+      a.b = new B();
+      expect(a.b.value).equals(undefined);
+    });
+  });
+
+  describe('inject: setter/getter, provides: getter, consumes: setter', () => {
+    it('should work with injected setters', () => {
+      class A {
+        @pantry(Number)
+        get value() {
+          return 5;
+        }
+
+        internalB?: B;
+        @feed
+        set b(value: B) {
+          this.internalB = value;
+        }
+      }
+
+      class B {
+        internalValue?: number;
+        @eat(Number)
+        set value(value: number) {
+          this.internalValue = value;
+        }
+      }
+
+      const a = new A();
+      expect(a.internalB).equals(undefined);
+
+      const b = new B();
+      expect(b.internalValue).equals(undefined);
+
+      a.b = b;
+      expect(a.internalB).equals(b);
+      expect(b.internalValue).equals(a.value);
+    });
+
+    it('should work with injected getters', () => {
+      class A {
+        @pantry(Number)
+        get value() {
+          return 5;
+        }
+
+        @feed
+        get b() {
+          return new B();
+        }
+      }
+
+      class B {
+        internalValue?: number;
+        @eat(Number)
+        set value(value: number) {
+          this.internalValue = value;
+        }
+      }
+
+      const a = new A();
+      expect(a.b.internalValue).equals(a.value);
+    });
+  });
+
+  describe('inject: accessor, provides: accessor, consumes: accessor', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should work out of order', () => {
+      class A {
+        @feed
+        accessor b = new B();
+
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should work with constructors', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value: symbol;
+
+        @feed
+        accessor b: B;
+
+        constructor() {
+          this.value = Symbol();
+          this.b = new B();
+        }
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should descend modifications', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      a.value = Symbol();
+      expect(a.b.value).equals(a.value);
+    });
+
+    it('should reinject', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      a.b = new B();
+      expect(a.b.value).equals(a.value);
+    });
+  });
+
+  describe('inject: field, provides: accessor, consumes: accessor', () => {
+    it('should not work out of order in constructor', () => {
+      class A {
+        @feed
+        accessor b: B;
+
+        @pantry(SymbolSym)
+        readonly value: symbol;
+
+        constructor() {
+          this.b = new B();
+          this.value = Symbol();
+        }
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor value!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.value).equals(undefined);
+    });
+  });
+
+  it('should work with multiple', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+      @pantry(SymbolSym2)
+      accessor value2 = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor value!: symbol;
+      @eat(SymbolSym2)
+      accessor value2!: symbol;
+    }
+
+    const a = new A();
+    expect(a.b.value).equals(a.value);
+    expect(a.b.value2).equals(a.value2);
+  });
+
+  it('should work with private properties', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor #value = Symbol();
+
+      get value(): symbol {
+        return this.#value;
+      }
+
+      @feed
+      accessor #b = new B();
+
+      get b(): B {
+        return this.#b;
+      }
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor #value!: symbol;
+
+      get value(): symbol {
+        return this.#value;
+      }
+    }
+
+    const a = new A();
+    expect(a.b.value).equals(a.value);
+  });
+
+  it('should work with consumer setter', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      set value(value: symbol) {
+        this.value2 = value;
+      }
+
+      value2!: symbol;
+    }
+
+    const a = new A();
+    expect(a.b.value2).equals(a.value);
+  });
+
+  it('should work not have properties before constructor is used', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor value!: symbol;
+
+      accessor value2: symbol;
+
+      constructor() {
+        this.value2 = this.value;
+      }
+    }
+
+    const a = new A();
+    expect(a.b.value2).equals(undefined);
+  });
+
+  describe('nesting', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        @pantry(SymbolSym)
+        accessor bValue!: symbol;
+
+        @feed
+        accessor c = new C();
+      }
+
+      class C {
+        @eat(SymbolSym)
+        accessor cValue!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.bValue).equals(a.value);
+      expect(a.b.c.cValue).equals(a.value);
+
+      a.value = Symbol();
+      expect(a.b.bValue).equals(a.value);
+      expect(a.b.c.cValue).equals(a.value);
+    });
+
+    it('should work deeply', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @feed
+        accessor c = new C();
+      }
+
+      class C {
+        @feed
+        accessor d = new D();
+      }
+
+      class D {
+        @eat(SymbolSym)
+        accessor dValue!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.c.d.dValue).equals(a.value);
+
+      a.value = Symbol();
+      expect(a.b.c.d.dValue).equals(a.value);
+    });
+  });
+
+  it('should work with multiple consumers', () => {
+    class A {
+      @pantry(SymbolSym)
+      accessor value = Symbol();
+
+      @feed
+      accessor b = new B();
+    }
+
+    class B {
+      @eat(SymbolSym)
+      accessor bValue!: symbol;
+
+      @eat(SymbolSym)
+      accessor bValue2!: symbol;
+    }
+
+    const a = new A();
+    expect(a.b.bValue).equals(a.value);
+    expect(a.b.bValue2).equals(a.value);
+
+    a.value = Symbol();
+    expect(a.b.bValue).equals(a.value);
+    expect(a.b.bValue2).equals(a.value);
+  });
+
+  describe('Required', () => {
+    it('should work', () => {
+      class A {
+        @pantry(SymbolSym)
+        accessor value = Symbol();
+        @pantry(SymbolSym2)
+        accessor value2 = Symbol();
+
+        @feed
+        accessor b = new B();
+      }
+
+      class B {
+        @eat(SymbolSym)
+        accessor bValue!: symbol;
+
+        @feed
+        accessor c = new C();
+      }
+
+      class C {
+        @eat(SymbolSym)
+        accessor cValue!: symbol;
+
+        @eat(SymbolSym2)
+        accessor cValue2!: symbol;
+      }
+
+      const a = new A();
+      expect(a.b.bValue).equals(a.value);
+      expect(a.b.c.cValue).equals(a.value);
+      expect(a.b.c.cValue2).equals(a.value2);
+    });
+  });
+});

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,0 +1,395 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ClassMemberDecoratorContext<This, Value> =
+  | ClassGetterDecoratorContext<This, Value>
+  | ClassSetterDecoratorContext<This, Value>
+  | ClassFieldDecoratorContext<This, Value>
+  | ClassAccessorDecoratorContext<This, Value>;
+
+type InjectableKey =
+  | (abstract new (...args: any[]) => any)
+  | keyof InjectableRegistry;
+
+type ValueOf<Marker extends InjectableKey> =
+  Marker extends keyof InjectableRegistry
+    ? InjectableRegistry[Marker]
+    : Marker extends abstract new (...args: any[]) => any
+    ? InstanceType<Marker>
+    : never;
+
+/**
+ * Augment this to register your injectables.
+ *
+ * For example,
+ *
+ * ```ts
+ * const LoggerSym = Symbol('symbol');
+ *
+ * declare module './path/to/decorators.js' {
+ *  interface InjectableRegistry {
+ *    [LoggerSym]: Logger;
+ *   }
+ * }
+ * ```
+ */
+export interface InjectableRegistry {}
+
+type Consumer = {
+  getters: Map<InjectableKey, () => any>;
+  fields: Map<string | symbol, object>;
+};
+
+type Provider = Map<
+  InjectableKey,
+  [(value: any) => void, ...((value: any) => void)[]]
+>;
+
+const STATES = new WeakMap<
+  abstract new (...args: unknown[]) => unknown,
+  {
+    consumers?: WeakMap<object, Consumer>;
+    providers?: WeakMap<object, Provider>;
+  }
+>();
+
+function getInjectorState(object: object) {
+  const Class = object.constructor as abstract new (
+    ...args: unknown[]
+  ) => unknown;
+  let state = STATES.get(Class);
+  if (!state) {
+    state = {};
+    STATES.set(Class, state);
+  }
+  return state;
+}
+
+function getOrCreateProvider(object: object) {
+  const state = getInjectorState(object);
+  state.providers ??= new WeakMap();
+
+  const providers = state.providers;
+  let provider = providers.get(object);
+  if (!provider) {
+    provider = new Map();
+    providers.set(object, provider);
+  }
+  return provider;
+}
+
+function getProvider(object: object) {
+  const state = getInjectorState(object);
+  state.providers ??= new WeakMap();
+
+  const providers = state.providers;
+  return providers.get(object);
+}
+
+function getOrCreateConsumers(object: object) {
+  const state = getInjectorState(object);
+  state.consumers ??= new WeakMap();
+
+  const consumers = state.consumers;
+  let consumer = consumers.get(object);
+  if (!consumer) {
+    consumer = {getters: new Map(), fields: new Map()};
+    consumers.set(object, consumer);
+  }
+  return consumer;
+}
+
+function getConsumers(object: object) {
+  const state = getInjectorState(object);
+  state.consumers ??= new WeakMap();
+
+  const consumers = state.consumers;
+  return consumers.get(object);
+}
+
+/**
+ * Injects the decorated member with objects associated with the given symbols.
+ *
+ * Before injecting a given symbol, make sure it's registered with
+ * {@link InjectableRegistry}.
+ */
+export function feed(
+  target: any,
+  context: ClassMemberDecoratorContext<object, object>
+): any {
+  let consumers: Consumer;
+  context.addInitializer(function initializer() {
+    consumers = getOrCreateConsumers(this);
+  });
+
+  const getCachedKeys = memoize(getInjectableKeys);
+
+  switch (context.kind) {
+    case 'accessor':
+      return {
+        set(this: object, value?: object) {
+          return target.set.call(this, inject(value));
+        },
+        init: inject,
+      };
+    case 'field':
+      return inject;
+    case 'setter':
+      return function set(this: object, value?: object) {
+        return target.call(this, inject(value));
+      };
+    case 'getter':
+      return function get(this: object) {
+        return inject(target.call(this));
+      };
+  }
+
+  function inject(object?: object) {
+    if (object !== undefined) {
+      consumers.fields.set(context.name, object);
+      const keys = getCachedKeys(object);
+      const provider = getProvider(object);
+      if (provider !== undefined) {
+        for (const key of provider.keys()) {
+          keys.add(key);
+        }
+        for (const mark of keys) {
+          const get = consumers.getters.get(mark);
+          if (get !== undefined) {
+            const setters = provider.get(mark)!;
+            if (setters !== undefined) {
+              for (const set of setters) {
+                set(get());
+              }
+            }
+          }
+        }
+      }
+    }
+    return object;
+  }
+}
+
+/**
+ * Declares a member as an object provider for the given symbol.
+ *
+ * Before injecting a given symbol, make sure it's registered with
+ * {@link InjectableRegistry}.
+ */
+export function pantry<Marker extends InjectableKey>(mark: Marker) {
+  return <
+    Interface,
+    Value = ValueOf<Marker> extends Interface ? Interface : ValueOf<Marker>,
+  >(
+    target: any,
+    context: ClassMemberDecoratorContext<object, Value>
+  ): any => {
+    let consumers: Consumer;
+    context.addInitializer(function initializer() {
+      consumers = getOrCreateConsumers(this);
+      switch (context.kind) {
+        case 'getter':
+          consumers.getters.set(mark, context.access.get.bind(undefined, this));
+          break;
+        default:
+      }
+    });
+
+    switch (context.kind) {
+      case 'accessor':
+        return {
+          set(this: object, value: Value) {
+            return target.set.call(this, reinject(consumers, mark, value));
+          },
+          init(this: object, initialValue: Value) {
+            consumers.getters.set(
+              mark,
+              context.access.get.bind(undefined, this)
+            );
+            return reinject(consumers, mark, initialValue);
+          },
+        };
+      case 'field':
+        return function init(this: object, initialValue: Value) {
+          consumers.getters.set(mark, context.access.get.bind(undefined, this));
+          return reinject(consumers, mark, initialValue);
+        };
+      case 'getter':
+        break;
+      default:
+        throw new Error(`Cannot decorate ${context.kind}`);
+    }
+  };
+}
+
+/**
+ * Declares a member as an object consumer for the given symbol.
+ *
+ * Before injecting a given symbol, make sure it's registered with
+ * {@link InjectableRegistry}.
+ */
+export function eat<Marker extends InjectableKey>(mark: Marker) {
+  return <
+    Interface,
+    Value = ValueOf<Marker> extends Interface ? Interface : ValueOf<Marker>,
+  >(
+    _: unknown,
+    context: ClassMemberDecoratorContext<object, Value>
+  ): any => {
+    context.addInitializer(function initializer() {
+      const provider = getOrCreateProvider(this);
+      switch (context.kind) {
+        case 'field':
+        case 'setter':
+        case 'accessor': {
+          const setters = provider.get(mark) ?? [() => {}];
+          setters.push(memoize(context.access.set.bind(undefined, this)));
+          provider.set(mark, setters);
+          break;
+        }
+        default:
+          throw new Error(`Cannot decorate ${context.kind}`);
+      }
+    });
+  };
+}
+
+/**
+ * For testing only! Injects a given object with a provided set of injectables.
+ *
+ * This must not be used to "skip" constructor arguments in favor of injection.
+ *
+ * For example, if you need to inject a `Logger` module into some class, do
+ *
+ * ```ts
+ * class A {
+ *  @pantry(LoggerSym)
+ *  #logger: Logger
+ *
+ *  constructor(logger: Logger) {
+ *    this.#logger = logger;
+ *  }
+ * }
+ *
+ * const a = new A(new Logger());
+ * ```
+ *
+ * Do not do
+ *
+ * ```ts
+ * class A {
+ *  @eat(LoggerSym)
+ *  #logger: Logger
+ *
+ *  constructor(logger: Logger) {
+ *    this.#logger = logger;
+ *  }
+ * }
+ *
+ * const a = inject(new A());
+ * ```
+ *
+ * If you need to pass some object to some descendent, you should declare
+ * the object on the root class, even if it's not used by the root class.
+ *
+ */
+export function inject<
+  T extends object,
+  Injectables extends Partial<InjectableRegistry> | Set<object>,
+>(object: T, injectables: Injectables): T {
+  const provider = getProvider(object);
+  if (provider !== undefined) {
+    if (injectables instanceof Set) {
+      for (const object of injectables) {
+        const setters = provider.get(object.constructor);
+        if (setters !== undefined) {
+          for (const set of setters) {
+            set(object);
+          }
+        }
+      }
+    } else {
+      for (const mark of Object.getOwnPropertySymbols(
+        injectables
+      ) as (keyof InjectableRegistry)[]) {
+        const setters = provider.get(mark);
+        if (setters !== undefined) {
+          for (const set of setters) {
+            set(injectables[mark]);
+          }
+        }
+      }
+    }
+  }
+  return object;
+}
+
+function reinject<
+  Marker extends InjectableKey,
+  Interface,
+  Value = ValueOf<Marker> extends Interface ? Interface : ValueOf<Marker>,
+>(consumer: Consumer, mark: Marker, value: Value) {
+  for (const object of consumer.fields.values()) {
+    // SAFETY: Being in consumer.field implies this object has a provider.
+    const provider = getProvider(object)!;
+    const setters = provider.get(mark);
+    if (setters !== undefined) {
+      for (const set of setters) {
+        set(value);
+      }
+    }
+  }
+  return value;
+}
+
+function getInjectableKeys(source: object) {
+  const keys = new Set<InjectableKey>();
+  const consumer = getConsumers(source);
+  if (consumer !== undefined) {
+    for (const child of consumer.fields.values()) {
+      for (const key of getInjectableKeys(child)) {
+        keys.add(key);
+      }
+      const provider = getProvider(child);
+      if (provider !== undefined) {
+        for (const mark of provider.keys()) {
+          keys.add(mark);
+        }
+      }
+    }
+    const provider = getOrCreateProvider(source);
+    for (const mark of keys) {
+      const setters = provider.get(mark) ?? [() => {}];
+      setters[0] = memoize(reinject.bind(undefined, consumer, mark));
+      provider.set(mark, setters);
+    }
+  }
+  return keys;
+}
+
+function memoize<T, U>(fn: (value: T) => U) {
+  let lastValue: {value: T} | undefined = undefined;
+  let lastResult: U | undefined = undefined;
+  return (value: T) => {
+    if (lastValue === undefined || value !== lastValue.value) {
+      lastResult = fn(value);
+      lastValue = {value};
+    }
+    return lastResult as U;
+  };
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "ESNext",
+    "target": "ES2022",
     "useUnknownInCatchVariables": true
   }
 }


### PR DESCRIPTION
This PR adds ESLint rules for the injection framework. They help prevent common mistakes and provides auto-fixes for some of them.