### PR TITLE
test: fix browsingContext.print `test_margin_same_as_page_dimension`

### DIFF
--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -851,7 +851,7 @@ export class BrowsingContextImpl {
         (error as Error).message ===
         'invalid print parameters: content area is empty'
       ) {
-        throw new InvalidArgumentException(error.message);
+        throw new UnsupportedOperationException(error.message);
       }
       throw error;
     }

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/print/margin.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/print/margin.py.ini
@@ -10,18 +10,3 @@
 
   [test_margin_default[bottom\]]
     expected: FAIL
-
-  [test_margin_same_as_page_dimension[top\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[left\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[right\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[bottom\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[all\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/print/margin.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/browsing_context/print/margin.py.ini
@@ -10,18 +10,3 @@
 
   [test_margin_default[bottom\]]
     expected: FAIL
-
-  [test_margin_same_as_page_dimension[top\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[left\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[right\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[bottom\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[all\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/print/margin.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/print/margin.py.ini
@@ -10,18 +10,3 @@
 
   [test_margin_default[bottom\]]
     expected: FAIL
-
-  [test_margin_same_as_page_dimension[top\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[left\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[right\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[bottom\]]
-    expected: FAIL
-
-  [test_margin_same_as_page_dimension[all\]]
-    expected: FAIL


### PR DESCRIPTION
Revert "feat: throw InvalidArgument instead of UnsupportedOperation for print… (#1280)"

This reverts commit b32ea31ca346caacf4af673c857ab97cb1e9ba45.

test: update wpt expectations

Chicken-and-egg: This PR will not be needed if
https://github.com/web-platform-tests/wpt/pull/41945 is merged.