### PR TITLE
ci: speed up prettier/eslint pre-commit hooks and use types instead of files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,7 @@ repos:
       # ESLint may update code style (formatting) so keep prettier last.
       - id: prettier
         name: prettier
-        entry: 'npx prettier --check .'
+        entry: 'npx prettier --write --ignore-unknown --check .'
         language: system
         files: \.[jt]s$
-        types: [file]
+        types: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,14 +108,14 @@ repos:
           .* See the License for the specific language governing permissions and
           .* limitations under the License.
         language: pygrep
-        files: \.js$|\.cjs$|\.mjs$|\.ts$|\.py$
+        types_or: [javascript, ts, python]
         exclude: __init__\.py$
         args: [--negate, --multiline]
       - id: node-self
         name: check nodejs `self.`
         entry: '\bself\.'
         language: pygrep
-        files: \.ts$
+        types_or: [ts]
       # ESLint is the slowest hook, so keep it at the bottom.
       - id: eslint
         name: eslint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,12 +122,10 @@ repos:
         entry: 'npx eslint --fix'
         language: system
         verbose: true
-        files: \.[jt]s$
-        types: [file]
+        types_or: [javascript, ts]
       # ESLint may update code style (formatting) so keep prettier last.
       - id: prettier
         name: prettier
         entry: 'npx prettier --write --ignore-unknown --check .'
         language: system
-        files: \.[jt]s$
-        types: [text]
+        types_or: [text]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,6 +126,6 @@ repos:
       # ESLint may update code style (formatting) so keep prettier last.
       - id: prettier
         name: prettier
-        entry: 'npx prettier --write --ignore-unknown --check .'
+        entry: 'npx prettier --write --ignore-unknown --check'
         language: system
         types_or: [text]


### PR DESCRIPTION
c.f. https://github.com/pre-commit/mirrors-prettier/blob/main/.pre-commit-hooks.yaml and https://github.com/pre-commit/identify/blob/main/identify/extensions.py
