### PR TITLE
misc: Set `selfTargetId` via `evaluate`

### DIFF
--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -112,7 +112,7 @@ export class BrowserInstance extends EventEmitter<Record<'message', string>> {
       cdpEndpoint
     );
 
-    // 2. Get `BiDi-CDP` mapper JS binaries using `readMapperTabFile`.
+    // 2. Get `BiDi-CDP` mapper JS binaries.
     const mapperTabSource = await getMapperTabSource();
 
     // 3. Run `BiDi-CDP` mapper in launched browser using `MapperRunner`.

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -36,7 +36,7 @@ import {WebSocketTransport} from '../utils/WebsocketTransport.js';
 import {EventEmitter} from '../utils/EventEmitter.js';
 
 import {MapperCdpConnection} from './MapperCdpConnection.js';
-import {readMapperTabFile} from './reader.js';
+import {getMapperTabSource} from './reader.js';
 
 const debugInternal = debug('bidi:mapper:internal');
 
@@ -113,12 +113,12 @@ export class BrowserInstance extends EventEmitter<Record<'message', string>> {
     );
 
     // 2. Get `BiDi-CDP` mapper JS binaries using `readMapperTabFile`.
-    const bidiMapperScript = await readMapperTabFile();
+    const mapperTabSource = await getMapperTabSource();
 
     // 3. Run `BiDi-CDP` mapper in launched browser using `MapperRunner`.
     const mapperCdpConnection = await MapperCdpConnection.create(
       cdpConnection,
-      bidiMapperScript,
+      mapperTabSource,
       verbose
     );
 

