### PR TITLE
ci: roll back browser update CI job

### DIFF
--- a/.github/workflows/update-browser-version.yml
+++ b/.github/workflows/update-browser-version.yml
@@ -16,17 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 0
-      - name: Config git user
-        run: |
-          git config --global user.email "browser-automation-bot@google.com"
-          git config --global user.name "Browser Automation Bot"
-      - name: Checkout `browser-automation-bot/update-browser-version` and rebase if exists
+      - name: Checkout `browser-automation-bot/update-browser-version` if exits
         run: |
           (git ls-remote --exit-code --heads origin refs/heads/browser-automation-bot/update-browser-version &&
           git checkout browser-automation-bot/update-browser-version &&
-          git rebase origin/main) || exit 0
+          git rebase main) || exit 0
       - name: Set up Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
@@ -39,7 +33,6 @@ jobs:
         with:
           token: ${{ secrets.BROWSER_AUTOMATION_BOT_TOKEN }}
           branch: browser-automation-bot/update-browser-version
-          base: main
           delete-branch: true
           committer: Browser Automation Bot <browser-automation-bot@google.com>
           author: Browser Automation Bot <browser-automation-bot@google.com>


### PR DESCRIPTION
Roll back latest changes in `update-browser-version.yml`, as it creates closed PRs. https://github.com/GoogleChromeLabs/chromium-bidi/pull/1813