### PR TITLE
ci: ignore input tests in headful mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       ]
     },
     "e2e-headful": {
-      "command": "python3 -m pytest",
+      "command": "python3 -m pytest --ignore=tests/input",
       "dependencies": [
         "server-headful"
       ],


### PR DESCRIPTION
They are extremely flaky in CI.

Tested:
  - Before: 268 passed, 11 skipped, 3 xfailed
  - After: 262 passed, 11 skipped, 2 xfailed

Fixed: #1407, #1452