### PR TITLE
feat(add intercept): address global intercepts

### DIFF
--- a/src/bidiMapper/domains/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.spec.ts
@@ -158,7 +158,7 @@ describe('NetworkStorage', () => {
 
     expect(networkStorage.getFetchEnableParams()).to.deep.equal({
       handleAuthRequests: false,
-      patterns: [],
+      patterns: undefined,
     });
   });
 
@@ -211,7 +211,7 @@ describe('NetworkStorage', () => {
     it('no intercepts', () => {
       expect(networkStorage.getFetchEnableParams()).to.deep.equal({
         handleAuthRequests: false,
-        patterns: [],
+        patterns: undefined,
       });
     });
 

--- a/src/bidiMapper/domains/network/NetworkStorage.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.ts
@@ -124,7 +124,7 @@ export class NetworkStorage {
     }
 
     return {
-      patterns,
+      patterns: patterns.length === 0 ? undefined : patterns,
       // If there's at least one intercept that requires auth, enable the
       // 'Fetch.authRequired' event.
       handleAuthRequests: [...this.#interceptMap.values()].some((param) => {


### PR DESCRIPTION
Whenever no patterns are specified in BiDi, omit the "patterns" parameter in "Fetch.enable", in order to match all requests:

> If specified, only requests matching any of these patterns will
produce fetchRequested event and will be paused until clients response. If not set, all requests will be affected.

Bug: #644
Docs: https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#method-enable