### PR TITLE
feat: respect partition

### DIFF
--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -29,7 +29,7 @@ def get_bidi_cookie(cookie_name,
                     domain,
                     path="/",
                     http_only=False,
-                    secure=True,
+                    secure=False,
                     same_site='none',
                     expiry=None):
     """ Return a cookie object with the given parameters."""
@@ -50,14 +50,13 @@ def get_bidi_cookie(cookie_name,
     } if expiry is not None else {})
 
 
-async def set_cookie(websocket, context_id, bidi_cookie, partition=None):
+async def set_cookie(websocket, context_id, bidi_cookie, partition):
     """ Set cookie via BiDi command."""
     await execute_command(
         websocket, {
             'method': 'storage.setCookie',
             'params': {
                 'cookie': bidi_cookie,
-            } | ({
                 'partition': partition
-            } if partition is not None else {})
+            }
         })

--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -17,21 +17,38 @@ from urllib.parse import urlparse
 
 from test_helpers import execute_command
 
+NON_SECURE_ADDRESS = 'http://some_non_secure_address.com'
+SECURE_ADDRESS = 'https://some_secure_address.com'
 
-def get_hostname_and_origin(url):
+BASE_DOMAIN_ADDRESS = 'https://some_domain.com'
+SUB_DOMAIN_ADDRESS = 'https://subdomain.some_domain.com'
+
+SOME_COOKIE_NAME = 'some_cookie_name'
+SOME_COOKIE_VALUE = 'some_cookie_value'
+ANOTHER_COOKIE_NAME = 'another_cookie_name'
+ANOTHER_COOKIE_VALUE = 'another_cookie_value'
+YET_ANOTHER_COOKIE_NAME = 'yet_another_cookie_name'
+YET_ANOTHER_COOKIE_VALUE = 'yet_another_cookie_value'
+
+
+def get_hostname_and_origin(url, share_with_subdomains=False):
     """ Return the hostname and origin of cookies for the given url."""
     parts = urlparse(url)
-    return parts.hostname, parts.scheme + '://' + parts.hostname
+    if parts.hostname is None or parts.scheme is None:
+        return None, None
+    # Leading `.` means the cookie is shared with subdomains.
+    return ('.' if share_with_subdomains else '') + str(
+        parts.hostname), parts.scheme + '://' + parts.hostname
 
 
-def get_bidi_cookie(cookie_name,
-                    cookie_value,
-                    domain,
-                    path="/",
-                    http_only=False,
-                    secure=False,
-                    same_site='none',
-                    expiry=None):
+def expected_bidi_cookie(cookie_name,
+                         cookie_value,
+                         domain,
+                         path="/",
+                         http_only=False,
+                         secure=False,
+                         same_site='none',
+                         expiry=None):
     """ Return a cookie object with the given parameters."""
     return {
         'domain': domain,
@@ -45,18 +62,52 @@ def get_bidi_cookie(cookie_name,
             'type': 'string',
             'value': cookie_value,
         },
-    } | ({
-        'expiry': expiry
-    } if expiry is not None else {})
+    } \
+        | ({
+               'expiry': expiry
+           } if expiry is not None else {})
 
 
-async def set_cookie(websocket, context_id, bidi_cookie, partition):
+async def set_cookie(
+    websocket,
+    cookie_name,
+    cookie_value,
+    domain,
+    origin,
+    path="/",
+    http_only=False,
+    secure=False,
+    same_site=None,
+    expiry=None,
+):
     """ Set cookie via BiDi command."""
+
+    cookie = {
+        'domain': domain,
+        'httpOnly': http_only,
+        'name': cookie_name,
+        'path': path,
+        # 'sameSite': same_site,
+        'secure': secure,
+        'size': len(cookie_name) + len(cookie_value),
+        'value': {
+            'type': 'string',
+            'value': cookie_value,
+        },
+    }
+    if expiry is not None:
+        cookie['expiry'] = expiry
+
+    if same_site is not None:
+        cookie['sameSite'] = same_site
+
+    partition = {'type': 'storageKey', 'sourceOrigin': origin}
+
     await execute_command(
         websocket, {
             'method': 'storage.setCookie',
             'params': {
-                'cookie': bidi_cookie,
+                'cookie': cookie,
                 'partition': partition
             }
         })

--- a/tests/storage/test_get_cookies.py
+++ b/tests/storage/test_get_cookies.py
@@ -15,43 +15,20 @@
 
 import pytest
 from anys import ANY_DICT
-from storage import get_bidi_cookie, get_hostname_and_origin, set_cookie
+from storage import (ANOTHER_COOKIE_NAME, ANOTHER_COOKIE_VALUE,
+                     BASE_DOMAIN_ADDRESS, NON_SECURE_ADDRESS, SECURE_ADDRESS,
+                     SOME_COOKIE_NAME, SOME_COOKIE_VALUE, SUB_DOMAIN_ADDRESS,
+                     YET_ANOTHER_COOKIE_NAME, YET_ANOTHER_COOKIE_VALUE,
+                     expected_bidi_cookie, get_hostname_and_origin, set_cookie)
 from test_helpers import execute_command, goto_url
 
