### PR TITLE
fix: separate click count by button

### DIFF
--- a/src/bidiMapper/domains/input/ActionDispatcher.ts
+++ b/src/bidiMapper/domains/input/ActionDispatcher.ts
@@ -26,7 +26,11 @@ import {assert} from '../../../utils/assert.js';
 import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
 
 import type {ActionOption} from './ActionOption.js';
-import type {KeySource, PointerSource, WheelSource} from './InputSource.js';
+import {
+  type KeySource,
+  PointerSource,
+  type WheelSource,
+} from './InputSource.js';
 import type {InputState} from './InputState.js';
 import {KeyToKeyCode} from './USKeyboardLayout.js';
 import {getKeyCode, getKeyLocation, getNormalizedKey} from './keyUtils.js';
@@ -229,7 +233,6 @@ export class ActionDispatcher {
     switch (pointerType) {
       case Input.PointerType.Mouse:
       case Input.PointerType.Pen:
-        source.setClickCount({x, y, timeStamp: performance.now()});
         // TODO: Implement width and height when available.
         return this.#context.cdpTarget.cdpClient.sendCommand(
           'Input.dispatchMouseEvent',
@@ -240,7 +243,10 @@ export class ActionDispatcher {
             modifiers,
             button: getCdpButton(button),
             buttons: source.buttons,
-            clickCount: source.clickCount,
+            clickCount: source.setClickCount(
+              button,
+              new PointerSource.ClickContext(x, y, performance.now())
+            ),
             pointerType,
             tangentialPressure,
             tiltX,
@@ -302,7 +308,7 @@ export class ActionDispatcher {
             modifiers,
             button: getCdpButton(button),
             buttons: source.buttons,
-            clickCount: source.clickCount,
+            clickCount: source.getClickCount(button),
             pointerType,
           }
         );

--- a/tests/input/__snapshots__/test_input.ambr
+++ b/tests/input/__snapshots__/test_input.ambr
@@ -659,6 +659,298 @@
     'type': 'success',
   })
 # ---
+# name: test_input_performActionsEmitsClickCountsByButton
+  dict({
+    'result': dict({
+      'type': 'array',
+      'value': list([
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'mousedown',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+            list([
+              'clientX',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientY',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+          ]),
+        }),
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'mouseup',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientX',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientY',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+          ]),
+        }),
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'mousedown',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+            list([
+              'clientX',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientY',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 2,
+              }),
+            ]),
+          ]),
+        }),
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'mouseup',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientX',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientY',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 2,
+              }),
+            ]),
+          ]),
+        }),
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'mousedown',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 4,
+              }),
+            ]),
+            list([
+              'clientX',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientY',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+          ]),
+        }),
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'mouseup',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientX',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clientY',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+          ]),
+        }),
+      ]),
+    }),
+    'type': 'success',
+  })
+# ---
 # name: test_input_performActionsEmitsDragging
   dict({
     'result': dict({
@@ -1202,6 +1494,13 @@
                 'value': 0,
               }),
             ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
           ]),
         }),
         dict({
@@ -1242,6 +1541,13 @@
                 'value': 1,
               }),
             ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
           ]),
         }),
         dict({
@@ -1277,6 +1583,13 @@
             ]),
             list([
               'clientY',
+              dict({
+                'type': 'number',
+                'value': 1,
+              }),
+            ]),
+            list([
+              'clickCount',
               dict({
                 'type': 'number',
                 'value': 1,
@@ -1330,6 +1643,13 @@
               dict({
                 'type': 'number',
                 'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
               }),
             ]),
           ]),
@@ -1403,6 +1723,13 @@
               dict({
                 'type': 'number',
                 'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 1,
               }),
             ]),
           ]),

--- a/tests/input/test_input.py
+++ b/tests/input/test_input.py
@@ -41,6 +41,7 @@ SCRIPT = """
                         buttons: event.buttons,
                         clientX: event.clientX,
                         clientY: event.clientY,
+                        clickCount: event.detail,
                     });
                     break;
                 case "keydown":
@@ -495,6 +496,49 @@ async def test_input_performActionsEmitsWheelEvents(websocket, context_id,
                         "y": 0,
                         "deltaX": 0,
                         "deltaY": 5,
+                    }]
+                }]
+            }
+        })
+
+    result = await get_events(websocket, context_id)
+
+    assert result == snapshot(exclude=props("realm"))
+
+
+@pytest.mark.asyncio
+async def test_input_performActionsEmitsClickCountsByButton(
+        websocket, context_id, html, activate_main_tab, snapshot):
+    await goto_url(websocket, context_id, html(SCRIPT))
+    await activate_main_tab()
+    await reset_mouse(websocket, context_id)
+
+    await execute_command(
+        websocket, {
+            "method": "input.performActions",
+            "params": {
+                "context": context_id,
+                "actions": [{
+                    "type": "pointer",
+                    "id": "main_mouse",
+                    "actions": [{
+                        "type": "pointerDown",
+                        "button": 0,
+                    }, {
+                        "type": "pointerUp",
+                        "button": 0,
+                    }, {
+                        "type": "pointerDown",
+                        "button": 0,
+                    }, {
+                        "type": "pointerUp",
+                        "button": 0,
+                    }, {
+                        "type": "pointerDown",
+                        "button": 1,
+                    }, {
+                        "type": "pointerUp",
+                        "button": 1,
                     }]
                 }]
             }


### PR DESCRIPTION
Previously, the click count was measured globally among all buttons. This was incorrect as browsers separate click count by button.