### PR TITLE
chore: no-op for trivial pen and touch movements

### DIFF
--- a/src/bidiMapper/domains/input/ActionDispatcher.ts
+++ b/src/bidiMapper/domains/input/ActionDispatcher.ts
@@ -380,7 +380,6 @@ export class ActionDispatcher {
         const {modifiers} = keyState;
         switch (pointerType) {
           case Input.PointerType.Mouse:
-          case Input.PointerType.Pen:
             // TODO: Implement width and height when available.
             await this.#context.cdpTarget.cdpClient.sendCommand(
               'Input.dispatchMouseEvent',
@@ -401,28 +400,55 @@ export class ActionDispatcher {
               }
             );
             break;
+          case Input.PointerType.Pen:
+            if (source.pressed.size !== 0) {
+              // TODO: Implement width and height when available.
+              await this.#context.cdpTarget.cdpClient.sendCommand(
+                'Input.dispatchMouseEvent',
+                {
+                  type: 'mouseMoved',
+                  x,
+                  y,
+                  modifiers,
+                  clickCount: 0,
+                  button: getCdpButton(
+                    source.pressed.values().next().value ?? 5
+                  ),
+                  buttons: source.buttons,
+                  pointerType,
+                  tangentialPressure,
+                  tiltX,
+                  tiltY,
+                  twist,
+                  force: pressure,
+                }
+              );
+            }
+            break;
           case Input.PointerType.Touch:
-            await this.#context.cdpTarget.cdpClient.sendCommand(
-              'Input.dispatchTouchEvent',
-              {
-                type: 'touchMove',
-                touchPoints: [
-                  {
-                    x,
-                    y,
-                    radiusX: width,
-                    radiusY: height,
-                    tangentialPressure,
-                    tiltX,
-                    tiltY,
-                    twist,
-                    force: pressure,
-                    id: source.pointerId,
-                  },
-                ],
-                modifiers,
-              }
-            );
+            if (source.pressed.size !== 0) {
+              await this.#context.cdpTarget.cdpClient.sendCommand(
+                'Input.dispatchTouchEvent',
+                {
+                  type: 'touchMove',
+                  touchPoints: [
+                    {
+                      x,
+                      y,
+                      radiusX: width,
+                      radiusY: height,
+                      tangentialPressure,
+                      tiltX,
+                      tiltY,
+                      twist,
+                      force: pressure,
+                      id: source.pointerId,
+                    },
+                  ],
+                  modifiers,
+                }
+              );
+            }
             break;
         }
         // --- Platform-specific code ends here ---

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/pointer_touch.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/pointer_touch.py.ini
@@ -1,7 +1,3 @@
 [pointer_touch.py]
-  expected: [ERROR, OK]
   [test_touch_pointer_properties]
-    expected: FAIL
-
-  [test_touch_pointer_properties_tilt_twist]
     expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/pointer_touch.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/pointer_touch.py.ini
@@ -1,6 +1,3 @@
 [pointer_touch.py]
   [test_touch_pointer_properties]
     expected: FAIL
-
-  [test_touch_pointer_properties_tilt_twist]
-    expected: FAIL


### PR DESCRIPTION
If there are no buttons pressed, we do a no-op as specified in https://w3c.github.io/webdriver/#dfn-perform-a-pointer-move