### PR TITLE
feat: allow Chrome-specific params in user contexts

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -153,7 +153,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       case 'browser.close':
         return this.#browserProcessor.close();
       case 'browser.createUserContext':
-        return await this.#browserProcessor.createUserContext();
+        return await this.#browserProcessor.createUserContext(command.params);
       case 'browser.getUserContexts':
         return await this.#browserProcessor.getUserContexts();
       case 'browser.removeUserContext':

--- a/src/bidiMapper/domains/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/domains/browser/BrowserProcessor.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import type Protocol from 'devtools-protocol';
+
 import {
   type EmptyResult,
   type Browser,
@@ -38,9 +40,20 @@ export class BrowserProcessor {
     return {};
   }
 
-  async createUserContext(): Promise<Browser.CreateUserContextResult> {
+  async createUserContext(
+    params: Record<string, any>
+  ): Promise<Browser.CreateUserContextResult> {
+    const request: Protocol.Target.CreateBrowserContextRequest = {
+      proxyServer: params['goog:proxyServer'] ?? undefined,
+    };
+    const proxyBypassList: string[] | undefined =
+      params['goog:proxyBypassList'] ?? undefined;
+    if (proxyBypassList) {
+      request.proxyBypassList = proxyBypassList.join(',');
+    }
     const context = await this.#browserCdpClient.sendCommand(
-      'Target.createBrowserContext'
+      'Target.createBrowserContext',
+      request
     );
     return {
       userContext: context.browserContextId,


### PR DESCRIPTION
The proxy servers are somewhat difficult to test. Does the pytest server support a proxy mode? Any test suggestions for vendor specific attributes?