### PR TITLE
chore: remove deprecated method

### DIFF
--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -17,7 +17,7 @@
  * @license
  */
 
-import {BidiServer, OutgoingMessage} from '../bidiMapper/BidiMapper.js';
+import {BidiServer} from '../bidiMapper/BidiMapper.js';
 import type {MapperOptions} from '../bidiMapper/BidiServer';
 import {CdpConnection} from '../cdp/CdpConnection.js';
 import {LogType} from '../utils/log.js';
@@ -48,13 +48,6 @@ declare global {
 
     // Set from the server side if verbose logging is required.
     sendDebugMessage?: ((message: string) => void) | null;
-
-    /**
-     * @deprecated Use `runMapperInstance` instead. Used for backward compatibility
-     * with ChromeDriver.
-     */
-    // TODO: Remove this after https://crrev.com/c/4952609 reaches stable.
-    setSelfTargetId: (targetId: string) => void;
   }
 }
 
@@ -103,19 +96,4 @@ async function runMapperInstance(
  * @param options Mapper options. E.g. `acceptInsecureCerts`. */
 window.runMapperInstance = async (selfTargetId, options?: MapperOptions) => {
   await runMapperInstance(selfTargetId, options);
-};
-
-/**
- * @deprecated Use `runMapperInstance` instead. Used for backward compatibility
- * with ChromeDriver.
- */
-// TODO: Remove this after https://crrev.com/c/4952609 reaches stable.
-window.setSelfTargetId = async (selfTargetId) => {
-  const bidiServer = await runMapperInstance(selfTargetId);
-  bidiServer.emitOutgoingMessage(
-    OutgoingMessage.createResolved({
-      launched: true,
-    }),
-    'launched'
-  );
 };


### PR DESCRIPTION
The required ChromeDriver change is landed in stable, so the method can be removed.