### PR TITLE
ci(wpt): add --restart-on-new-group to complement --run-by-dir

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -118,6 +118,7 @@ const wptRunArgs = [
   TIMEOUT_MULTIPLIER,
   '--run-by-dir',
   '1',
+  '--restart-on-new-group',
 ];
 
 if (VERBOSE === 'true') {


### PR DESCRIPTION
Docs: https://web-platform-tests.org/running-tests/command-line-arguments.html
Follow-up-of: #1544