### PR TITLE
refactor: Extract BiDi session in server runner

### DIFF
--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -141,8 +141,8 @@ export class BrowserInstance {
     await this.#browserProcess.close();
   }
 
-  get bidiSession(): SimpleTransport {
-    return this.#mapperCdpConnection.bidiSession;
+  bidiSession(): SimpleTransport {
+    return this.#mapperCdpConnection.bidiSession();
   }
 
   static #establishCdpConnection(cdpUrl: string): Promise<CdpConnection> {

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -36,7 +36,7 @@ import {WebSocketTransport} from '../utils/WebsocketTransport.js';
 
 import {MapperCdpConnection} from './MapperCdpConnection.js';
 import {getMapperTabSource} from './reader.js';
-import {SimpleTransport} from './SimpleTransport';
+import {SimpleTransport} from './SimpleTransport.js';
 
 const debugInternal = debug('bidi:mapper:internal');
 

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -33,10 +33,10 @@ import WebSocket from 'ws';
 
 import {CdpConnection} from '../cdp/CdpConnection.js';
 import {WebSocketTransport} from '../utils/WebsocketTransport.js';
-import {EventEmitter} from '../utils/EventEmitter.js';
 
 import {MapperCdpConnection} from './MapperCdpConnection.js';
 import {getMapperTabSource} from './reader.js';
+import {SimpleTransport} from './SimpleTransport';
 
 const debugInternal = debug('bidi:mapper:internal');
 
@@ -49,7 +49,7 @@ const debugInternal = debug('bidi:mapper:internal');
  * 4. Bind `BiDi-CDP` mapper to the `BiDi server` to forward messages from BiDi
  * Mapper to the client.
  */
-export class BrowserInstance extends EventEmitter<Record<'message', string>> {
+export class BrowserInstance {
   #mapperCdpConnection: MapperCdpConnection;
   #browserProcess: Process;
 
@@ -122,32 +122,15 @@ export class BrowserInstance extends EventEmitter<Record<'message', string>> {
       verbose
     );
 
-    const browserInstance = new BrowserInstance(
-      mapperCdpConnection,
-      browserProcess
-    );
-
-    // 4. Bind `BiDi-CDP` mapper to the `BiDi server` to forward messages from
-    // BiDi Mapper to the client.
-    mapperCdpConnection.on('message', (message) => {
-      browserInstance.emit('message', message);
-    });
-
-    return browserInstance;
+    return new BrowserInstance(mapperCdpConnection, browserProcess);
   }
 
   constructor(
     mapperCdpConnection: MapperCdpConnection,
     browserProcess: Process
   ) {
-    super();
     this.#mapperCdpConnection = mapperCdpConnection;
     this.#browserProcess = browserProcess;
-  }
-
-  // Forward messages from the client to BiDi Mapper.
-  async sendCommand(plainCommand: string) {
-    await this.#mapperCdpConnection.sendMessage(plainCommand);
   }
 
   async close() {
@@ -156,6 +139,10 @@ export class BrowserInstance extends EventEmitter<Record<'message', string>> {
 
     // Close browser.
     await this.#browserProcess.close();
+  }
+
+  get bidiSession(): SimpleTransport {
+    return this.#mapperCdpConnection.bidiSession;
   }
 
   static #establishCdpConnection(cdpUrl: string): Promise<CdpConnection> {

--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -21,7 +21,7 @@ import debug, {type Debugger} from 'debug';
 import type {CdpConnection} from '../cdp/CdpConnection.js';
 import type {CdpClient} from '../cdp/CdpClient.js';
 import type {LogPrefix, LogType} from '../utils/log.js';
-import {SimpleTransport} from './SimpleTransport';
+import {SimpleTransport} from './SimpleTransport.js';
 
 const debugInternal = debug('bidi:mapper:internal');
 const debugInfo = debug('bidi:mapper:info');

--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -97,7 +97,7 @@ export class MapperCdpConnection {
     this.#cdpConnection.close();
   }
 
-  get bidiSession(): SimpleTransport {
+  bidiSession(): SimpleTransport {
     return this.#bidiSession;
   }
 

--- a/src/bidiServer/SimpleTransport.ts
+++ b/src/bidiServer/SimpleTransport.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {EventEmitter} from '../utils/EventEmitter';
+
+export class SimpleTransport extends EventEmitter<Record<'message', string>> {
+  readonly #sendCommandDelegate: (plainCommand: string) => Promise<void>;
+
+  constructor(sendCommandDelegate: (plainCommand: string) => Promise<void>) {
+    super();
+    this.#sendCommandDelegate = sendCommandDelegate;
+  }
+
+  async sendCommand(plainCommand: string): Promise<void> {
+    await this.#sendCommandDelegate(plainCommand);
+  }
+}

--- a/src/bidiServer/SimpleTransport.ts
+++ b/src/bidiServer/SimpleTransport.ts
@@ -17,9 +17,16 @@
 
 import {EventEmitter} from '../utils/EventEmitter';
 
+/**
+ * Implements simple transport that allows sending string messages via
+ * `sendCommand` and receiving them via `on('message')`.
+ */
 export class SimpleTransport extends EventEmitter<Record<'message', string>> {
   readonly #sendCommandDelegate: (plainCommand: string) => Promise<void>;
 
+  /**
+   * @param sendCommandDelegate delegate to be called in `sendCommand`.
+   */
   constructor(sendCommandDelegate: (plainCommand: string) => Promise<void>) {
     super();
     this.#sendCommandDelegate = sendCommandDelegate;

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -138,7 +138,7 @@ export class WebSocketServer {
       );
 
       // Forward messages from BiDi Mapper to the client unconditionally.
-      browserInstance.bidiSession.on('message', (message) => {
+      browserInstance.bidiSession().on('message', (message) => {
         void this.#sendClientMessageString(message, connection);
       });
 
@@ -188,7 +188,7 @@ export class WebSocketServer {
         }
 
         // Forward all other commands to BiDi Mapper.
-        await browserInstance.bidiSession.sendCommand(plainCommandData);
+        await browserInstance.bidiSession().sendCommand(plainCommandData);
       });
 
       connection.on('close', async () => {

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -138,7 +138,7 @@ export class WebSocketServer {
       );
 
       // Forward messages from BiDi Mapper to the client unconditionally.
-      browserInstance.on('message', (message) => {
+      browserInstance.bidiSession.on('message', (message) => {
         void this.#sendClientMessageString(message, connection);
       });
 
@@ -188,7 +188,7 @@ export class WebSocketServer {
         }
 
         // Forward all other commands to BiDi Mapper.
-        await browserInstance.sendCommand(plainCommandData);
+        await browserInstance.bidiSession.sendCommand(plainCommandData);
       });
 
       connection.on('close', async () => {


### PR DESCRIPTION
Preparation for multiple session support. http://go/webdriver:bidi-multiple-sessions-proposal

**_Step 3._** Use BiDi session to communicate to Mapper Tab.

* Extract a `BiDiSession` class and communicate via it.
* Remove `EventEmitter` from BrowserInstance and MapperCdpConnection.