--- a/src/bidiServer/reader.ts
+++ b/src/bidiServer/reader.ts
@@ -18,6 +18,6 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-export async function readMapperTabFile(): Promise<string> {
+export async function getMapperTabSource(): Promise<string> {
   return fs.readFile(path.join(__dirname, '../../iife/mapperTab.js'), 'utf8');
 }

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -59,7 +59,7 @@ const cdpTransport = new WindowCdpTransport();
  * @param selfTargetId Needed to filter out info related to BiDi target.
  */
 window.runMapperInstance = async (selfTargetId) => {
-  console.log('Launching Mapper instance with selfTargetId: ', selfTargetId);
+  console.log('Launching Mapper instance with selfTargetId:', selfTargetId);
 
   await BidiServer.createAndStart(
     mapperTabToServerTransport,

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -50,32 +50,30 @@ declare global {
   }
 }
 
-void (async () => {
-  generatePage();
-  const mapperTabToServerTransport = new WindowBidiTransport();
-  const cdpTransport = new WindowCdpTransport();
+generatePage();
+const mapperTabToServerTransport = new WindowBidiTransport();
+const cdpTransport = new WindowCdpTransport();
 
-  /**
-   * Launches the BiDi mapper.
-   * @param selfTargetId Needed to filter out info related to BiDi target.
-   */
-  window.runMapper = async (selfTargetId) => {
-    console.log('launching with selfTargetId: ', selfTargetId);
+/**
+ * Set `window.runMapper` to a function which launches the BiDi mapper instance.
+ * @param selfTargetId Needed to filter out info related to BiDi target.
+ */
+window.runMapper = async (selfTargetId) => {
+  console.log('launching with selfTargetId: ', selfTargetId);
 
-    await BidiServer.createAndStart(
-      mapperTabToServerTransport,
-      /**
-       * A CdpTransport implementation that uses the window.cdp bindings
-       * injected by Target.exposeDevToolsProtocol.
-       */
-      new CdpConnection(cdpTransport, log),
-      selfTargetId,
-      new BidiParser(),
-      log
-    );
+  await BidiServer.createAndStart(
+    mapperTabToServerTransport,
+    /**
+     * A CdpTransport implementation that uses the window.cdp bindings
+     * injected by Target.exposeDevToolsProtocol.
+     */
+    new CdpConnection(cdpTransport, log),
+    selfTargetId,
+    new BidiParser(),
+    log
+  );
 
-    log(LogType.debugInfo, 'Launched');
+  log(LogType.debugInfo, 'Launched');
 
-    return 'launched';
-  };
-})();
+  return 'launched';
+};

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -17,7 +17,7 @@
  * @license
  */
 
-import {BidiServer, OutgoingMessage} from '../bidiMapper/BidiMapper.js';
+import {BidiServer} from '../bidiMapper/BidiMapper.js';
 import {CdpConnection} from '../cdp/CdpConnection.js';
 import {LogType} from '../utils/log.js';
 
@@ -27,6 +27,11 @@ import {generatePage, log} from './mapperTabPage.js';
 
 declare global {
   interface Window {
+    // `runMapper` function will be defined by the Mapper in the Tab, and will
+    // be evaluated via `Runtime.evaluate` by the Node runner, providing all the
+    // required parameters.
+    runMapper: ((...args: any) => Promise<string>) | null;
+
     // `window.cdp` is exposed by `Target.exposeDevToolsProtocol` from the server side.
     // https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-exposeDevToolsProtocol
     cdp: {
@@ -42,49 +47,35 @@ declare global {
 
     // Set from the server side if verbose logging is required.
     sendDebugMessage?: ((message: string) => void) | null;
-
-    // `window.setSelfTargetId` is called via `Runtime.evaluate` from the server side.
-    setSelfTargetId: (targetId: string) => void;
   }
 }
 
-// Initiate `setSelfTargetId` as soon as possible to prevent race condition.
-const waitSelfTargetIdPromise = waitSelfTargetId();
-
 void (async () => {
   generatePage();
+  const mapperTabToServerTransport = new WindowBidiTransport();
+  const cdpTransport = new WindowCdpTransport();
 
-  // Needed to filter out info related to BiDi target.
-  const selfTargetId = await waitSelfTargetIdPromise;
+  /**
+   * Launches the BiDi mapper.
+   * @param selfTargetId Needed to filter out info related to BiDi target.
+   */
+  window.runMapper = async (selfTargetId) => {
+    console.log('launching with selfTargetId: ', selfTargetId);
 
-  const bidiServer = await BidiServer.createAndStart(
-    new WindowBidiTransport(),
-    /**
-     * A CdpTransport implementation that uses the window.cdp bindings
-     * injected by Target.exposeDevToolsProtocol.
-     */
-    new CdpConnection(new WindowCdpTransport(), log),
-    selfTargetId,
-    new BidiParser(),
-    log
-  );
+    await BidiServer.createAndStart(
+      mapperTabToServerTransport,
+      /**
+       * A CdpTransport implementation that uses the window.cdp bindings
+       * injected by Target.exposeDevToolsProtocol.
+       */
+      new CdpConnection(cdpTransport, log),
+      selfTargetId,
+      new BidiParser(),
+      log
+    );
 
-  log(LogType.debugInfo, 'Launched');
+    log(LogType.debugInfo, 'Launched');
 
-  bidiServer.emitOutgoingMessage(
-    OutgoingMessage.createResolved({
-      launched: true,
-    }),
-    'launched'
-  );
+    return 'launched';
+  };
 })();
-
-// Needed to filter out info related to BiDi target.
-async function waitSelfTargetId(): Promise<string> {
-  return new Promise((resolve) => {
-    window.setSelfTargetId = (targetId) => {
-      log(LogType.debugInfo, 'Current target ID:', targetId);
-      resolve(targetId);
-    };
-  });
-}

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -30,7 +30,7 @@ declare global {
     // `runMapper` function will be defined by the Mapper in the Tab, and will
     // be evaluated via `Runtime.evaluate` by the Node runner, providing all the
     // required parameters.
-    runMapper: ((...args: any) => Promise<string>) | null;
+    runMapperInstance: ((...args: any) => Promise<void>) | null;
 
     // `window.cdp` is exposed by `Target.exposeDevToolsProtocol` from the server side.
     // https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-exposeDevToolsProtocol
@@ -58,8 +58,8 @@ const cdpTransport = new WindowCdpTransport();
  * Set `window.runMapper` to a function which launches the BiDi mapper instance.
  * @param selfTargetId Needed to filter out info related to BiDi target.
  */
-window.runMapper = async (selfTargetId) => {
-  console.log('launching with selfTargetId: ', selfTargetId);
+window.runMapperInstance = async (selfTargetId) => {
+  console.log('Launching Mapper instance with selfTargetId: ', selfTargetId);
 
   await BidiServer.createAndStart(
     mapperTabToServerTransport,
@@ -73,7 +73,5 @@ window.runMapper = async (selfTargetId) => {
     log
   );
 
-  log(LogType.debugInfo, 'Launched');
-
-  return 'launched';
+  log(LogType.debugInfo, 'Mapper instance has been launched');
 };


### PR DESCRIPTION
Preparation for multiple session support. http://go/webdriver:bidi-multiple-sessions-proposal

**_Step 1._** Simplify launching process. 

Switch Mapper Tab launch into 2 phases:
* Prepare all the handlers and transports.
* Launch the Mapper instance with some parameters (`selfTargetId ` for now).