### PR TITLE
feat: addPreloadScript respects new contexts

### DIFF
--- a/src/bidiMapper/domains/context/CdpTarget.ts
+++ b/src/bidiMapper/domains/context/CdpTarget.ts
@@ -200,7 +200,9 @@ export class CdpTarget {
 
   /** Loads all top-level preload scripts. */
   async #initAndEvaluatePreloadScripts() {
-    for (const script of this.#preloadScriptStorage.find()) {
+    for (const script of this.#preloadScriptStorage.find({
+      global: true,
+    })) {
       await script.initInTarget(this, true);
     }
   }

--- a/src/bidiMapper/domains/script/PreloadScriptStorage.ts
+++ b/src/bidiMapper/domains/script/PreloadScriptStorage.ts
@@ -20,7 +20,10 @@ import type {PreloadScript} from './PreloadScript.js';
 
 /** PreloadScripts can be filtered by BiDi ID or target ID. */
 export type PreloadScriptFilter = Partial<
-  Pick<PreloadScript, 'id'> & Pick<CdpTarget, 'targetId'>
+  Pick<PreloadScript, 'id'> &
+    Pick<CdpTarget, 'targetId'> & {
+      global: boolean;
+    }
 >;
 
 /**
@@ -43,6 +46,15 @@ export class PreloadScriptStorage {
       if (
         filter.targetId !== undefined &&
         !script.targetIds.has(filter.targetId)
+      ) {
+        return false;
+      }
+      if (
+        filter.global !== undefined &&
+        // Global scripts have no contexts
+        ((filter.global && script.contexts !== undefined) ||
+          // Non global scripts always have contexts
+          (!filter.global && script.contexts === undefined))
       ) {
         return false;
       }


### PR DESCRIPTION
We should be OK using the global approach due to https://w3c.github.io/webdriver-bidi/#command-script-addPreloadScript 
Step 4  - making sure that the Context exits, if we don't already have it we in our storage.
Adding the note because on there was discussion around ID and sharing them between Multiple BiDi sessions. 

From Alex: The above is only true if we are adding the scripts to same origin iframes. This will not work for example for workers, cross-origin iframes and a like that create a new target, and per spec preload scripts should affect them as well.

Tracked at #1353