### PR TITLE
feat: allow Chrome-specific params in user contexts

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-skips = B101
+skips = B101,B404,B603,B607

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -153,7 +153,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       case 'browser.close':
         return this.#browserProcessor.close();
       case 'browser.createUserContext':
-        return await this.#browserProcessor.createUserContext();
+        return await this.#browserProcessor.createUserContext(command.params);
       case 'browser.getUserContexts':
         return await this.#browserProcessor.getUserContexts();
       case 'browser.removeUserContext':

--- a/src/bidiMapper/domains/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/domains/browser/BrowserProcessor.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import type Protocol from 'devtools-protocol';
+
 import {
   type EmptyResult,
   type Browser,
@@ -38,9 +40,20 @@ export class BrowserProcessor {
     return {};
   }
 
-  async createUserContext(): Promise<Browser.CreateUserContextResult> {
+  async createUserContext(
+    params: Record<string, any>
+  ): Promise<Browser.CreateUserContextResult> {
+    const request: Protocol.Target.CreateBrowserContextRequest = {
+      proxyServer: params['goog:proxyServer'] ?? undefined,
+    };
+    const proxyBypassList: string[] | undefined =
+      params['goog:proxyBypassList'] ?? undefined;
+    if (proxyBypassList) {
+      request.proxyBypassList = proxyBypassList.join(',');
+    }
     const context = await this.#browserCdpClient.sendCommand(
-      'Target.createBrowserContext'
+      'Target.createBrowserContext',
+      params
     );
     return {
       userContext: context.browserContextId,

--- a/src/bidiMapper/domains/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/domains/browser/BrowserProcessor.ts
@@ -53,7 +53,7 @@ export class BrowserProcessor {
     }
     const context = await this.#browserCdpClient.sendCommand(
       'Target.createBrowserContext',
-      params
+      request
     );
     return {
       userContext: context.browserContextId,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from pytest_httpserver import HTTPServer
 from test_helpers import (execute_command, get_tree, goto_url,
                           read_JSON_message, wait_for_event, wait_for_events)
 
+from tools.http_proxy_server import HttpProxyServer
 from tools.local_http_server import LocalHttpServer
 
 
@@ -35,6 +36,15 @@ def local_server(httpserver) -> LocalHttpServer:
     HTTP requests locally.
     """
     return LocalHttpServer(httpserver)
+
+
+@pytest_asyncio.fixture
+def http_proxy_server() -> HttpProxyServer:
+    """ Returns and starts an instance of a HttpProxyServer.
+    """
+    server = HttpProxyServer()
+    server.start()
+    return server
 
 
 @pytest_asyncio.fixture

--- a/tests/tools/http_proxy_server.py
+++ b/tests/tools/http_proxy_server.py
@@ -1,0 +1,47 @@
+#  Copyright 2024 Google LLC.
+#  Copyright (c) Microsoft Corporation.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from subprocess import PIPE, Popen
+
+
+class HttpProxyServer():
+    """A wrapper of `tools/http-proxy.mjs` to simplify the usage. Sets
+    up common use cases and provides url for them."""
+    def __init__(self) -> None:
+        self._url = ""
+
+    def start(self):
+        self._process = Popen(["node", "tools/http-proxy.mjs"],
+                              stdout=PIPE,
+                              shell=False)
+        self._url = self._process.stdout.read1().decode("utf-8").strip()
+
+    def stop(self):
+        """
+        Stops the server and reads all URLs that have been proxied by the server.
+        """
+        lines = []
+        self._process.terminate()
+        while self._process.stdout.peek().decode("utf-8").strip() != '':
+            line = self._process.stdout.read1().decode("utf-8").strip()
+            print("line: " + line)
+            lines.append(line)
+        return lines
+
+    def url(self):
+        """
+        Returns the proxy URL. Available after the `start` call has succeeded.
+        """
+        return self._url

--- a/tools/http-proxy.mjs
+++ b/tools/http-proxy.mjs
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2024 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview `node http-proxy.mjs` starts a new HTTP proxy server on
+ * localhost:{FREE_PORT}. Upon the start the server prints its URL to stdout.
+ * After that it will print a URL per line for each of the requests it proxied.
+ */
+
+import http from 'node:http';
+
+const proxyServer = http
+  .createServer((originalRequest, originalResponse) => {
+    console.log(originalRequest.url);
+    const proxyRequest = http.request(
+      originalRequest.url,
+      {
+        method: originalRequest.method,
+        headers: originalRequest.headers,
+      },
+      (proxyResponse) => {
+        originalResponse.writeHead(
+          proxyResponse.statusCode,
+          proxyResponse.headers
+        );
+        proxyResponse.pipe(originalResponse, {end: true});
+      }
+    );
+
+    originalRequest.pipe(proxyRequest, {end: true});
+  })
+  .listen();
+
+console.log(
+  `http://${process.argv[2] || 'localhost'}:${proxyServer.address().port}`
+);


### PR DESCRIPTION
This PR adds a python proxy server wrapper over a Node.js proxy server to test the URLs.