### PR TITLE
feat(network intercept): specify BeforeRequestSent whenever AuthRequi…

### DIFF
--- a/src/bidiMapper/domains/network/NetworkProcessor.ts
+++ b/src/bidiMapper/domains/network/NetworkProcessor.ts
@@ -53,6 +53,15 @@ export class NetworkProcessor {
       );
     }
 
+    // If AuthRequired is specified, BeforeRequestSent must also be specified.
+    // This is a CDP quirk.
+    if (
+      params.phases.includes(Network.InterceptPhase.AuthRequired) &&
+      !params.phases.includes(Network.InterceptPhase.BeforeRequestSent)
+    ) {
+      params.phases.unshift(Network.InterceptPhase.BeforeRequestSent);
+    }
+
     const urlPatterns: Network.UrlPattern[] = params.urlPatterns ?? [];
     const parsedUrlPatterns: Network.UrlPattern[] =
       NetworkProcessor.parseUrlPatterns(urlPatterns);

--- a/tests/network/test_continue_with_auth.py
+++ b/tests/network/test_continue_with_auth.py
@@ -156,7 +156,7 @@ async def test_continue_with_auth_invalid_credentials(websocket, context_id,
             "initiator": {
                 "type": "other",
             },
-            "isBlocked": False,
+            "isBlocked": True,
             "navigation": ANY_STR,
             "redirectCount": 0,
             "request": {
@@ -231,7 +231,7 @@ async def test_continue_with_auth_completes(websocket, context_id,
             "initiator": {
                 "type": "other",
             },
-            "isBlocked": False,
+            "isBlocked": True,
             "navigation": ANY_STR,
             "redirectCount": 0,
             "request": {


### PR DESCRIPTION
…red is specified

The BiDi spec supports "authRequired" by itself, however CDP requires both events.

Bug: #644