-SOME_COOKIE_NAME = 'some_cookie_name'
-SOME_COOKIE_VALUE = 'some_cookie_value'
-ANOTHER_COOKIE_NAME = 'another_cookie_name'
-ANOTHER_COOKIE_VALUE = 'another_cookie_value'
 
-
+@pytest.mark.parametrize('url', [NON_SECURE_ADDRESS, SECURE_ADDRESS])
 @pytest.mark.asyncio
-async def test_cookies_get_with_empty_params(websocket, context_id,
-                                             example_url):
-    await goto_url(websocket, context_id, example_url)
-
-    hostname, origin = get_hostname_and_origin(example_url)
-    cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname)
-    await set_cookie(websocket, context_id, cookie)
-
-    res = await execute_command(websocket, {
-        'method': 'storage.getCookies',
-        'params': {}
-    })
-
-    assert res == {
-        'cookies': [cookie],
-        'partitionKey': {},
-    }
-
-
-@pytest.mark.asyncio
-async def test_cookies_get_with_partition_source_origin(
-        websocket, context_id, example_url):
-    await goto_url(websocket, context_id, example_url)
-
-    hostname, origin = get_hostname_and_origin(example_url)
-    cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname)
-    await set_cookie(websocket, context_id, cookie)
+async def test_cookies_get_with_partition_source_origin(websocket, url):
+    hostname, origin = get_hostname_and_origin(url)
+    await set_cookie(websocket, SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname,
+                     origin)
 
     res = await execute_command(
         websocket, {
@@ -65,7 +42,9 @@ async def test_cookies_get_with_partition_source_origin(
         })
 
     assert res == {
-        'cookies': [cookie],
+        'cookies': [
+            expected_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname)
+        ],
         'partitionKey': {
             'sourceOrigin': origin,
         },
@@ -74,11 +53,10 @@ async def test_cookies_get_with_partition_source_origin(
 
 @pytest.mark.asyncio
 async def test_cookies_get_with_unsupported_partition_key(
-        websocket, context_id, example_url):
-    await goto_url(websocket, context_id, example_url)
+        websocket, example_url):
     hostname, origin = get_hostname_and_origin(example_url)
-    cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname)
-    await set_cookie(websocket, context_id, cookie)
+    await set_cookie(websocket, SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname,
+                     origin)
 
     unknown_partition_key = 'UNKNOWN_PARTITION_KEY'
     unknown_partition_value = 'UNKNOWN_PARTITION_VALUE'
@@ -96,7 +74,8 @@ async def test_cookies_get_with_unsupported_partition_key(
         })
 
     assert res == {
-        'cookies': [cookie],
+        'cookies': [(expected_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE,
+                                          hostname))],
         'partitionKey': {
             'sourceOrigin': origin,
         },
