### PR TITLE
ci(wpt): add --retry-unexpected to complement --run-by-dir

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -118,6 +118,8 @@ const wptRunArgs = [
   TIMEOUT_MULTIPLIER,
   '--run-by-dir',
   '1',
+  '--retry-unexpected',
+  '1',
 ];
 
 if (VERBOSE === 'true') {


### PR DESCRIPTION
Docs: https://web-platform-tests.org/running-tests/command-line-arguments.html
Follow-up-of: #1544