### PR TITLE
ci: introduce dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,31 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      all:
+        patterns:
+          - '*'
   - package-ecosystem: pip
     directory: examples/
     schedule:
       interval: monthly
+    groups:
+      all:
+        patterns:
+          - '*'
   - package-ecosystem: pip
     directory: tests/
     schedule:
       interval: monthly
+    groups:
+      all:
+        patterns:
+          - '*'
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
+    groups:
+      all:
+        patterns:
+          - '*'


### PR DESCRIPTION
Instead of receiving dozens of PRs per month, each one for an individual dependency, have dependabot group PRs into a single one per ecosystem.

Inspired by https://github.com/puppeteer/puppeteer/pull/11126

Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups