### PR TITLE
chore: fix chromedriver log location

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -18,6 +18,7 @@
  */
 
 import {execSync, spawnSync} from 'child_process';
+import {mkdirSync, existsSync} from 'fs';
 import {join, resolve} from 'path';
 
 import {packageDirectorySync} from 'pkg-dir';
@@ -156,6 +157,10 @@ if (RUN_TESTS === 'true') {
   }
 
   if (CHROMEDRIVER === 'true') {
+    if (!existsSync(join('logs'))) {
+      mkdirSync(join('logs'));
+    }
+
     let chromeDriverLogs = join('logs', 'chromedriver.log');
 
     log('Using chromedriver with mapper...');

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -156,8 +156,11 @@ if (RUN_TESTS === 'true') {
   }
 
   if (CHROMEDRIVER === 'true') {
+    let chromeDriverLogs = join('logs', 'chromedriver.log');
+
     log('Using chromedriver with mapper...');
     if (HEADLESS === 'true') {
+      chromeDriverLogs = join('logs', 'chromedriver-headless.log');
       wptRunArgs.push('--binary-arg=--headless=new');
     }
     wptRunArgs.push(
@@ -167,7 +170,7 @@ if (RUN_TESTS === 'true') {
         'iife',
         'mapperTab.js'
       )}`,
-      `--webdriver-arg=--log-path=${join('out', 'chromedriver.log')}`,
+      `--webdriver-arg=--log-path=${chromeDriverLogs}`,
       `--webdriver-arg=--log-level=${VERBOSE === 'true' ? 'ALL' : 'INFO'}`,
       '--yes'
     );


### PR DESCRIPTION
Store all logs under `logs` rather than under `out`. Also separates the headless and headful.