### PR TITLE
test: dynamic local http server for e2e tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def static_web_server():
 @pytest_asyncio.fixture(scope='session')
 def url_200(static_web_server):
     def url_200(content='<html><body>default 200 page</body></html>'):
-        return static_web_server.url_200(content)
+        return static_web_server.url(200, bytes(content, 'utf-8'))
 
     return url_200
 
@@ -44,7 +44,7 @@ def url_200(static_web_server):
 @pytest_asyncio.fixture(scope='session')
 def url_301(static_web_server, url_200):
     def url_301(location=url_200()):
-        return static_web_server.url_301(location)
+        return static_web_server.url(301, headers={"Location": location})
 
     return url_301
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,33 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 import websockets
+from http_server.test_web_server import StaticWebServer
 from test_helpers import execute_command, get_tree, goto_url, read_JSON_message
+
+
+@pytest_asyncio.fixture(scope='session')
+def static_web_server():
+    # TODO: provide a path to a certificate for HTTPS once `ignoreHTTPSErrors`
+    # capability is implemented.
+    server = StaticWebServer()
+    yield server
+    server.shutdown()
+
+
+@pytest_asyncio.fixture(scope='session')
+def url_200(static_web_server):
+    def url_200(content='<html><body>default 200 page</body></html>'):
+        return static_web_server.url_200(content)
+
+    return url_200
+
+
+@pytest_asyncio.fixture(scope='session')
+def url_301(static_web_server, url_200):
+    def url_301(location=url_200()):
+        return static_web_server.url_301(location)
+
+    return url_301
 
 
 @pytest_asyncio.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,18 +33,26 @@ def static_web_server():
     server.shutdown()
 
 
-@pytest_asyncio.fixture(scope='session')
-def url_200(static_web_server):
+@pytest_asyncio.fixture
+def url(static_web_server):
+    def url(code=200, content=b'', headers=None):
+        return static_web_server.url(code, content, headers)
+
+    return url
+
+
+@pytest_asyncio.fixture
+def url_200(url):
     def url_200(content='<html><body>default 200 page</body></html>'):
-        return static_web_server.url(200, bytes(content, 'utf-8'))
+        return url(200, bytes(content, 'utf-8'))
 
     return url_200
 
 
-@pytest_asyncio.fixture(scope='session')
-def url_301(static_web_server, url_200):
+@pytest_asyncio.fixture
+def url_301(url, url_200):
     def url_301(location=url_200()):
-        return static_web_server.url(301, headers={"Location": location})
+        return url(301, headers={"Location": location})
 
     return url_301
 

--- a/tests/http_server/test_static_server.py
+++ b/tests/http_server/test_static_server.py
@@ -1,0 +1,62 @@
+#  Copyright 2023 Google LLC.
+#  Copyright (c) Microsoft Corporation.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+from test_helpers import execute_command
+
+
+async def get_content(websocket, context_id, url):
+    await execute_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "url": url,
+                "wait": "complete",
+                "context": context_id
+            }
+        })
+
+    resp = await execute_command(
+        websocket, {
+            "method": "script.evaluate",
+            "params": {
+                "expression": "document.body.innerText",
+                "target": {
+                    "context": context_id
+                },
+                "awaitPromise": True
+            }
+        })
+
+    return resp["result"]["value"]
+
+
+@pytest.mark.asyncio
+async def test_staticWebServer_url_200(websocket, context_id, url_200):
+    assert await get_content(websocket, context_id, url_200()) \
+           == "default 200 page"
+    assert await get_content(websocket, context_id, url_200("MY CUSTOM PAGE")) \
+           == "MY CUSTOM PAGE"
+
+
+@pytest.mark.asyncio
+async def test_staticWebServer_url_301(websocket, context_id, url_200,
+                                       url_301):
+    assert await get_content(websocket, context_id, url_301()) \
+           == "default 200 page"
+    assert await get_content(websocket, context_id,
+                             url_301(url_200("MY CUSTOM PAGE"))) \
+           == "MY CUSTOM PAGE"

