### PR TITLE
feat: abort navigation if network request failed

### DIFF
--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -69,8 +69,6 @@ export class BrowsingContextImpl {
   };
 
   #url = 'about:blank';
-  // Required to provide navigation info in case of navigation was canceled.
-  #ongoingNavigationUrl?: string;
   readonly #eventManager: EventManager;
   readonly #realmStorage: RealmStorage;
   #loaderId?: Protocol.Network.LoaderId;
@@ -635,8 +633,6 @@ export class BrowsingContextImpl {
       throw new UnknownErrorException(cdpNavigateResult.errorText);
     }
 
-    this.#ongoingNavigationUrl = url;
-
     this.#documentChanged(cdpNavigateResult.loaderId);
 
     switch (wait) {
@@ -660,7 +656,6 @@ export class BrowsingContextImpl {
         break;
     }
 
-    this.#ongoingNavigationUrl = undefined;
     return {
       navigation: cdpNavigateResult.loaderId ?? null,
       // Url can change due to redirect get the latest one.

--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -161,6 +161,9 @@ export class BrowsingContextImpl {
       this.parent!.#children.delete(this.id);
     }
 
+    // Fail all ongoing navigations.
+    this.#failDeferredsIfNotFinished();
+
     this.#eventManager.registerEvent(
       {
         type: 'event',
@@ -326,31 +329,6 @@ export class BrowsingContextImpl {
         // previous page are detached and realms are destroyed.
         // Remove children from context.
         this.#deleteAllChildren();
-      }
-    );
-
-    this.#cdpTarget.cdpClient.on(
-      'Network.loadingFailed',
-      (params: Protocol.Network.LoadingFailedEvent) => {
-        if (this.#loaderId !== params.requestId) {
-          return;
-        }
-        // TODO: consider process only specific `errorText === 'net::ERR_ABORTED'`.
-        this.#eventManager.registerEvent(
-          {
-            type: 'event',
-            method: ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
-            params: {
-              context: this.id,
-              navigation: this.#loaderId ?? null,
-              timestamp: BrowsingContextImpl.getTimestamp(),
-              url: this.#ongoingNavigationUrl ?? this.#url,
-            },
-          },
-          this.id
-        );
-
-        this.#failDeferredsIfNotFinished();
       }
     );
 

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -384,10 +384,8 @@ async def test_browsingContext_navigationStartedEvent_viaCommand(
 
 
 @pytest.mark.asyncio
-async def test_browsingContext_navigationStarted_browsingContextClosedBeforeNavigationEnded_navigationAborted(
+async def test_browsingContext_navigationStarted_browsingContextClosedBeforeNavigationEnded_navigationFailed(
         websocket, context_id, hang_url):
-    await subscribe(websocket, ["browsingContext.navigationAborted"])
-
     navigate_command_id = await send_JSON_command(
         websocket, {
             "method": "browsingContext.navigate",
@@ -404,18 +402,6 @@ async def test_browsingContext_navigationStarted_browsingContextClosedBeforeNavi
             "context": context_id
         }
     })
-
-    response = await read_JSON_message(websocket)
-    assert response == {
-        'type': 'event',
-        'method': 'browsingContext.navigationAborted',
-        'params': {
-            'context': context_id,
-            'url': hang_url,
-            'navigation': ANY_STR,
-            'timestamp': ANY_TIMESTAMP,
-        }
-    }
 
     response = await read_JSON_message(websocket)
     assert response == AnyExtending({

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -77,6 +77,8 @@ class LocalHttpServer:
             .expect_request(self.__path_basic_auth) \
             .respond_with_handler(process_auth)
 
+        self.hang_forever_stop_flag = None
+
         def hang_forever(_):
             self.hang_forever_stop_flag = Event()
             while not self.hang_forever_stop_flag.is_set():
@@ -106,7 +108,8 @@ class LocalHttpServer:
             .respond_with_handler(cache)
 
     def hang_forever_stop(self):
-        self.hang_forever_stop_flag.set()
+        if self.hang_forever_stop_flag is not None:
+            self.hang_forever_stop_flag.set()
 
     def _url_for(self, suffix: str, host: str = 'localhost') -> str:
         """


### PR DESCRIPTION
If browsing context is closed, cancel all ongoing navigations.

Required for [Puppeteer tests](https://github.com/puppeteer/puppeteer/blob/9f161ec76b19c419bb1dd36357c09c044d5f82f4/test/src/launcher.spec.ts#L40).