### PR TITLE
feat: throw InvalidArgument instead of UnsupportedOperation for print…

### DIFF
--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -846,7 +846,7 @@ export class BrowsingContextImpl {
         (error as Error).message ===
         'invalid print parameters: content area is empty'
       ) {
-        throw new UnsupportedOperationException(error.message);
+        throw new InvalidArgumentException(error.message);
       }
       throw error;
     }


### PR DESCRIPTION
…ing an empty content area

Related, in sync with, and blocked on: https://github.com/web-platform-tests/wpt/pull/40872