### PR TITLE
test: fix Promise rejection was handled asynchronously

### DIFF
--- a/src/cdp/CdpClient.spec.ts
+++ b/src/cdp/CdpClient.spec.ts
@@ -206,21 +206,24 @@ describe('CdpClient', () => {
       };
 
       // Send CDP command and store returned promise.
-      const commandPromise = cdpClient.sendCommand('Target.attachToTarget', {
-        targetId: TEST_TARGET_ID,
-      });
+      const resultOrError = cdpClient
+        .sendCommand('Target.attachToTarget', {
+          targetId: TEST_TARGET_ID,
+        })
+        .catch((error) => error);
 
       // Verify CDP command was sent.
       sinon.assert.calledOnce(mockCdpServer.sendMessage);
 
       // Notify 'cdpClient' the CDP command is finished.
+      //
       await mockCdpServer.emulateIncomingMessage({
         id: 0,
         error: expectedError,
       });
 
       // Assert sendCommand rejects with error.
-      await expect(commandPromise).to.be.eventually.rejectedWith(expectedError);
+      await expect(resultOrError).to.eventually.deep.equal(expectedError);
     });
   });
 });

--- a/src/cdp/CdpClient.spec.ts
+++ b/src/cdp/CdpClient.spec.ts
@@ -216,7 +216,6 @@ describe('CdpClient', () => {
       sinon.assert.calledOnce(mockCdpServer.sendMessage);
 
       // Notify 'cdpClient' the CDP command is finished.
-      //
       await mockCdpServer.emulateIncomingMessage({
         id: 0,
         error: expectedError,


### PR DESCRIPTION
There were errors coming from this UnitTest
```
(node:1270676) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 3)
    at handledRejection (node:internal/process/promises:173:23)
    at promiseRejectHandler (node:internal/process/promises:119:7)
    at Promise.then (<anonymous>)
    at Proxy.<anonymous> (/usr/local/google/home/nvitkov/bidi/node_modules/chai-as-promised/lib/chai-as-promised.js:169:53)
    at Proxy.<anonymous> (/usr/local/google/home/nvitkov/bidi/node_modules/chai-as-promised/lib/chai-as-promised.js:47:29)
    at Proxy.methodWrapper (/usr/local/google/home/nvitkov/bidi/node_modules/chai/lib/chai/utils/addMethod.js:57:25)
    at Context.<anonymous> (/usr/local/google/home/nvitkov/bidi/src/cdp/CdpClient.spec.ts:223:53)

```