### PR TITLE
test: extend e2e with chromedriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "pre-commit": "pre-commit run --hook-stage manual --all-files",
     "prepare": "wireit",
     "rollup": "wireit",
-    "server": "npm run server-headless --",
-    "server-headful": "wireit",
-    "server-headless": "wireit",
+    "server": "wireit",
     "test": "wireit",
     "tsc": "wireit",
     "unit": "wireit",
@@ -41,8 +39,11 @@
     "e2e-headful": {
       "command": "pipenv run python -m pytest --ignore=tests/input",
       "dependencies": [
-        "server-headful"
+        "server"
       ],
+      "env": {
+        "HEADLESS": false
+      },
       "files": [
         "pytest.ini",
         "tests/**/*.py"
@@ -51,11 +52,26 @@
     "e2e-headless": {
       "command": "pipenv run python -m pytest",
       "dependencies": [
-        "server-headless"
+        "server"
       ],
+      "env": {
+        "HEADLESS": false
+      },
       "files": [
         "pytest.ini",
         "tests/**/*.py"
+      ]
+    },
+    "install-browser": {
+      "command": "node install-browser.mjs",
+      "files": [
+        ".browser"
+      ]
+    },
+    "install-driver": {
+      "command": "node install-browser.mjs --chromedriver",
+      "files": [
+        ".browser"
       ]
     },
     "prepare": {
@@ -76,19 +92,8 @@
         "lib/iife/mapperTab.js"
       ]
     },
-    "server-headful": {
-      "command": "npm run server-headless -- --headless=false",
-      "service": {
-        "readyWhen": {
-          "lineMatches": "BiDi server is listening on port \\d+"
-        }
-      },
-      "dependencies": [
-        "rollup"
-      ]
-    },
-    "server-headless": {
-      "command": "tools/run-bidi-server.mjs --headless=true",
+    "server": {
+      "command": "tools/run-bidi-server.mjs",
       "files": [
         "tools/run-bidi-server.mjs"
       ],

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -45,7 +45,6 @@ type ChromeOptions = {
   chromeArgs: string[];
   chromeBinary?: string;
   channel: ChromeReleaseChannel;
-  headless: boolean;
 };
 
 /**
@@ -70,10 +69,8 @@ export class BrowserInstance {
       path.join(os.tmpdir(), 'web-driver-bidi-server-')
     );
     // See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
+
     const chromeArguments = [
-      ...(chromeOptions.headless
-        ? ['--headless', '--hide-scrollbars', '--mute-audio']
-        : []),
       // keep-sorted start
       '--allow-browser-signin=false',
       '--disable-component-update',
@@ -91,9 +88,7 @@ export class BrowserInstance {
       '--use-mock-keychain',
       `--user-data-dir=${profileDir}`,
       // keep-sorted end
-      ...chromeOptions.chromeArgs.filter(
-        (arg) => !arg.startsWith('--headless')
-      ),
+      ...chromeOptions.chromeArgs,
       'about:blank',
     ];
 

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -45,7 +45,6 @@ type ChromeOptions = {
   readonly chromeArgs: string[];
   readonly chromeBinary?: string;
   readonly channel: ChromeReleaseChannel;
-  readonly headless: boolean;
 };
 
 type SessionOptions = {
@@ -60,13 +59,11 @@ export class WebSocketServer {
   /**
    * @param bidiPort Port to start ws server on.
    * @param channel
-   * @param headless
    * @param verbose
    */
   static run(
     bidiPort: number,
     channel: ChromeReleaseChannel,
-    headless: boolean,
     verbose: boolean
   ) {
     const server = http.createServer(
@@ -102,8 +99,7 @@ export class WebSocketServer {
                 sessionOptions: {
                   chromeOptions: this.#getChromeOptions(
                     jsonBody.capabilities,
-                    channel,
-                    headless
+                    channel
                   ),
                   mapperOptions: this.#getMapperOptions(jsonBody.capabilities),
                   verbose,
@@ -279,8 +275,7 @@ export class WebSocketServer {
             const sessionOptions = {
               chromeOptions: this.#getChromeOptions(
                 parsedCommandData.params?.capabilities,
-                channel,
-                headless
+                channel
               ),
               mapperOptions: this.#getMapperOptions(
                 parsedCommandData.params?.capabilities
@@ -446,15 +441,13 @@ export class WebSocketServer {
 
   static #getChromeOptions(
     capabilities: any,
-    channel: ChromeReleaseChannel,
-    headless: boolean
+    channel: ChromeReleaseChannel
   ): ChromeOptions {
     const chromeCapabilities =
       capabilities?.alwaysMatch?.['goog:chromeOptions'];
     return {
       chromeArgs: chromeCapabilities?.args ?? [],
       channel,
-      headless,
       chromeBinary: chromeCapabilities?.binary ?? undefined,
     };
   }

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -179,7 +179,12 @@ export class WebSocketServer {
       // Session is set either by Classic or BiDi commands.
       let session: Session | undefined;
 
-      const requestSessionId = (request.resource ?? '').split('/').pop();
+      // Request to `/session` should be treated as a new session request.
+      let requestSessionId: string | undefined = '';
+      if ((request.resource ?? '').startsWith(`/session/`)) {
+        requestSessionId = (request.resource ?? '').split('/').pop() ?? '';
+      }
+
       debugInternal(
         `new WS request received. Path: ${JSON.stringify(
           request.resourceURL.path
@@ -316,6 +321,46 @@ export class WebSocketServer {
                 sessionId: session.sessionId,
                 capabilities: {},
               },
+            },
+            connection
+          );
+          return;
+        }
+
+        // Handle ending session. Close browser if open, remove session.
+        if (parsedCommandData.method === 'session.end') {
+          if (session === undefined) {
+            debugInfo('WS connection does not have an associated session.');
+
+            this.#respondWithError(
+              connection,
+              plainCommandData,
+              ErrorCode.SessionNotCreated,
+              'WS connection does not have an associated session.'
+            );
+            return;
+          }
+
+          try {
+            await this.#closeBrowserInstanceIfLaunched(session);
+            this.#sessions.delete(session.sessionId);
+          } catch (e: any) {
+            debugInfo('Error while closing session', e);
+
+            this.#respondWithError(
+              connection,
+              plainCommandData,
+              ErrorCode.UnknownError,
+              `Session cannot be closed. Error: ${e?.message}`
+            );
+            return;
+          }
+
+          this.#sendClientMessage(
+            {
+              id: parsedCommandData.id,
+              type: 'success',
+              result: {},
             },
             connection
           );

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -39,11 +39,6 @@ function parseArguments(): {
     default: ChromeReleaseChannel.DEV,
   });
 
-  parser.add_argument('--headless', {
-    help: 'Sets if browser should run in headless or headful mode. Default is true.',
-    default: true,
-  });
-
   parser.add_argument('-p', '--port', {
     help: 'Port that BiDi server should listen to. Default is 8080.',
     type: 'int',
@@ -63,12 +58,11 @@ function parseArguments(): {
   try {
     const args = parseArguments();
     const {channel, port} = args;
-    const headless = args.headless !== 'false';
     const verbose = args.verbose === true;
 
     debugInfo('Launching BiDi server...');
 
-    WebSocketServer.run(port, channel, headless, verbose);
+    WebSocketServer.run(port, channel, verbose);
     debugInfo('BiDi server launched');
   } catch (e) {
     debugInfo('Error launching BiDi server', e);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,9 @@ async def websocket(request, _websocket_connection):
         capabilities["goog:chromeOptions"]["binary"] = maybe_browser_bin
     maybe_headless = os.getenv("HEADLESS")
     if maybe_headless == "true":
-        capabilities["goog:chromeOptions"]["args"] = ["--headless=new"]
+        capabilities["goog:chromeOptions"]["args"] = [
+            "--headless=new", '--hide-scrollbars', '--mute-audio'
+        ]
 
     capabilities.update(request.param['capabilities'])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,9 +43,13 @@ async def _websocket_connection():
     active BiDi session.
     """
     port = os.getenv("PORT", 8080)
-    url = f"ws://localhost:{port}"
+    url = f"ws://localhost:{port}/session"
     async with websockets.connect(url) as connection:
         yield connection
+        await execute_command(connection, {
+            "method": "session.end",
+            "params": {}
+        })
 
 
 @pytest_asyncio.fixture(params=[{"capabilities": {}}])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,15 @@ async def _websocket_connection():
 @pytest_asyncio.fixture(params=[{"capabilities": {}}])
 async def websocket(request, _websocket_connection):
     """Return a websocket with an active BiDi session."""
-    capabilities = {
-        "webSocketUrl": True,
-    }
+    capabilities = {"webSocketUrl": True, "goog:chromeOptions": {}}
+
+    maybe_browser_bin = os.getenv("BROWSER_BIN")
+    if maybe_browser_bin:
+        capabilities["goog:chromeOptions"]["binary"] = maybe_browser_bin
+    maybe_headless = os.getenv("HEADLESS")
+    if maybe_headless == "true":
+        capabilities["goog:chromeOptions"]["args"] = ["--headless=new"]
+
     capabilities.update(request.param['capabilities'])
 
     await execute_command(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,11 @@ async def _websocket_connection():
 @pytest_asyncio.fixture(params=[{"capabilities": {}}])
 async def websocket(request, _websocket_connection):
     """Return a websocket with an active BiDi session."""
-    capabilities = request.param['capabilities']
+    capabilities = {
+        "webSocketUrl": True,
+    }
+    capabilities.update(request.param['capabilities'])
+
     await execute_command(
         _websocket_connection, {
             "method": "session.new",

--- a/tools/run-bidi-server.mjs
+++ b/tools/run-bidi-server.mjs
@@ -40,13 +40,11 @@ function usage() {
         [CHROMEDRIVER_BIN=<path, default: download pinned chrome>]
         [DEBUG=*]
         [DEBUG_COLORS=<yes | no>]
-        [HEADLESS=<default: true | false>]
         [LOG_DIR=logs]
         [NODE_OPTIONS=--unhandled-rejections=strict]
         [PORT=8080]
         ${process.argv[1]}
         [--channel,-c=<channel, default: CHANNEL environment variable>]
-        [--headless=<true | false, default: HEADLESS environment variable>]
         [--verbose,-v<true | default: false>]
       `
   );
@@ -68,7 +66,6 @@ let CHROMEDRIVER_BIN = process.env.CHROMEDRIVER_BIN;
 const DEBUG = process.env.DEBUG ?? 'bidi:*';
 const DEBUG_COLORS = process.env.DEBUG_COLORS || 'false';
 const DEBUG_DEPTH = process.env.DEBUG_DEPTH || '10';
-let HEADLESS = process.env.HEADLESS | 'true';
 const LOG_DIR = process.env.LOG_DIR || 'logs';
 const LOG_FILE =
   process.env.LOG_FILE ||
@@ -88,14 +85,6 @@ const restArgs = process.argv.slice(2);
 for (const arg of restArgs) {
   const argParts = arg.split('=');
   switch (argParts[0]) {
-    case '--headless':
-      if (CHROMEDRIVER === 'true') {
-        log(
-          `WARNING! Chromedriver '--headless' is not supported via CLI. It can only be set via capabilities.`
-        );
-      }
-      HEADLESS = argParts[1] || 'true';
-      break;
     case '-c':
     case '--channel':
       if (argParts[1] === undefined) {
@@ -163,8 +152,6 @@ if (CHROMEDRIVER === 'true') {
       resolve(join('lib', 'cjs', 'bidiServer', 'index.js')),
       `--channel`,
       CHANNEL,
-      `--headless`,
-      HEADLESS,
       `--verbose`,
       VERBOSE,
       ...process.argv.slice(2),

--- a/tools/run-bidi-server.mjs
+++ b/tools/run-bidi-server.mjs
@@ -22,8 +22,6 @@ import {createWriteStream, mkdirSync} from 'fs';
 import {basename, join, resolve} from 'path';
 
 import {packageDirectorySync} from 'pkg-dir';
-import yargs from 'yargs';
-import {hideBin} from 'yargs/helpers';
 
 // Changing the current work directory to the package directory.
 process.chdir(packageDirectorySync());
@@ -33,57 +31,144 @@ function log(message) {
   console.log(`(${basename(process.argv[1])}) ${message}`);
 }
 
-const argv = yargs(hideBin(process.argv))
-  .usage(
-    `[CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [DEBUG_COLORS=<yes | no>] [HEADLESS=<true | false>] [LOG_DIR=logs] [NODE_OPTIONS=--unhandled-rejections=strict] [PORT=8080] $0`
-  )
-  .option('headless', {
-    describe:
-      'Whether to start the server in headless or headful mode. The --headless flag takes precedence over the HEADLESS environment variable.',
-    type: 'boolean',
-    default: process.env.HEADLESS === 'true',
-  })
-  .parse();
+function usage() {
+  log(
+    `Usage:
+        [BROWSER_BIN=<path, default: download pinned chrome>]
+        [CHANNEL=<stable | beta | canary | dev>]
+        [CHROMEDRIVER=<true | default: false>]
+        [CHROMEDRIVER_BIN=<path, default: download pinned chrome>]
+        [DEBUG=*]
+        [DEBUG_COLORS=<yes | no>]
+        [HEADLESS=<default: true | false>]
+        [LOG_DIR=logs]
+        [NODE_OPTIONS=--unhandled-rejections=strict]
+        [PORT=8080]
+        ${process.argv[1]}
+        [--channel,-c=<channel, default: CHANNEL environment variable>]
+        [--headless=<true | false, default: HEADLESS environment variable>]
+        [--verbose,-v<true | default: false>]
+      `
+  );
+}
+
+if (
+  process.argv.length > 2 &&
+  (process.argv.includes('-h') || process.argv.includes('--help'))
+) {
+  usage();
+  process.exit(0);
+}
 
 let BROWSER_BIN = process.env.BROWSER_BIN;
 let CHANNEL = process.env.CHANNEL || 'local';
-if (CHANNEL === 'local') {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  BROWSER_BIN = spawnSync('node', [join('tools', 'install-browser.mjs')])
-    .stdout.toString()
-    .trim();
-  // Need to pass valid CHANNEL to the command below
-  CHANNEL = 'canary';
-}
-
+let CHROMEDRIVER = process.env.CHROMEDRIVER || 'false';
+let CHROMEDRIVER_BIN = process.env.CHROMEDRIVER_BIN;
 // DEBUG = (empty string) is allowed.
 const DEBUG = process.env.DEBUG ?? 'bidi:*';
 const DEBUG_COLORS = process.env.DEBUG_COLORS || 'false';
 const DEBUG_DEPTH = process.env.DEBUG_DEPTH || '10';
+let HEADLESS = process.env.HEADLESS | 'true';
 const LOG_DIR = process.env.LOG_DIR || 'logs';
 const LOG_FILE =
   process.env.LOG_FILE ||
-  join(LOG_DIR, `${new Date().toISOString().replace(/[:]/g, '-')}.log`);
+  join(
+    LOG_DIR,
+    `${new Date().toISOString().replace(/[:]/g, '-')}.${
+      CHROMEDRIVER === 'true' ? 'chromedriver' : 'mapper'
+    }.log`
+  );
 const NODE_OPTIONS =
   process.env.NODE_OPTIONS || '--unhandled-rejections=strict';
 const PORT = process.env.PORT || '8080';
+let VERBOSE = process.env.VERBOSE || 'false';
 
-log(`Starting BiDi Server with DEBUG='${DEBUG}'...`);
+// Parse arguments.
+const restArgs = process.argv.slice(2);
+for (const arg of restArgs) {
+  const argParts = arg.split('=');
+  switch (argParts[0]) {
+    case '--headless':
+      if (CHROMEDRIVER === 'true') {
+        log(
+          `WARNING! Chromedriver '--headless' is not supported via CLI. It can only be set via capabilities.`
+        );
+      }
+      HEADLESS = argParts[1] || 'true';
+      break;
+    case '-c':
+    case '--channel':
+      if (argParts[1] === undefined) {
+        log(`Missing channel value in ${arg}.`);
+        usage();
+        process.exit(1);
+      }
+      CHANNEL = argParts[1];
+      break;
+    case '-v':
+    case '--verbose':
+      VERBOSE = argParts[1] || 'true';
+      break;
+    default:
+      log(`Unknown argument ${arg}.`);
+      usage();
+      process.exit(1);
+  }
+}
+
+if (CHANNEL === 'local') {
+  if (!BROWSER_BIN) {
+    // Download pinned chrome.
+    BROWSER_BIN = spawnSync('node', [join('tools', 'install-browser.mjs')])
+      .stdout.toString()
+      .trim();
+  }
+
+  if (CHROMEDRIVER === 'true') {
+    if (!CHROMEDRIVER_BIN) {
+      // Download pinned chromedriver.
+      CHROMEDRIVER_BIN = spawnSync('node', [
+        join('tools', 'install-browser.mjs'),
+        '--chromedriver',
+      ])
+        .stdout.toString()
+        .trim();
+    }
+  }
+
+  // Need to pass valid CHANNEL to the command below
+  CHANNEL = 'canary';
+}
 
 mkdirSync(LOG_DIR, {recursive: true});
 
-const subprocess = spawn(
-  'node',
-  [
-    resolve(join('lib', 'cjs', 'bidiServer', 'index.js')),
-    `--channel`,
-    CHANNEL,
-    `--headless`,
-    argv.headless,
-    ...process.argv.slice(2),
-  ],
-  {
-    stdio: ['inherit', 'pipe', 'pipe'],
+let runParams;
+if (CHROMEDRIVER === 'true') {
+  runParams = {
+    file: CHROMEDRIVER_BIN,
+    args: [
+      `--port=${PORT}`,
+      `--bidi-mapper-path=${resolve(join('lib', 'iife', 'mapperTab.js'))}`,
+      // `--log-path=${LOG_FILE}`,
+      // `--append-log`,
+      `--readable-timestamp`,
+      ...(VERBOSE === 'true' ? ['--verbose', '--replayable'] : []),
+    ],
+    env: {},
+  };
+} else {
+  runParams = {
+    file: 'node',
+    args: [
+      resolve(join('lib', 'cjs', 'bidiServer', 'index.js')),
+      `--channel`,
+      CHANNEL,
+      `--headless`,
+      HEADLESS,
+      `--verbose`,
+      VERBOSE,
+      ...process.argv.slice(2),
+    ],
     env: {
       ...process.env,
       // keep-sorted start
@@ -94,9 +179,22 @@ const subprocess = spawn(
       NODE_OPTIONS,
       PORT,
       // keep-sorted end
+      ...(VERBOSE === 'true' ? ['DEBUG=*', 'DEBUG_DEPTH=999'] : []),
     },
-  }
-);
+  };
+}
+
+log(`Starting ${CHROMEDRIVER === 'true' ? 'ChromeDriver' : 'Mapper'}...`);
+
+if (VERBOSE === 'true') {
+  log(`Environment variables: `, runParams.env);
+  log(`Command: ${runParams.file} ${runParams.args.join(' ')}`);
+}
+
+const subprocess = spawn(runParams.file, runParams.args, {
+  stdio: ['inherit', 'pipe', 'pipe'],
+  env: runParams.env,
+});
 
 if (subprocess.stderr) {
   subprocess.stderr.pipe(process.stdout);

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -123,7 +123,6 @@ if (RUN_TESTS === 'true') {
   const wptRunArgs = [
     '--binary',
     BROWSER_BIN,
-    `--webdriver-arg=--headless=${HEADLESS}`,
     '--log-wptreport',
     WPT_REPORT,
     '--manifest',
@@ -180,11 +179,10 @@ if (RUN_TESTS === 'true') {
       '--yes'
     );
   } else {
-    wptRunArgs.push(
-      `--webdriver-arg=--headless=${HEADLESS}`,
-      '--webdriver-binary',
-      join('tools', 'run-bidi-server.mjs')
-    );
+    if (HEADLESS === 'true') {
+      wptRunArgs.push('--binary-arg=--headless=new');
+    }
+    wptRunArgs.push('--webdriver-binary', join('tools', 'run-bidi-server.mjs'));
     log('Using pure mapper...');
   }
 
@@ -209,6 +207,8 @@ if (RUN_TESTS === 'true') {
     // The last argument is the test.
     test
   );
+
+  console.log('... running wpt: ', wptBinary, wptRunArgs.join(' '));
 
   run_status = spawnSync(wptBinary, ['run', ...wptRunArgs], {
     stdio: 'inherit',

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -180,7 +180,7 @@ if (RUN_TESTS === 'true') {
     );
   } else {
     if (HEADLESS === 'true') {
-      wptRunArgs.push('--binary-arg=--headless=new');
+      wptRunArgs.push('--binary-arg=--headless');
     }
     wptRunArgs.push('--webdriver-binary', join('tools', 'run-bidi-server.mjs'));
     log('Using pure mapper...');
@@ -196,6 +196,7 @@ if (RUN_TESTS === 'true') {
     .replace('mapper/headless/', '')
     .replace('mapper/headful/', '')
     .replace('chromedriver/headless/', '')
+    .replace('chromedriver/headful/', '')
     .replace('.ini', '');
 
   log(`Running "${test}" with "${BROWSER_BIN}"...`);
@@ -208,7 +209,7 @@ if (RUN_TESTS === 'true') {
     test
   );
 
-  console.log('... running wpt: ', wptBinary, wptRunArgs.join(' '));
+  console.log('... running wpt: ', wptBinary, ['run', ...wptRunArgs].join(' '));
 
   run_status = spawnSync(wptBinary, ['run', ...wptRunArgs], {
     stdio: 'inherit',


### PR DESCRIPTION
* extend e2e with chromedriver
* align js runner with BiDi protocol
* provide headless in capabilities

Blocked by:
1. Chromedriver converts `id` in response to double instead of `js-uint`.
2. JS runner disregards `headless` args from capabilities.