### PR TITLE
ci: extand `Update WebdriverBidi types` with a custom reference

### DIFF
--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -10,6 +10,12 @@ on:
     # Run daily at 10AM.
     - cron: '0 10 * * *'
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Ref in spec repo to update from
+        default: main
+        required: false
+        type: string
 
 jobs:
   build:
@@ -20,6 +26,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.5.3
         with:
           repository: w3c/webdriver-bidi
+          ref: ${{ github.event.inputs.source_ref }}
       - name: Generate WebDriverBidi CDDL
         run: ./scripts/test.sh
       - name: Upload WebDriverBidi CDDL

--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -12,8 +12,13 @@ on:
   workflow_dispatch:
     inputs:
       source_ref:
-        description: Ref in spec repo to update from
+        description: Ref in spec repo to update from. Default is `main`.
         default: main
+        required: false
+        type: string
+      repository:
+        description: Repository with the spec to update from. Default is `w3c/webdriver-bidi`.
+        default: w3c/webdriver-bidi
         required: false
         type: string
 
@@ -25,7 +30,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.5.3
         with:
-          repository: w3c/webdriver-bidi
+          repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.source_ref }}
       - name: Generate WebDriverBidi CDDL
         run: ./scripts/test.sh


### PR DESCRIPTION
Sometimes it is required to have types from not-yet merged branch of spec (https://github.com/GoogleChromeLabs/chromium-bidi/pull/1593). This PR provides a way to specify a branch of a specific commit to update types from.