### PR TITLE
feat: support user context in permissions

### DIFF
--- a/src/bidiMapper/domains/permissions/PermissionsProcessor.ts
+++ b/src/bidiMapper/domains/permissions/PermissionsProcessor.ts
@@ -33,8 +33,15 @@ export class PermissionsProcessor {
     params: Permissions.SetPermissionParameters
   ): Promise<EmptyResult> {
     try {
+      const userContextId = (params as {'goog:userContext'?: string})[
+        'goog:userContext'
+      ];
       await this.#browserCdpClient.sendCommand('Browser.setPermission', {
         origin: params.origin,
+        browserContextId:
+          userContextId && userContextId !== 'default'
+            ? userContextId
+            : undefined,
         permission: {
           name: params.descriptor.name,
         },

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -350,9 +350,13 @@ export namespace Permissions {
   export function parseSetPermissionsParams(
     params: unknown
   ): Protocol.Permissions.SetPermissionParameters {
-    return parseObject(
-      params,
-      WebDriverBidiPermissions.Permissions.SetPermissionParametersSchema
-    ) as Protocol.Permissions.SetPermissionParameters;
+    return {
+      // TODO: remove once "goog:" attributes are not needed.
+      ...(params as object),
+      ...(parseObject(
+        params,
+        WebDriverBidiPermissions.Permissions.SetPermissionParametersSchema
+      ) as Protocol.Permissions.SetPermissionParameters),
+    };
   }
 }

--- a/tests/permissions/__init__.py
+++ b/tests/permissions/__init__.py
@@ -45,7 +45,11 @@ async def query_permission(websocket, context_id, name):
     return result['result']['value']
 
 
-async def set_permission(websocket, origin, descriptor, state):
+async def set_permission(websocket,
+                         origin,
+                         descriptor,
+                         state,
+                         user_context=None):
     """ Set a permission via the permissions.setPermission command."""
     return await execute_command(
         websocket, {
@@ -53,6 +57,7 @@ async def set_permission(websocket, origin, descriptor, state):
             'params': {
                 'origin': origin,
                 'descriptor': descriptor,
-                'state': state
+                'state': state,
+                'goog:userContext': user_context
             }
         })


### PR DESCRIPTION
This PR adds `goog:` prefixed user context to allow use cases required by Puppeteer. Once permissions spec issue is resolved https://github.com/w3c/permissions/pull/438 we can remove the prefix.