### PR TITLE
chore: use helper to navigate

### DIFF
--- a/tests/browsing_context/test_create.py
+++ b/tests/browsing_context/test_create.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 import pytest
 from anys import ANY_DICT, ANY_STR
-from test_helpers import (ANY_TIMESTAMP, AnyExtending, execute_command,
-                          get_tree, read_JSON_message, send_JSON_command,
-                          subscribe)
+from test_helpers import (ANY_TIMESTAMP, AnyExtending, get_tree, goto_url,
+                          read_JSON_message, send_JSON_command, subscribe)
 
 
 @pytest.mark.asyncio
@@ -180,15 +179,7 @@ async def test_browsingContext_create_withUserGesture_eventsEmitted(
     LINK_WITH_BLANK_TARGET = html(
         f'''<a href="{blank_url}" target="_blank">new tab</a>''')
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "context": context_id,
-                "url": LINK_WITH_BLANK_TARGET,
-                "wait": "complete",
-            }
-        })
+    await goto_url(websocket, context_id, LINK_WITH_BLANK_TARGET)
 
     await subscribe(websocket, [
         "browsingContext.contextCreated",

--- a/tests/browsing_context/test_fragment_navigated.py
+++ b/tests/browsing_context/test_fragment_navigated.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from test_helpers import (ANY_TIMESTAMP, execute_command, read_JSON_message,
+from test_helpers import (ANY_TIMESTAMP, goto_url, read_JSON_message,
                           send_JSON_command, subscribe)
 
 
@@ -23,15 +23,7 @@ async def test_browsingContext_fragmentNavigated_event(websocket, context_id):
 
     await subscribe(websocket, ["browsingContext.fragmentNavigated"])
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "context": context_id,
-                "url": url,
-                "wait": "complete",
-            }
-        })
+    await goto_url(websocket, context_id, url)
 
     await send_JSON_command(
         websocket, {

--- a/tests/browsing_context/test_nested_browsing_context.py
+++ b/tests/browsing_context/test_nested_browsing_context.py
@@ -49,15 +49,7 @@ async def test_nestedBrowsingContext_navigateWaitNone_navigated(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
 
-    result = await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": url,
-                "wait": "none",
-                "context": iframe_id
-            }
-        })
+    result = await goto_url(websocket, iframe_id, url, 'none')
     navigation_id = result["navigation"]
 
     assert result == {"navigation": navigation_id, "url": url}
@@ -94,15 +86,7 @@ async def test_nestedBrowsingContext_navigateWaitInteractive_navigated(
         websocket,
         ["browsingContext.domContentLoaded", "browsingContext.load"])
 
-    result = await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": url,
-                "wait": "interactive",
-                "context": iframe_id
-            }
-        })
+    result = await goto_url(websocket, iframe_id, url, 'interactive')
     navigation_id = result["navigation"]
 
     assert result == {"navigation": navigation_id, "url": url}

--- a/tests/script/test_add_preload_script.py
+++ b/tests/script/test_add_preload_script.py
@@ -15,7 +15,7 @@
 
 import pytest
 from anys import ANY_DICT, ANY_STR
-from test_helpers import (ANY_UUID, AnyExtending, execute_command,
+from test_helpers import (ANY_UUID, AnyExtending, execute_command, goto_url,
                           read_JSON_message, send_JSON_command, subscribe)
 
 
@@ -31,15 +31,7 @@ async def test_preloadScript_add_setGlobalVariable(websocket, context_id,
         })
     assert result == {'script': ANY_UUID}
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     result = await execute_command(
         websocket, {
@@ -114,15 +106,7 @@ async def test_preloadScript_add_multipleScripts(websocket, context_id, html):
             }
         })
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     result = await execute_command(
         websocket, {
@@ -167,15 +151,7 @@ async def test_preloadScript_add_sameScript_multipleTimes(
     # Same script added twice should result in different ids.
     assert id1 != id2
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     result = await execute_command(
         websocket, {
@@ -365,15 +341,7 @@ async def test_preloadScript_add_loadedInMultipleContexts(
             }
         })
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     response = await execute_command(
         websocket, {
@@ -401,15 +369,7 @@ async def test_preloadScript_add_loadedInMultipleContexts_withIframes(
             }
         })
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     result = await execute_command(
         websocket, {
@@ -490,15 +450,7 @@ async def test_preloadScript_add_loadedInNewContexts(websocket, context_id,
             }
         })
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     result = await execute_command(
         websocket, {
@@ -530,15 +482,7 @@ async def test_preloadScript_add_loadedInNewContexts(websocket, context_id,
         })
     assert result["result"] == {"type": "string", "value": 'bar'}
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": new_context_id
-            }
-        })
+    await goto_url(websocket, new_context_id, html())
 
     result = await execute_command(
         websocket, {
@@ -567,15 +511,7 @@ async def test_preloadScript_add_sandbox(websocket, context_id, html):
         })
     assert result == {'script': ANY_UUID}
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     # Evaluate in the standard sandbox, script takes no effect.
     result = await execute_command(
@@ -614,15 +550,8 @@ async def test_preloadScript_add_sandbox(websocket, context_id, html):
                          ids=["with reload", "without reload"])
 async def test_preloadScript_add_runImmediately(websocket, html, context_id,
                                                 with_reload):
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+
+    await goto_url(websocket, context_id, html())
 
     await execute_command(
         websocket, {
@@ -687,15 +616,7 @@ async def test_preloadScript_add_withUserGesture_blankTargetLink(
             }
         })
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "context": context_id,
-                "url": LINK_WITH_BLANK_TARGET,
-                "wait": "complete",
-            }
-        })
+    await goto_url(websocket, context_id, LINK_WITH_BLANK_TARGET)
 
     await subscribe(websocket, ["log.entryAdded"])
 

--- a/tests/script/test_remove_preload_script.py
+++ b/tests/script/test_remove_preload_script.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import pytest
 from anys import ANY_STR
-from test_helpers import execute_command
+from test_helpers import execute_command, goto_url
 
 
 @pytest.mark.asyncio
@@ -53,15 +53,7 @@ async def test_preloadScript_remove_addAndRemoveIsNoop_secondRemoval_fails(
     })
     assert result == {}
 
-    await execute_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": html(),
-                "wait": "complete",
-                "context": context_id
-            }
-        })
+    await goto_url(websocket, context_id, html())
 
     result = await execute_command(
         websocket, {


### PR DESCRIPTION
Use `goto_url` to simplify test code.
We should consider adding some for `script.evaluate` as we use that a lot.