### PR TITLE
test(timeout): reset timeout multiplier to 4

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -67,7 +67,7 @@ const MANIFEST = process.env.MANIFEST || 'MANIFEST.json';
 const PRODUCT = process.env.PRODUCT || 'chrome';
 
 // Multiplier relative to standard test timeout to use.
-const TIMEOUT_MULTIPLIER = process.env.TIMEOUT_MULTIPLIER || '8';
+const TIMEOUT_MULTIPLIER = process.env.TIMEOUT_MULTIPLIER || '2';
 
 // Whether to update the WPT expectations after running the tests.
 const UPDATE_EXPECTATIONS = process.env.UPDATE_EXPECTATIONS || 'false';

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -67,7 +67,7 @@ const MANIFEST = process.env.MANIFEST || 'MANIFEST.json';
 const PRODUCT = process.env.PRODUCT || 'chrome';
 
 // Multiplier relative to standard test timeout to use.
-const TIMEOUT_MULTIPLIER = process.env.TIMEOUT_MULTIPLIER || '2';
+const TIMEOUT_MULTIPLIER = process.env.TIMEOUT_MULTIPLIER || '4';
 
 // Whether to update the WPT expectations after running the tests.
 const UPDATE_EXPECTATIONS = process.env.UPDATE_EXPECTATIONS || 'false';


### PR DESCRIPTION
The current default of `8` seems to be slowing down CI significantly.

An increased timeout is useful for debugging purposes only.