### PR TITLE
feat: support user context in cookies API

### DIFF
--- a/src/bidiMapper/domains/storage/StorageProcessor.ts
+++ b/src/bidiMapper/domains/storage/StorageProcessor.ts
@@ -50,9 +50,7 @@ export class StorageProcessor {
     const cdpResponse = await this.#browserCdpClient.sendCommand(
       'Storage.getCookies',
       {
-        ...(partitionKey.userContext === undefined
-          ? {}
-          : {browserContextId: partitionKey.userContext}),
+   browserContextId: partitionKey.userContext,
       }
     );
 

--- a/src/bidiMapper/domains/storage/StorageProcessor.ts
+++ b/src/bidiMapper/domains/storage/StorageProcessor.ts
@@ -50,7 +50,7 @@ export class StorageProcessor {
     const cdpResponse = await this.#browserCdpClient.sendCommand(
       'Storage.getCookies',
       {
-   browserContextId: partitionKey.userContext,
+        browserContextId: partitionKey.userContext,
       }
     );
 
@@ -81,9 +81,7 @@ export class StorageProcessor {
     try {
       await this.#browserCdpClient.sendCommand('Storage.setCookies', {
         cookies: [cdpCookie],
-        ...(partitionKey.userContext === undefined
-          ? {}
-          : {browserContextId: partitionKey.userContext}),
+        browserContextId: partitionKey.userContext,
       });
     } catch (e: any) {
       this.#logger?.(LogType.debugError, e);

--- a/src/bidiMapper/domains/storage/StorageProcessor.ts
+++ b/src/bidiMapper/domains/storage/StorageProcessor.ts
@@ -49,7 +49,11 @@ export class StorageProcessor {
 
     const cdpResponse = await this.#browserCdpClient.sendCommand(
       'Storage.getCookies',
-      {}
+      {
+        ...(partitionKey.userContext === undefined
+          ? {}
+          : {browserContextId: partitionKey.userContext}),
+      }
     );
 
     const filteredBiDiCookies = cdpResponse.cookies
@@ -79,6 +83,9 @@ export class StorageProcessor {
     try {
       await this.#browserCdpClient.sendCommand('Storage.setCookies', {
         cookies: [cdpCookie],
+        ...(partitionKey.userContext === undefined
+          ? {}
+          : {browserContextId: partitionKey.userContext}),
       });
     } catch (e: any) {
       this.#logger?.(LogType.debugError, e);
@@ -93,14 +100,18 @@ export class StorageProcessor {
     descriptor: Storage.BrowsingContextPartitionDescriptor
   ): Storage.PartitionKey {
     const browsingContextId: string = descriptor.context;
-    // Assert the browsing context exists.
-    this.#browsingContextStorage.getContext(browsingContextId);
+    const browsingContext =
+      this.#browsingContextStorage.getContext(browsingContextId);
     // https://w3c.github.io/webdriver-bidi/#associated-storage-partition.
     // Each browsing context also has an associated storage partition, which is the
     // storage partition it uses to persist data. In Chromium it's a `BrowserContext`
     // which maps to BiDi `UserContext`.
-    // TODO: extend with UserContext.
-    return {};
+    return {
+      userContext:
+        browsingContext.userContext === 'default'
+          ? undefined
+          : browsingContext.userContext,
+    };
   }
 
   #expandStoragePartitionSpecByStorageKey(
@@ -120,13 +131,16 @@ export class StorageProcessor {
       }
     }
 
+    const userContext =
+      descriptor.userContext === 'default' ? undefined : descriptor.userContext;
+
     // Partition spec is a storage partition.
     // Let partition key be partition spec.
     for (const [key, value] of Object.entries(descriptor)) {
       if (
         key !== undefined &&
         value !== undefined &&
-        !['type', 'sourceOrigin'].includes(key)
+        !['type', 'sourceOrigin', 'userContext'].includes(key)
       ) {
         unsupportedPartitionKeys.set(key, value);
       }
@@ -143,6 +157,7 @@ export class StorageProcessor {
 
     return {
       ...(sourceOrigin === undefined ? {} : {sourceOrigin}),
+      ...(userContext === undefined ? {} : {userContext}),
     };
   }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,13 +80,16 @@ async def another_context_id(create_context):
 @pytest_asyncio.fixture
 def create_context(websocket):
     """Return a browsing context factory."""
-    async def create_context():
-        result = await execute_command(websocket, {
-            "method": "browsingContext.create",
-            "params": {
-                "type": "tab"
-            }
-        })
+    async def create_context(user_context=None):
+        result = await execute_command(
+            websocket, {
+                "method": "browsingContext.create",
+                "params": {
+                    "type": "tab"
+                } | ({
+                    "userContext": user_context
+                } if user_context is not None else {})
+            })
         return result['context']
 
     return create_context
@@ -377,3 +380,14 @@ async def iframe_id(websocket, context_id: str, html_iframe_same_origin, html):
     await goto_url(websocket, iframe_id, html("<h1>FRAME</h1>"))
 
     return iframe_id
+
+
+@pytest_asyncio.fixture
+async def user_context(websocket):
+    """Create a new user context and return its id."""
+    result = await execute_command(websocket, {
+        "method": "browser.createUserContext",
+        "params": {}
+    })
+
+    return result['userContext']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,15 +80,15 @@ async def another_context_id(create_context):
 @pytest_asyncio.fixture
 def create_context(websocket):
     """Return a browsing context factory."""
-    async def create_context(user_context=None):
+    async def create_context(user_context_id=None):
         result = await execute_command(
             websocket, {
                 "method": "browsingContext.create",
                 "params": {
                     "type": "tab"
                 } | ({
-                    "userContext": user_context
-                } if user_context is not None else {})
+                    "userContext": user_context_id
+                } if user_context_id is not None else {})
             })
         return result['context']
 
