### PR TITLE
chore: fix `update-browser-version`

### DIFF
--- a/.github/workflows/update-browser-version.yml
+++ b/.github/workflows/update-browser-version.yml
@@ -16,11 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
       - name: Checkout `browser-automation-bot/update-browser-version` if exits
         run: |
           (git ls-remote --exit-code --heads origin refs/heads/browser-automation-bot/update-browser-version &&
           git checkout browser-automation-bot/update-browser-version &&
-          git rebase main) || exit 0
+          git rebase origin/main) || exit 0
       - name: Set up Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
@@ -33,6 +35,7 @@ jobs:
         with:
           token: ${{ secrets.BROWSER_AUTOMATION_BOT_TOKEN }}
           branch: browser-automation-bot/update-browser-version
+          base: origin/main
           delete-branch: true
           committer: Browser Automation Bot <browser-automation-bot@google.com>
           author: Browser Automation Bot <browser-automation-bot@google.com>


### PR DESCRIPTION
Don't override previous changes in the branch.

1. The action step ["Checkout `browser-automation-bot/update-browser-version` if exits"](https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/7693953409/job/20963706285) failed with "error: pathspec 'browser-automation-bot/update-browser-version' did not match any file(s) known to git". `fetch-depth: 0` should fix the issue.
2. The `Create Pull Request` step defaults base to the checked out branch, which is not correct in case of the task was run from a branch.