### PR TITLE
feat: add network redirects

### DIFF
--- a/src/bidiMapper/domains/network/NetworkManager.ts
+++ b/src/bidiMapper/domains/network/NetworkManager.ts
@@ -43,6 +43,14 @@ export class NetworkManager {
     return this.#cdpTarget;
   }
 
+  #forgetNetworkRequest(requestId: Network.Request): void {
+    this.#networkStorage.deleteRequest(requestId);
+  }
+
+  #getOrCreateNetworkRequest(requestId: Network.Request): NetworkRequest {
+    return this.#networkStorage.getRequest(requestId);
+  }
+
   static create(
     cdpTarget: CdpTarget,
     networkStorage: NetworkStorage
@@ -111,29 +119,17 @@ export class NetworkManager {
         networkManager
           .#getOrCreateNetworkRequest(params.requestId)
           .onLoadingFailedEvent(params);
-        networkManager.#forgetRequest(params.requestId);
+        networkManager.#forgetNetworkRequest(params.requestId);
       }
     );
 
     cdpTarget.cdpClient.on(
       'Network.loadingFinished',
       (params: Protocol.Network.RequestServedFromCacheEvent) => {
-        networkManager.#forgetRequest(params.requestId);
+        networkManager.#forgetNetworkRequest(params.requestId);
       }
     );
 
     return networkManager;
-  }
-
-  #forgetRequest(requestId: Network.Request): void {
-    const request = this.#networkStorage.requestMap.get(requestId);
-    if (request) {
-      request.dispose();
-      this.#networkStorage.requestMap.delete(requestId);
-    }
-  }
-
-  #getOrCreateNetworkRequest(requestId: Network.Request): NetworkRequest {
-    return this.#networkStorage.requestMap.get(requestId);
   }
 }

--- a/src/bidiMapper/domains/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.spec.ts
@@ -35,9 +35,11 @@ describe('NetworkStorage', () => {
   });
 
   it('disposeRequestMap', () => {
+    const dispose = sinon.stub(networkStorage.getRequest('_test_'), 'dispose');
+
     networkStorage.disposeRequestMap();
 
-    expect(networkStorage.requestMap).to.be.empty;
+    sinon.assert.called(dispose);
   });
 
   it('requestStageFromPhase', () => {

--- a/src/bidiMapper/domains/network/NetworkStorage.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.ts
@@ -58,11 +58,6 @@ export class NetworkStorage {
     this.#blockedRequestMap = new Map();
   }
 
-  // XXX: Replace getters with custom operations, follow suit of Browsing Context Storage.
-  get requestMap() {
-    return this.#requestMap;
-  }
-
   disposeRequestMap() {
     for (const request of this.#requestMap.values()) {
       request.dispose();
@@ -133,6 +128,19 @@ export class NetworkStorage {
         return param.phases.includes(Network.InterceptPhase.AuthRequired);
       }),
     };
+  }
+
+  getRequest(id: Network.Request) {
+    return this.#requestMap.get(id);
+  }
+
+  deleteRequest(id: Network.Request) {
+    const request = this.#requestMap.get(id);
+    if (request) {
+      request.dispose();
+    }
+
+    this.#requestMap.delete(id);
   }
 
   /** Converts a URL pattern from the spec to a CDP URL pattern. */

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export function assert<T>(predicate: T): asserts predicate {
+export function assert<T>(predicate: T, message?: string): asserts predicate {
   if (!predicate) {
-    throw new Error('Internal assertion failed.');
+    throw new Error(message ?? 'Internal assertion failed.');
   }
 }


### PR DESCRIPTION
This should cover the base case of redirects, some edge cases may need to be fix similar to what to do with the `responseExtraInfo` that's emitted between events. Puppeteer sort handles them as Reponses.