@@ -383,7 +383,7 @@ async def iframe_id(websocket, context_id: str, html_iframe_same_origin, html):
 
 
 @pytest_asyncio.fixture
-async def user_context(websocket):
+async def user_context_id(websocket):
     """Create a new user context and return its id."""
     result = await execute_command(websocket, {
         "method": "browser.createUserContext",

--- a/tests/storage/test_get_cookies.py
+++ b/tests/storage/test_get_cookies.py
@@ -110,10 +110,10 @@ async def test_cookies_get_partition_source_origin(websocket, context_id):
 
 @pytest.mark.asyncio
 async def test_cookies_get_partition_user_context(websocket, context_id,
-                                                  user_context):
+                                                  user_context_id):
     user_context_partition = {
         'type': 'storageKey',
-        'userContext': user_context,
+        'userContext': user_context_id,
     }
 
     cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, SOME_DOMAIN)
@@ -137,7 +137,7 @@ async def test_cookies_get_partition_user_context(websocket, context_id,
     assert res == {
         'cookies': [AnyExtending(cookie)],
         'partitionKey': {
-            'userContext': user_context
+            'userContext': user_context_id
         },
     }
 
@@ -191,14 +191,14 @@ async def test_cookies_get_partition_browsing_context(websocket, context_id):
 
 @pytest.mark.asyncio
 async def test_cookies_get_partition_browsing_context_from_user_context(
-        websocket, create_context, user_context):
-    context_id = await create_context(user_context)
+        websocket, create_context, user_context_id):
+    context_id = await create_context(user_context_id)
 
     cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, SOME_DOMAIN)
     # Set `cookie` to the new user context.
     await set_cookie(websocket, context_id, cookie, {
         'type': 'storageKey',
-        'userContext': user_context,
+        'userContext': user_context_id,
     })
 
     another_cookie = get_bidi_cookie(ANOTHER_COOKIE_NAME, ANOTHER_COOKIE_VALUE,
@@ -221,7 +221,7 @@ async def test_cookies_get_partition_browsing_context_from_user_context(
     assert res == {
         'cookies': [AnyExtending(cookie)],
         'partitionKey': {
-            'userContext': user_context
+            'userContext': user_context_id
         },
     }
 

--- a/tests/storage/test_set_cookies.py
+++ b/tests/storage/test_set_cookies.py
@@ -144,8 +144,8 @@ async def test_cookie_set_partition_user_context(websocket, context_id):
 
 
 async def test_cookie_set_partition_browsing_context_from_user_context(
-        websocket, create_context, user_context):
-    context_id = await create_context(user_context)
+        websocket, create_context, user_context_id):
+    context_id = await create_context(user_context_id)
     resp = await execute_command(
         websocket, {
             'method': 'storage.setCookie',
@@ -165,7 +165,7 @@ async def test_cookie_set_partition_browsing_context_from_user_context(
                 }
             }
         })
-    assert resp == {'partitionKey': {'userContext': user_context, }}
+    assert resp == {'partitionKey': {'userContext': user_context_id, }}
 
     resp = await execute_command(
         websocket, {
@@ -173,7 +173,7 @@ async def test_cookie_set_partition_browsing_context_from_user_context(
             'params': {
                 'partition': {
                     'type': 'storageKey',
-                    'userContext': user_context,
+                    'userContext': user_context_id,
                 }
             }
         })
@@ -186,7 +186,7 @@ async def test_cookie_set_partition_browsing_context_from_user_context(
                                 secure=True))
         ],
         'partitionKey': {
-            'userContext': user_context,
+            'userContext': user_context_id,
         }
     }
 

