### PR TITLE
test: do not rerun e2e tests in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,8 +10,6 @@ env:
   DEBUG_DEPTH: 10
   FORCE_COLOR: 3
   PIP_DISABLE_PIP_VERSION_CHECK: 1
-  # https://pypi.org/project/pytest-rerunfailures/
-  PYTEST_ADDOPTS: '--reruns 1'
 
 on:
   merge_group:


### PR DESCRIPTION
1. `pytest-rerunfailures` is not compatible with the `pytest-timeout plugin`: https://github.com/pytest-dev/pytest-rerunfailures/issues/99. This ends up with failing e2e with timeout with confusing output in [test runs](https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/6983089114/job/19003555638?pr=1593).
2. Rerun masks flaky tests, but should not: http://goto.google.com/webdriver:improve-operations.