### PR TITLE
ci: cache support is only top level

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          cache: npm
           node-version: lts/*
       - name: Install Chromium-BiDi dependencies
         working-directory: bidi


### PR DESCRIPTION
For node set-up cache to work you need to have a `package-lock.json`.
As we will run this infrequently we can opt to not use cache. 