### PR TITLE
feat: unblock event queue when network events are blocked

### DIFF
--- a/src/bidiMapper/domains/context/CdpTarget.ts
+++ b/src/bidiMapper/domains/context/CdpTarget.ts
@@ -117,19 +117,6 @@ export class CdpTarget {
   }
 
   /**
-   * Calls `Fetch.disable` followed by `Fetch.enable`.
-   * The order is important. Do not use `Promise.all`.
-   *
-   * This is necessary because `Fetch.disable` removes all intercepts.
-   * In a situation where there are two or more intercepts and one of them is
-   * removed, the `Fetch.enable` call will restore the remaining intercepts.
-   */
-  async fetchApply() {
-    await this.fetchDisable();
-    await this.fetchEnable();
-  }
-
-  /**
    * Enables all the required CDP domains and unblocks the target.
    */
   async #unblock() {
@@ -143,7 +130,7 @@ export class CdpTarget {
         // XXX: #1080: Do not always enable the network domain globally.
         // TODO: enable Network domain for OOPiF targets.
         this.#cdpClient.sendCommand('Network.enable'),
-        this.fetchApply(),
+        this.fetchEnable(),
         this.#cdpClient.sendCommand('Target.setAutoAttach', {
           autoAttach: true,
           waitForDebuggerOnStart: true,

--- a/src/bidiMapper/domains/context/CdpTarget.ts
+++ b/src/bidiMapper/domains/context/CdpTarget.ts
@@ -130,6 +130,7 @@ export class CdpTarget {
         // XXX: #1080: Do not always enable the network domain globally.
         // TODO: enable Network domain for OOPiF targets.
         this.#cdpClient.sendCommand('Network.enable'),
+        // XXX: #1080: Do not always enable the fetch domain globally.
         this.fetchEnable(),
         this.#cdpClient.sendCommand('Target.setAutoAttach', {
           autoAttach: true,

--- a/src/bidiMapper/domains/network/NetworkProcessor.ts
+++ b/src/bidiMapper/domains/network/NetworkProcessor.ts
@@ -147,7 +147,7 @@ export class NetworkProcessor {
   async #applyIntercepts() {
     await Promise.all(
       this.#browsingContextStorage.getAllContexts().map(async (context) => {
-        await context.cdpTarget.fetchApply();
+        await context.cdpTarget.fetchEnable();
       })
     );
   }

--- a/src/bidiMapper/domains/network/NetworkProcessor.ts
+++ b/src/bidiMapper/domains/network/NetworkProcessor.ts
@@ -95,8 +95,6 @@ export class NetworkProcessor {
 
     this.#networkStorage.removeBlockedRequest(networkId);
 
-    // TODO: Emit event?
-
     return {};
   }
 
@@ -126,8 +124,6 @@ export class NetworkProcessor {
       ?.failRequest(fetchId, 'Failed');
 
     this.#networkStorage.removeBlockedRequest(networkId);
-
-    // TODO: Emit event?
 
     return {};
   }

--- a/src/bidiMapper/domains/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.spec.ts
@@ -117,6 +117,35 @@ describe('NetworkStorage', () => {
         2
       );
     });
+
+    it('is idempotent', () => {
+      const intercept1 = networkStorage.addIntercept({
+        urlPatterns: [
+          {
+            type: 'string',
+            pattern: 'http://example.com',
+          },
+        ],
+        phases: [Network.InterceptPhase.BeforeRequestSent],
+      });
+      const intercept2 = networkStorage.addIntercept({
+        urlPatterns: [
+          {
+            type: 'string',
+            pattern: 'http://example.com',
+          },
+        ],
+        phases: [Network.InterceptPhase.BeforeRequestSent],
+      });
+
+      expect(intercept1).to.match(UUID_REGEX);
+      expect(intercept2).to.match(UUID_REGEX);
+      expect(intercept1).to.be.equal(intercept2);
+
+      expect(networkStorage.getFetchEnableParams().patterns).to.have.lengthOf(
+        1
+      );
+    });
   });
 
   it('remove intercept', () => {

--- a/src/bidiMapper/domains/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.spec.ts
@@ -137,6 +137,51 @@ describe('NetworkStorage', () => {
     });
   });
 
