### PR TITLE
ci: script look relative to cwd

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -61,7 +61,8 @@ jobs:
           key: ${{ runner.os }}-browsers-${{ hashFiles('.browser') }}) }}
       - name: Install pinned browser
         id: browser
-        run: node bidi/tools/install-browser.mjs
+        working-directory: bidi
+        run: node tools/install-browser.mjs
       - name: Run tests
         working-directory: puppeteer
         env:


### PR DESCRIPTION
We need to set up the correct directory to do this on else `.browser` file is not found as script look at `cwd()/.browser`.