### PR TITLE
fix: Add `window.setSelfTargetId` for backward compatibility with chrome driver

### DIFF
--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -17,7 +17,7 @@
  * @license
  */
 
-import {BidiServer} from '../bidiMapper/BidiMapper.js';
+import {BidiServer, OutgoingMessage} from '../bidiMapper/BidiMapper.js';
 import {CdpConnection} from '../cdp/CdpConnection.js';
 import {LogType} from '../utils/log.js';
 
@@ -47,6 +47,13 @@ declare global {
 
     // Set from the server side if verbose logging is required.
     sendDebugMessage?: ((message: string) => void) | null;
+
+    /**
+     * @deprecated Use `runMapperInstance` instead. Used for backward compatibility
+     * with ChromeDriver.
+     */
+    // TODO: Remove this after https://crrev.com/c/4952609 reaches stable.
+    setSelfTargetId: (targetId: string) => void;
   }
 }
 
@@ -59,14 +66,10 @@ const cdpTransport = new WindowCdpTransport();
  */
 const cdpConnection = new CdpConnection(cdpTransport, log);
 
-/**
- * Set `window.runMapper` to a function which launches the BiDi mapper instance.
- * @param selfTargetId Needed to filter out info related to BiDi target.
- */
-window.runMapperInstance = async (selfTargetId) => {
+async function runMapperInstance(selfTargetId: string) {
   console.log('Launching Mapper instance with selfTargetId:', selfTargetId);
 
-  await BidiServer.createAndStart(
+  const bidiServer = await BidiServer.createAndStart(
     mapperTabToServerTransport,
     cdpConnection,
     /**
@@ -79,4 +82,29 @@ window.runMapperInstance = async (selfTargetId) => {
   );
 
   log(LogType.debugInfo, 'Mapper instance has been launched');
+
+  return bidiServer;
+}
+
+/**
+ * Set `window.runMapper` to a function which launches the BiDi mapper instance.
+ * @param selfTargetId Needed to filter out info related to BiDi target.
+ */
+window.runMapperInstance = async (selfTargetId) => {
+  await runMapperInstance(selfTargetId);
+};
+
+/**
+ * @deprecated Use `runMapperInstance` instead. Used for backward compatibility
+ * with ChromeDriver.
+ */
+// TODO: Remove this after https://crrev.com/c/4952609 reaches stable.
+window.setSelfTargetId = async (selfTargetId) => {
+  const bidiServer = await runMapperInstance(selfTargetId);
+  bidiServer.emitOutgoingMessage(
+    OutgoingMessage.createResolved({
+      launched: true,
+    }),
+    'launched'
+  );
 };

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -66,6 +66,10 @@ const cdpTransport = new WindowCdpTransport();
  */
 const cdpConnection = new CdpConnection(cdpTransport, log);
 
+/**
+ * Launches the BiDi mapper instance.
+ * @param {string} selfTargetId
+ */
 async function runMapperInstance(selfTargetId: string) {
   console.log('Launching Mapper instance with selfTargetId:', selfTargetId);
 


### PR DESCRIPTION
Add back `window.setSelfTargetId` for backward compatibility with ChromeDriver Classic, until https://crrev.com/c/4952609 is landed in stable.