+  it('has intercepts', () => {
+    expect(networkStorage.hasIntercepts()).to.be.false;
+
+    const intercept = networkStorage.addIntercept({
+      urlPatterns: [
+        {
+          type: 'string',
+          pattern: 'http://example.com',
+        },
+      ],
+      phases: [Network.InterceptPhase.BeforeRequestSent],
+    });
+
+    expect(networkStorage.hasIntercepts()).to.be.true;
+
+    networkStorage.removeIntercept(intercept);
+    expect(networkStorage.hasIntercepts()).to.be.false;
+  });
+
+  it('has blocked requests', () => {
+    expect(networkStorage.hasBlockedRequests()).to.be.false;
+
+    networkStorage.addBlockedRequest('REQUEST_ID', {
+      request: '1',
+      phase: Network.InterceptPhase.BeforeRequestSent,
+      response: {
+        url: '',
+        protocol: '',
+        status: 0,
+        statusText: '',
+        fromCache: false,
+        headers: [],
+        mimeType: '',
+        bytesReceived: 0,
+        headersSize: 0,
+        bodySize: 0,
+        content: {
+          size: 0,
+        },
+      },
+    });
+
+    expect(networkStorage.hasBlockedRequests()).to.be.true;
+  });
+
   describe('getFetchEnableParams', () => {
     it('no intercepts', () => {
       expect(networkStorage.getFetchEnableParams()).to.deep.equal({

--- a/src/bidiMapper/domains/network/NetworkStorage.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.ts
@@ -82,8 +82,20 @@ export class NetworkStorage {
     urlPatterns: Network.UrlPattern[];
     phases: Network.InterceptPhase[];
   }): Network.Intercept {
-    const interceptId: Network.Intercept = uuidv4();
+    // Check if the given intercept entry already exists.
+    for (const [
+      interceptId,
+      {urlPatterns, phases},
+    ] of this.#interceptMap.entries()) {
+      if (
+        JSON.stringify(value.urlPatterns) === JSON.stringify(urlPatterns) &&
+        JSON.stringify(value.phases) === JSON.stringify(phases)
+      ) {
+        return interceptId;
+      }
+    }
 
+    const interceptId: Network.Intercept = uuidv4();
     this.#interceptMap.set(interceptId, value);
 
     return interceptId;

--- a/src/bidiMapper/domains/network/NetworkStorage.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.ts
@@ -103,6 +103,11 @@ export class NetworkStorage {
     this.#interceptMap.delete(intercept);
   }
 
+  /** Returns true iff there's at least one added intercept. */
+  hasIntercepts() {
+    return this.#interceptMap.size > 0;
+  }
+
   /** Gets parameters for CDP 'Fetch.enable' command from the intercept map. */
   getFetchEnableParams(): Protocol.Fetch.EnableRequest {
     const patterns: Protocol.Fetch.RequestPattern[] = [];
@@ -144,6 +149,11 @@ export class NetworkStorage {
       request.dispose();
       this.#requestMap.delete(id);
     }
+  }
+
+  /** Returns true iff there's at least one blocked network request. */
+  hasBlockedRequests() {
+    return this.#blockedRequestMap.size > 0;
   }
 
   /** Converts a URL pattern from the spec to a CDP URL pattern. */

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,16 @@ def auth_required_url():
     # All of these URLs work, just pick one.
     # url = "https://authenticationtest.com/HTTPAuth/"
     # url = "http://the-internet.herokuapp.com/basic_auth"
+    pytest.skip(reason='TODO: Use our own test server.')
     return "http://httpstat.us/401"
+
+
+@pytest.fixture
+def hang_url():
+    # TODO: Start a local server alongside tests that use this fixture.
+    """Return a URL that hangs forever."""
+    pytest.skip(reason='TODO: Use our own test server.')
+    return "http://127.0.0.1:5000/hang"
 
 
 @pytest.fixture

--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -300,5 +300,4 @@ async def create_dummy_blocked_request(
     return network_id
 
 
-# TODO: AuthRequired + exception test
 # TODO: assertion with isBlocked: true

--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -301,3 +301,4 @@ async def create_dummy_blocked_request(
 
 
 # TODO: assertion with isBlocked: true
+# TODO: Replace cdp.Network.loadingFailed with network.fetchError BiDi event when it is implemented?

--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -354,5 +354,4 @@ async def create_dummy_blocked_request(
     return network_id
 
 
-# TODO: assertion with isBlocked: true
 # TODO: Replace cdp.Network.loadingFailed with network.fetchError BiDi event when it is implemented?

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -208,7 +208,7 @@ async def test_fail_request_with_auth_required_phase(
 
     network_event_response = await wait_for_event(websocket,
                                                   "network.beforeRequestSent")
-    assert network_event_response == AnyExtending({
+    assert network_event_response == {
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -231,7 +231,7 @@ async def test_fail_request_with_auth_required_phase(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    })
+    }
     network_id_from_bidi_event = network_event_response["params"]["request"][
         "request"]
 
@@ -313,7 +313,7 @@ async def test_fail_request_completes(websocket, context_id, example_url):
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == AnyExtending({
+    assert event_response == {
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -336,7 +336,7 @@ async def test_fail_request_completes(websocket, context_id, example_url):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    })
+    }
     network_id = event_response["params"]["request"]["request"]
 
     await subscribe(websocket, ["cdp.Network.loadingFailed"])
@@ -400,7 +400,7 @@ async def test_fail_request_completes_new_request_still_blocks(
 
     event_response1 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response1 == AnyExtending({
+    assert event_response1 == {
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -423,7 +423,7 @@ async def test_fail_request_completes_new_request_still_blocks(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    })
+    }
     network_id_1 = event_response1["params"]["request"]["request"]
 
     await subscribe(websocket, ["cdp.Network.loadingFailed"])
@@ -466,7 +466,7 @@ async def test_fail_request_completes_new_request_still_blocks(
 
     event_response2 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response2 == AnyExtending({
+    assert event_response2 == {
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -489,7 +489,7 @@ async def test_fail_request_completes_new_request_still_blocks(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    })
+    }
     network_id_2 = event_response2["params"]["request"]["request"]
 
     assert event_response1 != event_response2
@@ -531,7 +531,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
 
     event_response1 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response1 == AnyExtending({
+    assert event_response1 == {
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -554,7 +554,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    })
+    }
     network_id_1 = event_response1["params"]["request"]["request"]
 
     # Navigation in second context.
@@ -569,7 +569,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
 
     event_response2 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response2 == AnyExtending({
+    assert event_response2 == {
         "method": "network.beforeRequestSent",
         "params": {
             "context": another_context_id,
@@ -592,7 +592,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    })
+    }
     network_id_2 = event_response2["params"]["request"]["request"]
 
     assert network_id_1 != network_id_2

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -652,3 +652,93 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
         },
         "type": "event",
     }
+
+
+@pytest.mark.asyncio
+async def test_fail_request_remove_intercept_inflight_request(
+        websocket, context_id, example_url):
+    await subscribe(websocket, ["cdp.Fetch.requestPaused"])
+
+    result = await execute_command(
+        websocket, {
+            "method": "network.addIntercept",
+            "params": {
+                "phases": ["beforeRequestSent"],
+                "urlPatterns": [{
+                    "type": "string",
+                    "pattern": example_url,
+                }, ],
+            },
+        })
+
+    assert result == {
+        "intercept": ANY_UUID,
+    }
+    intercept_id = result["intercept"]
+
+    await send_JSON_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "url": example_url,
+                "context": context_id,
+            }
+        })
+
+    event_response = await wait_for_event(websocket, "cdp.Fetch.requestPaused")
+    assert event_response == {
+        "method": "cdp.Fetch.requestPaused",
+        "params": {
+            "event": "Fetch.requestPaused",
+            "params": {
+                "frameId": context_id,
+                "networkId": ANY_STR,
+                "request": AnyExtending({
+                    "headers": ANY_DICT,
+                    "url": example_url,
+                }),
+                "requestId": ANY_STR,
+                "resourceType": "Document",
+            },
+            "session": ANY_STR,
+        },
+        "type": "event",
+    }
+    network_id = event_response["params"]["params"]["networkId"]
+
+    result = await execute_command(
+        websocket, {
+            "method": "network.removeIntercept",
+            "params": {
+                "intercept": intercept_id,
+            },
+        })
+    assert result == {}
+
+    await subscribe(websocket, ["cdp.Network.loadingFailed"])
+
+    result = await execute_command(websocket, {
+        "method": "network.failRequest",
+        "params": {
+            "request": network_id,
+        },
+    })
+    assert result == {}
+
+    loading_failed_response = await wait_for_event(
+        websocket, "cdp.Network.loadingFailed")
+    assert loading_failed_response == {
+        "method": "cdp.Network.loadingFailed",
+        "params": {
+            "event": "Network.loadingFailed",
+            "params": {
+                "canceled": False,
+                "errorText": "net::ERR_FAILED",
+                "requestId": network_id,
+                "timestamp": ANY_NUMBER,
+                "type": "Document",
+            },
+            "session": ANY_STR,
+        },
+        "type": "event",
+    }

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -749,3 +749,6 @@ async def test_fail_request_remove_intercept_inflight_request(
         },
         "type": "event",
     }
+
+
+# TODO: Replace cdp.Network.loadingFailed with network.fetchError BiDi event when it is implemented?

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -37,12 +37,9 @@ async def test_fail_request_non_existent_request(websocket):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="TODO: replace url with a server whose requests hang forever.")
 async def test_fail_request_non_blocked_request(websocket, context_id,
-                                                assert_no_events_in_queue):
-    url = "http://127.0.0.1:5000/hang"
-
+                                                assert_no_events_in_queue,
+                                                hang_url):
     await subscribe(websocket, [
         "network.beforeRequestSent", "cdp.Network.responseReceived",
         "cdp.Network.loadingFailed"
@@ -53,7 +50,7 @@ async def test_fail_request_non_blocked_request(websocket, context_id,
             "method": "browsingContext.navigate",
             "params": {
                 "context": context_id,
-                "url": url,
+                "url": hang_url,
                 "wait": "complete",
             }
         })
@@ -178,7 +175,6 @@ async def test_fail_request_twice(websocket, context_id, example_url):
                              "beforeRequestSent",
                              "beforeRequestSent and authRequired",
                          ])
-@pytest.mark.skip(reason="TODO: Use our own test server.")
 async def test_fail_request_with_auth_required_phase(
         websocket, context_id, phases, exception_and_response_expected,
         auth_required_url):


### PR DESCRIPTION
Furthermore, update some E2E tests so that they do not rely on CDP events.

Bug #644, #1080
Co-authored-by: Maksim Sadym <sadym@chromium.org>

Re-created from #1400.