### PR TITLE
fix: use 0.5 for default radiusX and radiusY

### DIFF
--- a/src/bidiMapper/domains/input/ActionDispatcher.ts
+++ b/src/bidiMapper/domains/input/ActionDispatcher.ts
@@ -439,8 +439,8 @@ export class ActionDispatcher {
                     {
                       x,
                       y,
-                      radiusX: width && width / 2,
-                      radiusY: height && height / 2,
+                      radiusX: width ? width / 2 : 0.5,
+                      radiusY: height ? height / 2 : 0.5,
                       tangentialPressure,
                       tiltX,
                       tiltY,


### PR DESCRIPTION
The default in CDP (i.e. 1) causes the width to equal 2.