### PR TITLE
test: use local http server when possible

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,42 +135,38 @@ def url_cross_origin(request):
     'data:text/html,<h2>child page</h2>',  # Data URL: Cross-origin
 ])
 def url_all_origins(request):
-    """Return an URL exhaustively, including same-origin and cross-origin."""
+    """Return a URL exhaustively, including same-origin and cross-origin."""
     return request.param
 
 
 @pytest.fixture
-def example_url():
+def example_url(local_server: LocalHttpServer):
     """Return a generic example URL with status code 200."""
-    # TODO: Switch to a local server so that it works off-line.
-    # Alternatively: https://www.example.org/
-    return "https://www.example.com/"
+    return local_server.url_200()
 
 
 @pytest.fixture
-def another_example_url():
-    # TODO: Switch to a local server so that it works off-line.
-    """Return a generic example URL with status code 200, in a domain other than the example_url fixture."""
-    return "https://www.example.org/"
+def another_example_url(local_server: LocalHttpServer):
+    """Return a generic example URL with status code 200, in a domain other than
+    the example_url fixture."""
+    return local_server.url_200('127.0.0.1')
 
 
 @pytest.fixture
-def auth_required_url():
+def auth_required_url(local_server: LocalHttpServer):
     """Return a URL that requires authentication (status code 401)."""
-    # TODO: Switch to a local server so that it works off-line.
     # All of these URLs work, just pick one.
     # url = "https://authenticationtest.com/HTTPAuth/"
     # url = "http://the-internet.herokuapp.com/basic_auth"
     pytest.skip(reason='TODO: Use our own test server.')
-    return "http://httpstat.us/401"
+    return local_server.url_basic_auth()
 
 
 @pytest.fixture
-def hang_url():
-    # TODO: Start a local server alongside tests that use this fixture.
+def hang_url(local_server: LocalHttpServer):
     """Return a URL that hangs forever."""
     pytest.skip(reason='TODO: Use our own test server.')
-    return "http://127.0.0.1:5000/hang"
+    return local_server.url_hang_forever()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,6 @@ async def websocket():
     url = f"ws://localhost:{port}"
     async with websockets.connect(url) as connection:
         yield connection
-        await execute_command(connection, {
-            "method": "browser.close",
-            "params": {}
-        })
 
 
 @pytest_asyncio.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,7 @@ def auth_required_url(local_server: LocalHttpServer):
     # All of these URLs work, just pick one.
     # url = "https://authenticationtest.com/HTTPAuth/"
     # url = "http://the-internet.herokuapp.com/basic_auth"
+    # url = "http://httpstat.us/401"
     pytest.skip(reason='TODO: Use our own test server.')
     return local_server.url_basic_auth()
 

--- a/tests/network/test_add_intercept.py
+++ b/tests/network/test_add_intercept.py
@@ -14,9 +14,8 @@
 #  limitations under the License.
 import pytest
 from anys import ANY_DICT, ANY_LIST, ANY_STR
-from test_helpers import (ANY_TIMESTAMP, ANY_UUID, AnyExtending,
-                          execute_command, send_JSON_command, subscribe,
-                          wait_for_event)
+from test_helpers import (ANY_TIMESTAMP, ANY_UUID, execute_command,
+                          send_JSON_command, subscribe, wait_for_event)
 
 
 @pytest.mark.asyncio
