### PR TITLE
ci: add wait=complete to all network intercept navigations

### DIFF
--- a/tests/network/test_add_intercept.py
+++ b/tests/network/test_add_intercept.py
@@ -315,6 +315,7 @@ async def test_add_intercept_blocks_use_cdp_events(websocket, context_id,
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -398,6 +399,7 @@ async def test_add_intercept_blocks_use_bidi_events(websocket, context_id,
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 

--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -125,8 +125,8 @@ async def test_continue_request_non_blocked_request(websocket, context_id,
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "context": context_id,
                 "url": hang_url,
+                "context": context_id,
                 "wait": "complete",
             }
         })
@@ -180,6 +180,7 @@ async def test_continue_request_completes_use_cdp_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
     event_response = await wait_for_event(websocket, "cdp.Fetch.requestPaused")
@@ -236,6 +237,7 @@ async def test_continue_request_completes_use_bidi_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -317,6 +319,7 @@ async def test_continue_request_twice(websocket, context_id, example_url):
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -406,6 +409,7 @@ async def test_continue_request_remove_intercept_inflight_request(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 

--- a/tests/network/test_continue_response.py
+++ b/tests/network/test_continue_response.py
@@ -149,8 +149,8 @@ async def test_continue_response_non_blocked_request(websocket, context_id,
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "context": context_id,
                 "url": hang_url,
+                "context": context_id,
                 "wait": "complete",
             }
         })
@@ -268,6 +268,7 @@ async def test_continue_response_completes_use_cdp_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
     event_response = await wait_for_event(websocket, "cdp.Fetch.requestPaused")
@@ -343,6 +344,7 @@ async def test_continue_response_completes_use_bidi_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -443,6 +445,7 @@ async def test_continue_response_twice(websocket, context_id, example_url):
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 

--- a/tests/network/test_continue_with_auth.py
+++ b/tests/network/test_continue_with_auth.py
@@ -81,8 +81,8 @@ async def test_continue_with_auth_non_blocked_request(
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "context": context_id,
                 "url": hang_url,
+                "context": context_id,
                 "wait": "complete",
             }
         })
@@ -234,6 +234,7 @@ async def test_continue_with_auth_twice(websocket, context_id, example_url):
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -49,8 +49,8 @@ async def test_fail_request_non_blocked_request(websocket, context_id,
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "context": context_id,
                 "url": hang_url,
+                "context": context_id,
                 "wait": "complete",
             }
         })
@@ -106,6 +106,7 @@ async def test_fail_request_twice(websocket, context_id, example_url):
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -202,6 +203,7 @@ async def test_fail_request_with_auth_required_phase(
             "params": {
                 "url": auth_required_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -308,6 +310,7 @@ async def test_fail_request_completes_use_cdp_events(websocket, context_id,
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -393,6 +396,7 @@ async def test_fail_request_completes_use_bidi_events(websocket, context_id,
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -623,6 +627,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -661,6 +666,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
             "params": {
                 "url": example_url,
                 "context": another_context_id,
+                "wait": "complete",
             }
         })
 
@@ -789,6 +795,7 @@ async def test_fail_request_remove_intercept_inflight_request(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 

--- a/tests/network/test_provide_response.py
+++ b/tests/network/test_provide_response.py
@@ -171,8 +171,8 @@ async def test_provide_response_non_blocked_request(websocket, context_id,
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "context": context_id,
                 "url": hang_url,
+                "context": context_id,
                 "wait": "complete",
             }
         })
@@ -225,6 +225,7 @@ async def test_provide_response_completes_use_cdp_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
     event_response = await wait_for_event(websocket, "cdp.Fetch.requestPaused")
@@ -304,6 +305,7 @@ async def test_provide_response_completes_use_bidi_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -409,6 +411,7 @@ async def test_provide_response_twice(websocket, context_id, example_url):
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -498,6 +501,7 @@ async def test_provide_response_remove_intercept_inflight_request(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 

--- a/tests/network/test_remove_intercept.py
+++ b/tests/network/test_remove_intercept.py
@@ -138,6 +138,7 @@ async def test_remove_intercept_unblocks_use_cdp_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -176,8 +177,8 @@ async def test_remove_intercept_unblocks_use_cdp_events(
             "method": "browsingContext.navigate",
             "params": {
                 "url": example_url,
-                "wait": "complete",
                 "context": another_context_id,
+                "wait": "complete",
             }
         })
 
@@ -270,6 +271,7 @@ async def test_remove_intercept_unblocks_use_bidi_events(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
 
@@ -387,6 +389,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
             "params": {
                 "url": example_url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
     event_response = await wait_for_event(websocket,
@@ -422,6 +425,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
             "params": {
                 "url": another_example_url,
                 "context": another_context_id,
+                "wait": "complete",
             }
         })
     event_response_2 = await wait_for_event(websocket,


### PR DESCRIPTION
In order to try to mitigate test flakiness.

Bug: #644, #1428