### PR TITLE
feat: return all cookies for a given browsing context

### DIFF
--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -13,15 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from urllib.parse import urlparse
-
 from test_helpers import execute_command
-
-
-def get_hostname_and_origin(url):
-    """ Return the hostname and origin of cookies for the given url."""
-    parts = urlparse(url)
-    return parts.hostname, parts.scheme + '://' + parts.hostname
 
 
 def get_bidi_cookie(cookie_name,

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
@@ -1,0 +1,6 @@
+[partition.py]
+  [test_partition_context]
+    expected: FAIL
+
+  [test_partition_context_frame]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
@@ -1,0 +1,6 @@
+[partition.py]
+  [test_partition_context]
+    expected: FAIL
+
+  [test_partition_context_frame]
+    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
@@ -1,0 +1,6 @@
+[partition.py]
+  [test_partition_context]
+    expected: FAIL
+
+  [test_partition_context_frame]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/set_cookie/partition.py.ini
@@ -1,0 +1,6 @@
+[partition.py]
+  [test_partition_context]
+    expected: FAIL
+
+  [test_partition_context_frame]
+    expected: FAIL


### PR DESCRIPTION
Return all the cookies if `getCookies` is called with `BrowsingContextPartitionDescriptor` is called, not only a partitioned one originated from it.

As per spec:
> * Let browsing context be the result of [trying](https://w3c.github.io/webdriver/#dfn-try) to [get a browsing context](https://w3c.github.io/webdriver-bidi/#get-a-browsing-context) given partition spec["context"].
> * Let partition key be the [key](https://w3c.github.io/webdriver-bidi/#storage-partition-key) of browsing context’s [associated storage partition](https://w3c.github.io/webdriver-bidi/#associated-storage-partition).
> * Return [success](https://w3c.github.io/webdriver/#dfn-success) with data partition key.

While: 
> Each [browsing context](https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context) also has an associated storage partition, which is the [storage partition](https://w3c.github.io/webdriver-bidi/#storage-partition) it uses to persist data.

In our case the **"associated storage partition"** is only a `UserContext`, support of which is out of scope yet.