### PR TITLE
ci(python): install pipenv with apt instead of pip

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: '3.11'
           cache: pipenv
       - name: Install pipenv
-        run: pip install pipenv
+        run: sudo apt-get -y install pipenv
       - name: Install python dependencies
         run: pipenv install
       - name: Run E2E tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.11'
           cache: pipenv
       - name: Install pipenv
-        run: pip install pipenv
+        run: sudo apt-get install -y pipenv
       - name: Install python dependencies
         run: pipenv install
       - name: Test


### PR DESCRIPTION
So that the `pipenv` installation itself is pinned / reproducible.

Bug: #1182