### PR TITLE
build: call `cddlconv` direcly

### DIFF
--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -88,15 +88,16 @@ jobs:
           name: permissions-cddl
       - name: Generate TypeScript types for the main spec
         run: npm run bidi-types -- --cddl-file all.cddl
-      - name: Generate TypeScript types for Permissions spec
-        run: cddlconv -f zod permissions.cddl > src/protocol/generated/webdriver-bidi-permissions.ts
+      - name: Generate types for Permissions spec
+        run: cddlconv permissions.cddl > src/protocol/generated/webdriver-bidi-permissions.ts
+      - name: Generate parser for Permissions spec
+        run: cddlconv -f zod permissions.cddl > src/protocol-parser/generated/webdriver-bidi-permissions.ts
       - run: git diff
       # Needed for `npm run format`.
       - run: python -m pip install pre-commit
       - run: python -m pip freeze --local
       - name: Run formatter
         run: npm run format || exit 0
-      - run: git diff
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:

--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Generate TypeScript types for the main spec
         run: npm run bidi-types -- --cddl-file all.cddl
       - name: Generate TypeScript types for Permissions spec
-        run: npm run bidi-types -- --cddl-file permissions.cddl --ts-file src/protocol/generated/webdriver-bidi-permissions.ts --zod-file src/protocol-parser/generated/webdriver-bidi-permissions.ts
+        run: cddlconv -f zod permissions.cddl > src/protocol/generated/webdriver-bidi-permissions.ts
       - run: git diff
       # Needed for `npm run format`.
       - run: python -m pip install pre-commit

--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -96,6 +96,7 @@ jobs:
       - run: python -m pip freeze --local
       - name: Run formatter
         run: npm run format || exit 0
+      - run: git diff
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:


### PR DESCRIPTION
Temp work-around to fix issue with generating permission types https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/7582257569/job/20651521640