### PR TITLE
fix: handle headless errors when creating a target

### DIFF
--- a/src/bidiMapper/domains/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextProcessor.ts
@@ -145,11 +145,13 @@ export class BrowsingContextProcessor {
         browserContextId: userContext === 'default' ? undefined : userContext,
       });
     } catch (err) {
-      // https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/devtools/protocol/target_handler.cc;l=1;drc=e80392ac11e48a691f4309964cab83a3a59e01c8
       if (
+        // See https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/devtools/protocol/target_handler.cc;l=90;drc=e80392ac11e48a691f4309964cab83a3a59e01c8
         (err as Error).message.startsWith(
           'Failed to find browser context with id'
-        )
+        ) ||
+        // See https://source.chromium.org/chromium/chromium/src/+/main:headless/lib/browser/protocol/target_handler.cc;l=49;drc=e80392ac11e48a691f4309964cab83a3a59e01c8
+        (err as Error).message === 'browserContextId'
       ) {
         throw new NoSuchUserContextException(
           `The context ${userContext} was not found`


### PR DESCRIPTION
the old headless has a different implementation.

Test coverage will be provided by WPT.