@@ -257,122 +256,49 @@ async def test_add_intercept_type_pattern_port_empty_invalid(websocket):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("url_patterns", [
-    [
-        {
-            "type": "string",
-            "pattern": "https://www.example.com/",
-        },
-    ],
-    [
-        {
-            "type": "pattern",
-            "protocol": "https",
-            "hostname": "www.example.com",
-            "pathname": "/",
-        },
-    ],
-    [
-        {
-            "type": "string",
-            "pattern": "https://www.example.com/",
-        },
-        {
-            "type": "pattern",
-            "protocol": "https",
-            "hostname": "www.example.com",
-            "pathname": "/",
-        },
-    ],
-],
-                         ids=[
-                             "string",
-                             "pattern",
-                             "string and pattern",
-                         ])
-async def test_add_intercept_blocks_use_cdp_events(websocket, context_id,
-                                                   url_patterns, example_url):
-    await subscribe(websocket, ["cdp.Fetch.requestPaused"])
-
-    result = await execute_command(
-        websocket, {
-            "method": "network.addIntercept",
-            "params": {
-                "phases": ["beforeRequestSent"],
-                "urlPatterns": url_patterns,
-            },
-        })
-
-    assert result == {
-        "intercept": ANY_UUID,
-    }
-
-    await send_JSON_command(
-        websocket, {
-            "method": "browsingContext.navigate",
-            "params": {
-                "url": example_url,
-                "context": context_id,
-            }
-        })
-
-    event_response = await wait_for_event(websocket, "cdp.Fetch.requestPaused")
-    assert event_response == {
-        "method": "cdp.Fetch.requestPaused",
-        "params": {
-            "event": "Fetch.requestPaused",
-            "params": {
-                "frameId": context_id,
-                "networkId": ANY_STR,
-                "request": AnyExtending({
-                    "headers": ANY_DICT,
-                    "url": example_url,
-                }),
-                "requestId": ANY_STR,
-                "resourceType": "Document",
-            },
-            "session": ANY_STR,
-        },
-        "type": "event",
-    }
+async def test_add_intercept_blocks_by_string(websocket, context_id,
+                                              example_url):
+    await assert_add_intercept_blocks_requests(websocket, context_id, [{
+        "type": "string",
+        "pattern": example_url,
+    }], example_url)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("url_patterns", [
-    [
-        {
+async def test_add_intercept_blocks_by_pattern(websocket, context_id,
+                                               example_url):
+    await assert_add_intercept_blocks_requests(
+        websocket, context_id, [get_pattern_filter(example_url)], example_url)
+
+
+@pytest.mark.asyncio
+async def test_add_intercept_blocks_by_string_and_pattern(
+        websocket, context_id, example_url):
+    await assert_add_intercept_blocks_requests(
+        websocket, context_id, [{
             "type": "string",
-            "pattern": "https://www.example.com/",
+            "pattern": example_url,
         },
-    ],
-    [
-        {
-            "type": "pattern",
-            "protocol": "https",
-            "hostname": "www.example.com",
-            "pathname": "/",
-        },
-    ],
-    [
-        {
-            "type": "string",
-            "pattern": "https://www.example.com/",
-        },
-        {
-            "type": "pattern",
-            "protocol": "https",
-            "hostname": "www.example.com",
-            "pathname": "/",
-        },
-    ],
-],
-                         ids=[
-                             "string",
-                             "pattern",
-                             "string and pattern",
-                         ])
-async def test_add_intercept_blocks_use_bidi_events(websocket, context_id,
-                                                    url_patterns, example_url):
+                                get_pattern_filter(example_url)], example_url)
+
+
+def get_pattern_filter(url):
+    protocol = url.split("://")[0]
+    hostname = url.split("://")[1].split("/")[0].split(":")[0]
+    port = url.split("://")[1].split("/")[0].split(":")[1]
+    pathname = "/" + url.split("://")[1].split("/")[1]
+
+    return {
+        "type": "pattern",
+        "protocol": protocol,
+        "hostname": hostname,
+        "port": port,
+        "pathname": pathname,
+    }
+
+
+async def assert_add_intercept_blocks_requests(websocket, context_id,
+                                               url_patterns, example_url):
     await subscribe(websocket, ["network.beforeRequestSent"])
 
     result = await execute_command(

--- a/tests/network/test_add_intercept.py
+++ b/tests/network/test_add_intercept.py
@@ -291,7 +291,9 @@ async def test_add_intercept_type_pattern_port_empty_invalid(websocket):
                              "string and pattern",
                          ])
 async def test_add_intercept_blocks_use_cdp_events(websocket, context_id,
-                                                   url_patterns, example_url):
+                                                   url_patterns):
+    # TODO: make offline
+    example_url = "https://www.example.com/"
     await subscribe(websocket, ["cdp.Fetch.requestPaused"])
 
     result = await execute_command(
@@ -372,7 +374,9 @@ async def test_add_intercept_blocks_use_cdp_events(websocket, context_id,
                              "string and pattern",
                          ])
 async def test_add_intercept_blocks_use_bidi_events(websocket, context_id,
-                                                    url_patterns, example_url):
+                                                    url_patterns):
+    # TODO: make offline
+    example_url = "https://www.example.com/"
     await subscribe(websocket, ["network.beforeRequestSent"])
 
     result = await execute_command(

--- a/tests/network/test_remove_intercept.py
+++ b/tests/network/test_remove_intercept.py
@@ -112,7 +112,9 @@ async def test_remove_intercept_twice(websocket):
                          ])
 @pytest.mark.asyncio
 async def test_remove_intercept_unblocks_use_cdp_events(
-        websocket, context_id, another_context_id, url_patterns, example_url):
+        websocket, context_id, another_context_id, url_patterns):
+    # TODO: make offline
+    example_url = "https://www.example.com/"
     await subscribe(websocket, ["cdp.Fetch.requestPaused"])
     await subscribe(websocket, ["network"], [another_context_id])
 
