### PR TITLE
ci: remove set-up in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,17 +26,6 @@ jobs:
           cache: npm
       - name: Install and build npm dependencies
         run: npm ci
-      - name: Set up Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
-        with:
-          python-version: '3.11'
-          cache: pipenv
-      - name: Install pipenv
-        run: pip install pipenv
-      - name: Install python dependencies
-        run: pipenv install
-      - name: Test
-        run: npm run unit
       - name: Publish
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
We don't need Python here and the unit test provide little value as they are not flaky and passed for release PR.