### PR TITLE
chore: increase test_scriptEvaluate_dedicated_worker timeout

### DIFF
--- a/tests/script/test_evaluate.py
+++ b/tests/script/test_evaluate.py
@@ -399,7 +399,7 @@ async def test_scriptEvaluate_realm(websocket, context_id):
     } == result
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(20)
 @pytest.mark.asyncio
 async def test_scriptEvaluate_dedicated_worker(websocket, context_id, html,
                                                snapshot):

--- a/tests/script/test_evaluate.py
+++ b/tests/script/test_evaluate.py
@@ -399,6 +399,7 @@ async def test_scriptEvaluate_realm(websocket, context_id):
     } == result
 
 
+@pytest.mark.timeout(30)
 @pytest.mark.asyncio
 async def test_scriptEvaluate_dedicated_worker(websocket, context_id, html,
                                                snapshot):


### PR DESCRIPTION
Sometimes the web worker may take some time before it's destroyed, so we need to increase the timeout for this test.