### PR TITLE
test: don't run headful mapper in quick WPT

### DIFF
--- a/.github/workflows/wpt-quick.yml
+++ b/.github/workflows/wpt-quick.yml
@@ -53,6 +53,10 @@ jobs:
         head: [headless, headful]
         total_chunks: [6]
         this_chunk: [1, 2, 3, 4, 5, 6]
+        exclude:
+          # Don't run headful mapper, as it takes 7 minutes. It will be checked in post-commit stage.
+          - kind: mapper
+            head: headful
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -99,7 +103,7 @@ jobs:
           TOTAL_CHUNKS: ${{ matrix.total_chunks }}
           UPDATE_EXPECTATIONS: false
           VERBOSE: ${{ github.event.inputs.verbose }}
-          WPT_REPORT: out/wptreport.${{ matrix.kind }}-${{ matrix.head }}.json
+          WPT_REPORT: out/wptreport.${{ matrix.kind }}-${{ matrix.head }}-${{ matrix.this_chunk }}.${{ matrix.total_chunks }}.json
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0


### PR DESCRIPTION
Exclude headful mapper WPT runner from quick WPT CI action, as:
1. Mapper config is not exposed to any external users, and is used only for dev purposes.
2. This configuration takes more then 7 minutes, while other configs are finished in under 5. 