@@ -242,7 +244,9 @@ async def test_remove_intercept_unblocks_use_cdp_events(
                          ])
 @pytest.mark.asyncio
 async def test_remove_intercept_unblocks_use_bidi_events(
-        websocket, context_id, another_context_id, url_patterns, example_url):
+        websocket, context_id, another_context_id, url_patterns):
+    # TODO: make offline
+    example_url = "https://www.example.com/"
     await subscribe(websocket, ["network.beforeRequestSent"], [context_id])
     await subscribe(websocket, ["network"], [another_context_id])
 

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -76,20 +76,44 @@ class LocalHttpServer:
         self.__http_server.expect_request(self.__path_hang_forever) \
             .respond_with_handler(hang_forever)
 
-    def url_200(self) -> str:
+    def _url_for(self, suffix: str, host: str = 'localhost') -> str:
+        """
+        Return an url for a given suffix.
+
+        Implementation is the same as the original one, but with a customizable
+        host: https://github.com/csernazs/pytest-httpserver/blob/8110d9d543de3b7c151bc1b5c8e85c01b05b226d/pytest_httpserver/httpserver.py#L665
+        :param suffix: the suffix which will be added to the base url. It can
+            start with ``/`` (slash) or not, the url will be the same.
+        :param host: the host to use in the url. Default is ``localhost``.
+        :return: the full url which refers to the server
+        """
+        if self.__http_server.ssl_context is None:
+            protocol = "http"
+        else:
+            protocol = "https"
+
+        if not suffix.startswith("/"):
+            suffix = "/" + suffix
+
+        host = self.__http_server.format_host(host)
+
+        return "{}://{}:{}{}".format(protocol, host, self.__http_server.port,
+                                     suffix)
+
+    def url_200(self, host='localhost') -> str:
         """Returns the url for the 200 page with the `default_200_page_content`.
         """
-        return self.__http_server.url_for(self.__path_200)
+        return self._url_for(self.__path_200, host)
 
     def url_permanent_redirect(self) -> str:
         """Returns the url for the permanent redirect page, redirecting to the
         200 page."""
-        return self.__http_server.url_for(self.__path_permanent_redirect)
+        return self._url_for(self.__path_permanent_redirect)
 
     def url_basic_auth(self) -> str:
         """Returns the url for the page with a basic auth."""
-        return self.__http_server.url_for(self.__path_basic_auth)
+        return self._url_for(self.__path_basic_auth)
 
     def url_hang_forever(self) -> str:
         """Returns the url for the page, request to which will never be finished."""
-        return self.__http_server.url_for(self.__path_hang_forever)
+        return self._url_for(self.__path_hang_forever)


### PR DESCRIPTION
Switch from `example.com` to local http server when possible.

Out of scope: 
* hardcoded addresses in url patterns.

Bug: #575