@@ -106,12 +85,14 @@ async def test_cookies_get_with_unsupported_partition_key(
 @pytest.mark.asyncio
 async def test_cookies_get_with_partition_browsing_context(
         websocket, context_id, example_url):
+    hostname, origin = get_hostname_and_origin(example_url)
+    await set_cookie(websocket, SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname,
+                     origin)
+
+    # Navigate to the page with the cookie.
     await goto_url(websocket, context_id, example_url)
 
-    hostname, origin = get_hostname_and_origin(example_url)
-    cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, hostname)
-    await set_cookie(websocket, context_id, cookie)
-
+    # Use the browsing context as a partition.
     resp = await execute_command(
         websocket, {
             'method': 'storage.getCookies',
@@ -124,7 +105,8 @@ async def test_cookies_get_with_partition_browsing_context(
         })
 
     assert resp == {
-        'cookies': [cookie],
+        'cookies': [(expected_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE,
+                                          hostname))],
         'partitionKey': {
             'sourceOrigin': origin,
         },
@@ -132,72 +114,106 @@ async def test_cookies_get_with_partition_browsing_context(
 
 
 @pytest.mark.asyncio
-async def test_cookies_get_with_partition_browsing_context_about_blank(
-        websocket, context_id):
-    await goto_url(websocket, context_id, 'about:blank')
+async def test_cookie_get_domain_subdomains(websocket):
+    base_hostname, base_origin = get_hostname_and_origin(
+        BASE_DOMAIN_ADDRESS, True)
+    base_hostname = base_hostname
+    sub_hostname, sub_origin = get_hostname_and_origin(SUB_DOMAIN_ADDRESS)
 
+    await set_cookie(websocket, SOME_COOKIE_NAME, SOME_COOKIE_VALUE,
+                     base_hostname, base_origin)
+
+    await set_cookie(websocket, ANOTHER_COOKIE_NAME, ANOTHER_COOKIE_VALUE,
+                     sub_hostname, base_origin)
+
+    # Assert the base origin accesses only its own cookies.
     resp = await execute_command(
         websocket, {
             'method': 'storage.getCookies',
             'params': {
                 'partition': {
-                    'type': 'context',
-                    'context': context_id
+                    'type': 'storageKey',
+                    'sourceOrigin': base_origin,
                 }
             }
         })
-
     assert resp == {
-        'cookies': [],
+        'cookies': [
+            expected_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE,
+                                 base_hostname)
+        ],
         'partitionKey': {
-            'sourceOrigin': 'null',
+            'sourceOrigin': base_origin
         },
     }
 
+    # Assert subdomain's origin accesses base and subdomain's cookies.
+    resp = await execute_command(
+        websocket, {
+            'method': 'storage.getCookies',
+            'params': {
+                'partition': {
+                    'type': 'storageKey',
+                    'sourceOrigin': sub_origin,
+                }
+            }
+        })
+    assert len(resp['cookies']) == 2
+
 
 @pytest.mark.asyncio
-async def test_cookies_get_with_filter(websocket, context_id, example_url,
+async def test_cookies_get_with_filter(websocket, example_url,
                                        another_example_url):
-    await goto_url(websocket, context_id, example_url)
-
     domain, origin = get_hostname_and_origin(example_url)
-    some_cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, domain)
-    await set_cookie(websocket, context_id, some_cookie)
-
     another_domain, another_origin = get_hostname_and_origin(
         another_example_url)
-    another_cookie = get_bidi_cookie(ANOTHER_COOKIE_NAME, ANOTHER_COOKIE_VALUE,
-                                     another_domain)
-    await set_cookie(websocket, context_id, another_cookie)
+    await set_cookie(websocket, SOME_COOKIE_NAME, SOME_COOKIE_VALUE, domain,
+                     origin)
+    await set_cookie(websocket, ANOTHER_COOKIE_NAME, ANOTHER_COOKIE_VALUE,
+                     domain, origin)
+    await set_cookie(websocket, YET_ANOTHER_COOKIE_NAME,
+                     YET_ANOTHER_COOKIE_VALUE, another_domain, another_origin)
 
-    # # Filter by domain.
-    await assert_cookie_filter(websocket, context_id, {'domain': domain},
-                               some_cookie)
-    # # Filter by name.
-    await assert_cookie_filter(websocket, context_id,
-                               {'name': SOME_COOKIE_NAME}, some_cookie)
+    some_expected_cookie = expected_bidi_cookie(SOME_COOKIE_NAME,
+                                                SOME_COOKIE_VALUE, domain)
+    another_expected_cookie = expected_bidi_cookie(ANOTHER_COOKIE_NAME,
+                                                   ANOTHER_COOKIE_VALUE,
+                                                   domain)
+    yet_another_expected_cookie = expected_bidi_cookie(
+        YET_ANOTHER_COOKIE_NAME, YET_ANOTHER_COOKIE_VALUE, another_domain)
+
+    # Filter by domain.
+    await assert_cookie_filter(websocket, {'domain': another_domain},
+                               yet_another_expected_cookie, another_origin)
+
+    # Filter by name.
+    await assert_cookie_filter(websocket, {'name': SOME_COOKIE_NAME},
+                               some_expected_cookie, origin)
 
     # Filter by value.
     await assert_cookie_filter(
-        websocket, context_id,
+        websocket,
         {'value': {
             'type': 'string',
             'value': ANOTHER_COOKIE_VALUE
-        }}, another_cookie)
+        }}, another_expected_cookie, origin)
+
     # TODO: test other filters.
 
 
-async def assert_cookie_filter(websocket, context_id, cookie_filter,
-                               expected_cookie):
+async def assert_cookie_filter(websocket, cookie_filter, expected_cookie,
+                               origin):
+    partition = {'type': 'storageKey', 'sourceOrigin': origin}
+
     resp = await execute_command(
         websocket, {
             'method': 'storage.getCookies',
             'params': {
                 'filter': cookie_filter,
-                'partition': {
-                    'type': 'context',
-                    'context': context_id
-                }
+                'partition': partition
             }
         })
-    assert resp == {'cookies': [expected_cookie], 'partitionKey': ANY_DICT}
+    if expected_cookie is None:
+        assert resp == {'cookies': [], 'partitionKey': ANY_DICT}
+    else:
+        assert resp == {'cookies': [expected_cookie], 'partitionKey': ANY_DICT}


### PR DESCRIPTION
Apparently, the partition is a required field, not related to "partitioned" cookies. This PR intended to respect this fact.

The origin is a protocol + domain, no port of path.

**Open question:**
* When cookies are requested for the given origin, we should return only cookies accessible from the provided origin. Currently, we get all the cookies, and filter out those accessible by checking by `domain` and [`CookieSourceScheme`](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookieSourceScheme) fields.
  * Is there a way to avoid getting all the cookies?
  * Is there a way to check the cookie availability from the given origin? Eg [`Network.getCookies`](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-getCookies) does not seem to work, as it filters our cookies by `path`.

* Is there a way to say if the cookie was not set? Eg setting cookie with domain `.com` successes. But it is obviously is not set.

TODO:
* respect port