### PR TITLE
chore: fix async code

### DIFF
--- a/src/bidiMapper/domains/network/NetworkRequest.ts
+++ b/src/bidiMapper/domains/network/NetworkRequest.ts
@@ -441,12 +441,19 @@ export class NetworkRequest {
     this.#eventManager.registerPromiseEvent(
       this.#beforeRequestSentDeferred.then((result) => {
         if (result.kind === 'success') {
-          return {
-            kind: 'success',
-            value: Object.assign(this.#getBeforeRequestEvent(), {
-              type: 'event' as const,
-            }),
-          };
+          try {
+            return {
+              kind: 'success',
+              value: Object.assign(this.#getBeforeRequestEvent(), {
+                type: 'event' as const,
+              }),
+            };
+          } catch (error) {
+            return {
+              kind: 'error',
+              error: error instanceof Error ? error : new Error('Unknown'),
+            };
+          }
         }
         return result;
       }),
@@ -478,12 +485,19 @@ export class NetworkRequest {
     this.#eventManager.registerPromiseEvent(
       this.#responseCompletedDeferred.then((result) => {
         if (result.kind === 'success') {
-          return {
-            kind: 'success',
-            value: Object.assign(this.#getResponseReceivedEvent(), {
-              type: 'event' as const,
-            }),
-          };
+          try {
+            return {
+              kind: 'success',
+              value: Object.assign(this.#getResponseReceivedEvent(), {
+                type: 'event' as const,
+              }),
+            };
+          } catch (error) {
+            return {
+              kind: 'error',
+              error: error instanceof Error ? error : new Error('Unknown'),
+            };
+          }
         }
         return result;
       }),

--- a/src/utils/ProcessingQueue.ts
+++ b/src/utils/ProcessingQueue.ts
@@ -52,28 +52,26 @@ export class ProcessingQueue<T> {
       const [entryPromise, name] = arrayEntry;
       this.#logger?.(ProcessingQueue.LOGGER_PREFIX, 'Processing event:', name);
 
-      if (entryPromise !== undefined) {
-        await entryPromise
-          .then((entry) => {
-            if (entry.kind === 'error') {
-              this.#logger?.(
-                LogType.debugError,
-                'Event threw before sending:',
-                entry.error.message,
-                entry.error.stack
-              );
-              return;
-            }
-            return this.#processor(entry.value);
-          })
-          .catch((error) => {
+      await entryPromise
+        .then((entry) => {
+          if (entry.kind === 'error') {
             this.#logger?.(
               LogType.debugError,
-              'Event was not processed:',
-              error?.message
+              'Event threw before sending:',
+              entry.error.message,
+              entry.error.stack
             );
-          });
-      }
+            return;
+          }
+          return this.#processor(entry.value);
+        })
+        .catch((error) => {
+          this.#logger?.(
+            LogType.debugError,
+            'Event was not processed:',
+            error?.message
+          );
+        });
     }
 
     this.#isProcessing = false;


### PR DESCRIPTION
We are getting this error from Puppeteer `Promise rejection was handled asynchronously` the test in question is `should not leak listeners during navigation of 11 pages`.

The issue is that the `this.#getResponseReceivedEvent()` has an assert that for this test fails most likely the page gets destroyed by the time it hits it and then it fails due to the the deferred being cancelled.

I think I will want to refactor this further to make the function return `Result<>` rather than this assign. 
Just wanted to put a PR before moving to other things. 