--- a/tests/storage/test_set_cookies.py
+++ b/tests/storage/test_set_cookies.py
@@ -32,7 +32,7 @@ SOME_URL = 'https://some_domain.com:1234/some/path?some=query#some-fragment'
 
 
 @pytest.mark.asyncio
-async def test_cookie_set_with_required_fields(websocket, context_id):
+async def test_cookie_set_required_fields(websocket, context_id):
     resp = await execute_command(
         websocket, {
             'method': 'storage.setCookie',
@@ -66,7 +66,7 @@ async def test_cookie_set_with_required_fields(websocket, context_id):
 
 
 @pytest.mark.asyncio
-async def test_cookie_set_partition_context(websocket, context_id):
+async def test_cookie_set_partition_browsing_context(websocket, context_id):
     resp = await execute_command(
         websocket, {
             'method': 'storage.setCookie',
@@ -101,6 +101,93 @@ async def test_cookie_set_partition_context(websocket, context_id):
                                 secure=True))
         ],
         'partitionKey': {}
+    }
+
+
+@pytest.mark.asyncio
+async def test_cookie_set_partition_user_context(websocket, context_id):
+    resp = await execute_command(
+        websocket, {
+            'method': 'storage.setCookie',
+            'params': {
+                'cookie': {
+                    'secure': True,
+                    'name': SOME_COOKIE_NAME,
+                    'value': {
+                        'type': 'string',
+                        'value': SOME_COOKIE_VALUE
+                    },
+                    'domain': SOME_DOMAIN,
+                },
+                'partition': {
+                    'type': 'context',
+                    'context': context_id
+                }
+            }
+        })
+    assert resp == {'partitionKey': {}}
+
+    resp = await execute_command(websocket, {
+        'method': 'storage.getCookies',
+        'params': {}
+    })
+    assert resp == {
+        'cookies': [
+            AnyExtending(
+                get_bidi_cookie(SOME_COOKIE_NAME,
+                                SOME_COOKIE_VALUE,
+                                SOME_DOMAIN,
+                                secure=True))
+        ],
+        'partitionKey': {}
+    }
+
+
+async def test_cookie_set_partition_browsing_context_from_user_context(
+        websocket, create_context, user_context):
+    context_id = await create_context(user_context)
+    resp = await execute_command(
+        websocket, {
+            'method': 'storage.setCookie',
+            'params': {
+                'cookie': {
+                    'secure': True,
+                    'name': SOME_COOKIE_NAME,
+                    'value': {
+                        'type': 'string',
+                        'value': SOME_COOKIE_VALUE
+                    },
+                    'domain': SOME_DOMAIN,
+                },
+                'partition': {
+                    'type': 'context',
+                    'context': context_id,
+                }
+            }
+        })
+    assert resp == {'partitionKey': {'userContext': user_context, }}
+
+    resp = await execute_command(
+        websocket, {
+            'method': 'storage.getCookies',
+            'params': {
+                'partition': {
+                    'type': 'storageKey',
+                    'userContext': user_context,
+                }
+            }
+        })
+    assert resp == {
+        'cookies': [
+            AnyExtending(
+                get_bidi_cookie(SOME_COOKIE_NAME,
+                                SOME_COOKIE_VALUE,
+                                SOME_DOMAIN,
+                                secure=True))
+        ],
+        'partitionKey': {
+            'userContext': user_context,
+        }
     }
 
 
@@ -144,7 +231,7 @@ async def test_cookie_set_partition_source_origin(websocket, context_id):
 
 
 @pytest.mark.asyncio
-async def test_cookie_set_with_all_fields(websocket, context_id):
+async def test_cookie_set_params_cookie_all_fields(websocket, context_id):
     some_path = "/SOME_PATH"
     http_only = True
     secure = True
@@ -188,7 +275,7 @@ async def test_cookie_set_with_all_fields(websocket, context_id):
 
 
 @pytest.mark.asyncio
-async def test_cookie_set_expired(websocket, context_id):
+async def test_cookie_set_params_cookie_expired(websocket, context_id):
     expiry = int((datetime.now() - timedelta(seconds=1)).timestamp())
     resp = await execute_command(
         websocket, {
@@ -210,7 +297,8 @@ async def test_cookie_set_expired(websocket, context_id):
 
 
 @pytest.mark.asyncio
-async def test_cookies_set_cdp_specific_fields(websocket, context_id):
+async def test_cookies_set_params_cookie_cdp_specific_fields(
+        websocket, context_id):
     resp = await execute_command(
         websocket,
         {


### PR DESCRIPTION
Get `userContext` from partition or from the linked browsing context.