### PR TITLE
feat(logging): pretty print received and sent bidi server messages

### DIFF
--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -156,10 +156,13 @@ export class WebSocketServer {
         }
 
         const plainCommandData = message.utf8Data;
-        try {
-          debugRecv(JSON.parse(plainCommandData));
-        } catch {
-          debugRecv(plainCommandData);
+
+        if (debugRecv.enabled) {
+          try {
+            debugRecv(JSON.parse(plainCommandData));
+          } catch {
+            debugRecv(plainCommandData);
+          }
         }
 
         // Try to parse the message to handle some of BiDi commands.
@@ -211,10 +214,12 @@ export class WebSocketServer {
     message: string,
     connection: websocket.connection
   ): Promise<void> {
-    try {
-      debugSend(JSON.parse(message));
-    } catch {
-      debugSend(message);
+    if (debugSend.enabled) {
+      try {
+        debugSend(JSON.parse(message));
+      } catch {
+        debugSend(message);
+      }
     }
     connection.sendUTF(message);
     return Promise.resolve();

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -31,8 +31,7 @@ const debugRecv = debug('bidi:server:RECV ◂');
 
 export class WebSocketServer {
   /**
-   *
-   * @param bidiPort port to start ws server on.
+   * @param bidiPort Port to start ws server on.
    * @param channel
    * @param headless
    * @param verbose
@@ -157,7 +156,11 @@ export class WebSocketServer {
         }
 
         const plainCommandData = message.utf8Data;
-        debugRecv(plainCommandData);
+        try {
+          debugRecv(JSON.parse(plainCommandData));
+        } catch {
+          debugRecv(plainCommandData);
+        }
 
         // Try to parse the message to handle some of BiDi commands.
         let parsedCommandData: {id: number; method: string};
@@ -208,7 +211,11 @@ export class WebSocketServer {
     message: string,
     connection: websocket.connection
   ): Promise<void> {
-    debugSend(message);
+    try {
+      debugSend(JSON.parse(message));
+    } catch {
+      debugSend(message);
+    }
     connection.sendUTF(message);
     return Promise.resolve();
   }


### PR DESCRIPTION
Example: <img width="731" alt="Screenshot 2023-10-27 at 11 05 56" src="https://github.com/GoogleChromeLabs/chromium-bidi/assets/2840106/fcca5904-8b11-48dc-9c58-1de56dbe9033">

Instead of having the output message string in a single line.