--- a/tests/http_server/test_web_server.py
+++ b/tests/http_server/test_web_server.py
@@ -1,0 +1,154 @@
+#  Copyright 2023 Google LLC.
+#  Copyright (c) Microsoft Corporation.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import http.server
+import itertools
+import socketserver
+import threading
+
+
+class _BaseServer(http.server.HTTPServer):
+    """Internal server that throws if timed out waiting for a request."""
+    def __init__(self, on_request):
+        """Starts the server."""
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            """Internal handler that just asks the server to handle the request."""
+            def do_GET(self):
+                if self.path.endswith('favicon.ico'):
+                    self.send_error(404)
+                    return
+                on_request(self)
+
+            def do_POST(self):
+                on_request(self)
+
+            def handle(self):
+                http.server.BaseHTTPRequestHandler.handle(self)
+
+            def finish(self):
+                http.server.BaseHTTPRequestHandler.finish(self)
+
+            def log_message(self, *args, **kwargs):
+                """Overrides base class method to disable logging."""
+                pass
+
+        http.server.HTTPServer.__init__(self, ('127.0.0.1', 0), _Handler)
+
+        # TODO: implement HTTPS along with `ignoreHTTPSErrors` capability.
+        # if server_cert_and_key_path is not None:
+        #     self._is_https_enabled = True
+        #     self.socket = ssl.wrap_socket(self.socket,
+        #                                   certfile=server_cert_and_key_path,
+        #                                   server_side=True)
+        # else:
+        self._is_https_enabled = False
+
+    def handle_timeout(self):
+        """Overridden from SocketServer."""
+        raise RuntimeError('Timed out waiting for http request')
+
+    def get_url(self, host=None):
+        """Returns the base URL of the server."""
+        postfix = '://{}:{}'.format(host or '127.0.0.1', self.server_port)
+        if self._is_https_enabled:
+            return 'https' + postfix
+        return 'http' + postfix
+
+
+class _ThreadingServer(socketserver.ThreadingMixIn, _BaseServer):
+    """_BaseServer enhanced to handle multiple requests simultaneously"""
+    pass
+
+
+class StaticWebServer:
+    """An HTTP or HTTPS server that serves on its own thread.
+    """
+    def __init__(self):
+        """Starts the server"""
+        self._server = _ThreadingServer(self._on_request)
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.daemon = True
+        self._thread.start()
+        self._path_data_map = {}
+        self._path_maps_lock = threading.Lock()
+        self._counter = itertools.count(1)
+        self.requests = {}
+
+    def _on_request(self, handler):
+        path = handler.path.split('?')[0]
+
+        self._path_maps_lock.acquire()
+        try:
+            print("path", path)
+            if path in self._path_data_map:
+                data = self._path_data_map[path]
+                print("data", data)
+                content = data["content"]
+                handler.send_response(data["code"])
+
+                if "headers" in data:
+                    headers = data["headers"]
+                else:
+                    headers = {}
+
+                print("headers", headers)
+                print(headers.items())
+                for field, value in headers.items():
+                    print("qwe", field, value)
+                    handler.send_header(field, value)
+
+                if content is not None:
+                    handler.send_header('Content-Length', len(content))
+                handler.end_headers()
+
+                if content is not None:
+                    handler.wfile.write(content)
+                return
+            else:
+                handler.send_error(404)
+                return
+        finally:
+            self._path_maps_lock.release()
+
+    def _get_url(self, host=None):
+        """Returns the base URL of the server."""
+        return self._server.get_url(host)
+
+    def shutdown(self):
+        """Shuts down the server synchronously."""
+        self._server.shutdown()
+        self._thread.join()
+
+    def url_200(self, content="<html><body>some page</body></html>"):
+        id = "/" + str(next(self._counter))
+        self._path_data_map[id] = {
+            "code": 200,
+            "content": bytes(content, 'utf-8')
+        }
+        return self._get_url() + id
+
+    def url_301(self, location=None):
+        if location is None:
+            location = self.url_200()
+        id = "/" + str(next(self._counter))
+        self._path_data_map[id] = {
+            "code": 301,
+            "content": bytes("some_content", 'utf-8'),
+            "headers": {
+                "Location": location
+            }
+        }
+        return self._get_url() + id

--- a/tests/http_server/test_web_server.py
+++ b/tests/http_server/test_web_server.py
@@ -126,11 +126,11 @@ class StaticWebServer:
         self._server.shutdown()
         self._thread.join()
 
-    def url(self, code=200, content=b'', headers=None):
+    def url(self, code, content, headers):
         """
         :param code: HTTP status code to be sent.
-        :param content: binary content to be sent.Defaults to empty content.
-        Provide `None` to have it omitted.
+        :param content: binary content to be sent. Provide `None` to have it
+        omitted.
         :param headers: dictionary of headers to be sent. Will be extended with
         `Content-Length` header, if `content` is not `None`.
         :return: url to navigate to in order to get the required response.


### PR DESCRIPTION
***Draft proposal.***

Addressing #575. 

Demo for an option "Dynamic server": http://go/chrome-devtools:mapper-test-http-server

Based on [`http.server`](https://docs.python.org/3/library/http.server.html), inspired by [ChromeDriver e2e test http server](https://source.chromium.org/chromium/chromium/src/+/main:chrome/test/chromedriver/test/webserver.py;drc=bdbfa8b9c04dbe680cbfb24f7ef81278c7be2604;l=131).

Static server for given parameters (http status code, headers, content) generates an URL, navigating to which provides a required response.

It can be extended with:
* Storing request data, so that it can be used for authentication verification.
* SSL certificate and domain aliases for testing OOPiF locally, but it is blocked on providing custom chrome-specific launch capabilities.