### PR TITLE
feat: addPreloadScripts respects contexts param for old contexts

### DIFF
--- a/src/bidiMapper/domains/script/PreloadScript.ts
+++ b/src/bidiMapper/domains/script/PreloadScript.ts
@@ -79,7 +79,7 @@ export class PreloadScript {
     return this.#channels;
   }
 
-  /** Channels of the preload script. */
+  /** Contexts of the preload script, if any */
   get contexts(): BrowsingContext.BrowsingContext[] | undefined {
     return this.#contexts;
   }

--- a/src/bidiMapper/domains/script/PreloadScript.ts
+++ b/src/bidiMapper/domains/script/PreloadScript.ts
@@ -18,7 +18,7 @@
 
 import type Protocol from 'devtools-protocol';
 
-import type {Script} from '../../../protocol/protocol.js';
+import type {BrowsingContext, Script} from '../../../protocol/protocol.js';
 import {uuidv4} from '../../../utils/uuid.js';
 import type {CdpTarget} from '../context/CdpTarget.js';
 import type {LoggerFn} from '../../../utils/log.js';
@@ -55,6 +55,8 @@ export class PreloadScript {
   readonly #channels: ChannelProxy[];
   /** The script sandbox / world name. */
   readonly #sandbox?: string;
+  /** The script contexts to execute in */
+  readonly #contexts?: BrowsingContext.BrowsingContext[];
 
   get id(): string {
     return this.#id;
@@ -69,11 +71,17 @@ export class PreloadScript {
       params.arguments?.map((a) => new ChannelProxy(a.value, logger)) ?? [];
     this.#functionDeclaration = params.functionDeclaration;
     this.#sandbox = params.sandbox;
+    this.#contexts = params.contexts;
   }
 
   /** Channels of the preload script. */
   get channels(): ChannelProxy[] {
     return this.#channels;
+  }
+
+  /** Channels of the preload script. */
+  get contexts(): BrowsingContext.BrowsingContext[] | undefined {
+    return this.#contexts;
   }
 
   /**

--- a/src/bidiMapper/domains/script/PreloadScript.ts
+++ b/src/bidiMapper/domains/script/PreloadScript.ts
@@ -55,7 +55,7 @@ export class PreloadScript {
   readonly #channels: ChannelProxy[];
   /** The script sandbox / world name. */
   readonly #sandbox?: string;
-  /** The script contexts to execute in */
+  /** The browsing contexts to execute the preload scripts in, if any. */
   readonly #contexts?: BrowsingContext.BrowsingContext[];
 
   get id(): string {

--- a/tests/script/test_add_preload_script.py
+++ b/tests/script/test_add_preload_script.py
@@ -862,7 +862,7 @@ async def test_preloadScript_add_respectContextsForOldContexts(
             }
         })
 
-    # NAvigate both contexts to trigger PreloadScripts
+    # Navigate both contexts to trigger PreloadScripts
     await goto_url(websocket, context_id, html())
     await goto_url(websocket, new_context_id, html())
 

--- a/tests/script/test_add_preload_script.py
+++ b/tests/script/test_add_preload_script.py
@@ -837,8 +837,8 @@ async def test_preloadScript_channel_newContext(websocket,
 
 
 @pytest.mark.asyncio
-async def test_preloadScript_add_respectContextsForOldContexts(websocket, context_id,
-                                                   html):
+async def test_preloadScript_add_respectContextsForOldContexts(
+        websocket, context_id, html):
 
     # Create a new context prior to adding PreloadScript
     result = await execute_command(websocket, {
@@ -863,12 +863,8 @@ async def test_preloadScript_add_respectContextsForOldContexts(websocket, contex
         })
 
     # NAvigate both contexts to trigger PreloadScripts
-    await goto_url(
-        websocket, context_id,
-        html())
-    await goto_url(
-        websocket, new_context_id,
-        html())
+    await goto_url(websocket, context_id, html())
+    await goto_url(websocket, new_context_id, html())
 
     # Expect context with context_id to be affected by PreloadScript
     result = await execute_command(
@@ -883,10 +879,7 @@ async def test_preloadScript_add_respectContextsForOldContexts(websocket, contex
                 "resultOwnership": "root"
             }
         })
-    assert result["result"] == {
-        "type": "string",
-        "value": 'BAR'
-    }
+    assert result["result"] == {"type": "string", "value": 'BAR'}
 
     # Expect context with new_context_id to not be affected by PreloadScript
     result = await execute_command(


### PR DESCRIPTION
This only makes the already created Contexts respect the PreloadScript, the newly create one will still run the script atm.
