### PR TITLE
test(network intercept): use network.responseCompleted instead of cdp…

### DIFF
--- a/tests/network/__init__.py
+++ b/tests/network/__init__.py
@@ -45,6 +45,7 @@ async def create_blocked_request(websocket, context_id: str, *, url: str,
             "params": {
                 "url": url,
                 "context": context_id,
+                "wait": "complete",
             }
         })
     event_response = await wait_for_event(websocket, "cdp.Fetch.requestPaused")

--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -117,7 +117,7 @@ async def test_continue_request_non_blocked_request(websocket, context_id,
                                                     assert_no_events_in_queue,
                                                     hang_url):
     await subscribe(websocket, [
-        "network.beforeRequestSent", "cdp.Network.responseReceived",
+        "network.beforeRequestSent", "network.responseCompleted",
         "network.fetchError"
     ])
 
@@ -136,7 +136,7 @@ async def test_continue_request_non_blocked_request(websocket, context_id,
 
     # Assert these events never happen, otherwise the test is ineffective.
     await assert_no_events_in_queue(
-        ["cdp.Network.responseReceived", "network.fetchError"], timeout=1.0)
+        ["network.responseCompleted", "network.fetchError"], timeout=1.0)
 
     assert not before_request_sent_event["params"]["isBlocked"]
 

--- a/tests/network/test_continue_response.py
+++ b/tests/network/test_continue_response.py
@@ -141,7 +141,7 @@ async def test_continue_response_non_blocked_request(websocket, context_id,
                                                      assert_no_events_in_queue,
                                                      hang_url):
     await subscribe(websocket, [
-        "network.beforeRequestSent", "cdp.Network.responseReceived",
+        "network.beforeRequestSent", "network.responseCompleted",
         "network.fetchError"
     ])
 
@@ -160,7 +160,7 @@ async def test_continue_response_non_blocked_request(websocket, context_id,
 
     # Assert these events never happen, otherwise the test is ineffective.
     await assert_no_events_in_queue(
-        ["cdp.Network.responseReceived", "network.fetchError"], timeout=1.0)
+        ["network.responseCompleted", "network.fetchError"], timeout=1.0)
 
     assert not before_request_sent_event["params"]["isBlocked"]
 

--- a/tests/network/test_continue_with_auth.py
+++ b/tests/network/test_continue_with_auth.py
@@ -68,14 +68,10 @@ async def test_continue_with_auth_invalid_phase(websocket, context_id,
 @pytest.mark.asyncio
 async def test_continue_with_auth_non_blocked_request(
         websocket, context_id, assert_no_events_in_queue, hang_url):
-    await subscribe(
-        websocket,
-        [
-            # TODO: Use "network.responseCompleted" BiDi event instead of the CDP event.
-            "network.beforeRequestSent",
-            "cdp.Network.responseReceived",
-            "network.fetchError"
-        ])
+    await subscribe(websocket, [
+        "network.beforeRequestSent", "network.responseCompleted",
+        "network.fetchError"
+    ])
 
     await send_JSON_command(
         websocket, {
@@ -92,7 +88,7 @@ async def test_continue_with_auth_non_blocked_request(
 
     # Assert these events never happen, otherwise the test is ineffective.
     await assert_no_events_in_queue(
-        ["cdp.Network.responseReceived", "network.fetchError"], timeout=1.0)
+        ["network.responseCompleted", "network.fetchError"], timeout=1.0)
 
     assert not before_request_sent_event["params"]["isBlocked"]
 

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -41,7 +41,7 @@ async def test_fail_request_non_blocked_request(websocket, context_id,
                                                 assert_no_events_in_queue,
                                                 hang_url):
     await subscribe(websocket, [
-        "network.beforeRequestSent", "cdp.Network.responseReceived",
+        "network.beforeRequestSent", "network.responseCompleted",
         "network.fetchError"
     ])
 
@@ -60,7 +60,7 @@ async def test_fail_request_non_blocked_request(websocket, context_id,
 
     # Assert these events never happen, otherwise the test is ineffective.
     await assert_no_events_in_queue(
-        ["cdp.Network.responseReceived", "network.fetchError"], timeout=1.0)
+        ["network.responseCompleted", "network.fetchError"], timeout=1.0)
 
     assert not before_request_sent_event["params"]["isBlocked"]
 

--- a/tests/network/test_provide_response.py
+++ b/tests/network/test_provide_response.py
@@ -163,7 +163,7 @@ async def test_provide_response_non_blocked_request(websocket, context_id,
                                                     assert_no_events_in_queue,
                                                     hang_url):
     await subscribe(websocket, [
-        "network.beforeRequestSent", "cdp.Network.responseReceived",
+        "network.beforeRequestSent", "network.responseCompleted",
         "network.fetchError"
     ])
 
@@ -182,7 +182,7 @@ async def test_provide_response_non_blocked_request(websocket, context_id,
 
     # Assert these events never happen, otherwise the test is ineffective.
     await assert_no_events_in_queue(
-        ["cdp.Network.responseReceived", "network.fetchError"], timeout=1.0)
+        ["network.responseCompleted", "network.fetchError"], timeout=1.0)
 
     assert not before_request_sent_event["params"]["isBlocked"]
 


### PR DESCRIPTION
….Network.responseReceived

Bug: #644