### PR TITLE
Revert "ci(wpt): add --retry-unexpected to complement --run-by-dir"

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -118,8 +118,6 @@ const wptRunArgs = [
   TIMEOUT_MULTIPLIER,
   '--run-by-dir',
   '1',
-  '--retry-unexpected',
-  '1',
 ];
 
 if (VERBOSE === 'true') {


### PR DESCRIPTION
Reverts GoogleChromeLabs/chromium-bidi#1549

WPT tests became false-positive: https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/6868628016/job/18679609674