### PR TITLE
test: pytest `wait_for_event` helper: match prefixes

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -137,7 +137,6 @@ async def set_html_content(websocket, context_id: str, html_content: str):
         })
 
 
-# TODO: Rewrite this method in terms of wait_for_events.
 async def wait_for_event(websocket, event_method: str) -> dict:
     """
     Wait for and return a specific event prefix from BiDi server.
@@ -148,12 +147,7 @@ async def wait_for_event(websocket, event_method: str) -> dict:
         wait_for_event(websocket, "browsingContext.")
         wait_for_event(websocket, "browsingContext")
     """
-    logger.info(f"Waiting for event '{event_method}'...")
-    while True:
-        event_response = await read_JSON_message(websocket)
-        if "method" in event_response and event_response["method"].startswith(
-                event_method):
-            return event_response
+    return await wait_for_events(websocket, [event_method])
 
 
 async def wait_for_events(websocket, event_methods: list[str]) -> dict:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -139,12 +139,20 @@ async def set_html_content(websocket, context_id: str, html_content: str):
 
 # TODO: Rewrite this method in terms of wait_for_events.
 async def wait_for_event(websocket, event_method: str) -> dict:
-    """Wait and return a specific event from BiDi server."""
+    """
+    Wait for and return a specific event prefix from BiDi server.
+
+    The following examples match the `browsingContext.domContentLoaded` event:
+
+        wait_for_event(websocket, "browsingContext.domContentLoaded")
+        wait_for_event(websocket, "browsingContext.")
+        wait_for_event(websocket, "browsingContext")
+    """
     logger.info(f"Waiting for event '{event_method}'...")
     while True:
         event_response = await read_JSON_message(websocket)
-        if "method" in event_response and event_response[
-                "method"] == event_method:
+        if "method" in event_response and event_response["method"].startswith(
+                event_method):
             return event_response
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -157,12 +157,14 @@ async def wait_for_event(websocket, event_method: str) -> dict:
 
 
 async def wait_for_events(websocket, event_methods: list[str]) -> dict:
-    """Wait and return any of the given events from BiDi server."""
+    """Wait and return any of the given event prefixes from BiDi server."""
     logger.info(f"Waiting for any of the events '{event_methods}'...")
     while True:
         event_response = await read_JSON_message(websocket)
-        if "method" in event_response and event_response[
-                "method"] in event_methods:
+        if "method" in event_response and any([
+                event_response["method"].startswith(event_method)
+                for event_method in event_methods
+        ]):
             return event_response
 
 


### PR DESCRIPTION
This added syntactic sugar is more flexible when we want to wait for any event from a given domain, e.g. "cdp" or "network".