### PR TITLE
build: bump Python to 3.12.2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.12.2'
           cache: pipenv
       - name: Install pipenv
         run: pip install pipenv

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm ci
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.12.2'
           cache: pip
       - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 #v3.0.0
         with:

--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.12.2'
           cache: pip
       - name: Setup Go
         uses: actions/setup-go@6c1fd22b67f7a7c42ad9a45c0f4197434035e429 # v5.0.0

--- a/.github/workflows/wpt-quick.yml
+++ b/.github/workflows/wpt-quick.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.12.2'
           cache: 'pip'
       - name: Set up virtualenv
         run: pip install virtualenv

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.12.2'
           cache: 'pip'
       - name: Set up virtualenv
         run: pip install virtualenv

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ mypy = "==1.6.0"
 pillow = "==10.2.0"
 pytest = "==7.4.2"
 pytest-asyncio = "==0.21.1"
-pytest-httpserver = "==1.0.8"
+pytest-httpserver = "==1.0.9"
 pytest-icdiff = "==0.8"
 pytest-rerunfailures = "==12.0"
 pytest-timeout = "==2.2.0"
@@ -24,7 +24,7 @@ pytest-randomly = "*"
 pytest-xdist = "*"
 
 [requires]
-python_version = "3.11"
+python_version = "3.12.2"
 
 [scripts]
 local_http_server = "python tools/run_local_http_server.py"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
   "_meta": {
     "hash": {
-      "sha256": "121f407839588a4f9482e5a337e85b702138dc97a51dddadc9006375c23e6221"
+      "sha256": "8bc47f9f877180def4186bd43815f441a5b63a2e465d04c9ce8060425a28bde2"
     },
     "pipfile-spec": 6,
     "requires": {
-      "python_version": "3.11"
+      "python_version": "3.12.2"
     },
     "sources": [
       {
@@ -22,16 +22,15 @@
         "sha256:ae4124d98ab0449a457d1563e86c9f9baa059707bf7bd65248d594b1fdc2a5c2"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==0.3.0"
     },
     "exceptiongroup": {
       "hashes": [
-        "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
-        "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
+        "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+        "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
       ],
       "markers": "python_version < '3.11'",
-      "version": "==1.1.3"
+      "version": "==1.2.0"
     },
     "icdiff": {
       "hashes": [
@@ -50,69 +49,69 @@
     },
     "markupsafe": {
       "hashes": [
-        "sha256:05fb21170423db021895e1ea1e1f3ab3adb85d1c2333cbc2310f2a26bc77272e",
-        "sha256:0a4e4a1aff6c7ac4cd55792abf96c915634c2b97e3cc1c7129578aa68ebd754e",
-        "sha256:10bbfe99883db80bdbaff2dcf681dfc6533a614f700da1287707e8a5d78a8431",
-        "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686",
-        "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c",
-        "sha256:1577735524cdad32f9f694208aa75e422adba74f1baee7551620e43a3141f559",
-        "sha256:1b40069d487e7edb2676d3fbdb2b0829ffa2cd63a2ec26c4938b2d34391b4ecc",
-        "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb",
-        "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939",
-        "sha256:282c2cb35b5b673bbcadb33a585408104df04f14b2d9b01d4c345a3b92861c2c",
-        "sha256:2c1b19b3aaacc6e57b7e25710ff571c24d6c3613a45e905b1fde04d691b98ee0",
-        "sha256:2ef12179d3a291be237280175b542c07a36e7f60718296278d8593d21ca937d4",
-        "sha256:338ae27d6b8745585f87218a3f23f1512dbf52c26c28e322dbe54bcede54ccb9",
-        "sha256:3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575",
-        "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba",
-        "sha256:42de32b22b6b804f42c5d98be4f7e5e977ecdd9ee9b660fda1a3edf03b11792d",
-        "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd",
-        "sha256:504b320cd4b7eff6f968eddf81127112db685e81f7e36e75f9f84f0df46041c3",
-        "sha256:525808b8019e36eb524b8c68acdd63a37e75714eac50e988180b169d64480a00",
-        "sha256:56d9f2ecac662ca1611d183feb03a3fa4406469dafe241673d521dd5ae92a155",
-        "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac",
-        "sha256:65c1a9bcdadc6c28eecee2c119465aebff8f7a584dd719facdd9e825ec61ab52",
-        "sha256:68e78619a61ecf91e76aa3e6e8e33fc4894a2bebe93410754bd28fce0a8a4f9f",
-        "sha256:69c0f17e9f5a7afdf2cc9fb2d1ce6aabdb3bafb7f38017c0b77862bcec2bbad8",
-        "sha256:6b2b56950d93e41f33b4223ead100ea0fe11f8e6ee5f641eb753ce4b77a7042b",
-        "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007",
-        "sha256:787003c0ddb00500e49a10f2844fac87aa6ce977b90b0feaaf9de23c22508b24",
-        "sha256:7ef3cb2ebbf91e330e3bb937efada0edd9003683db6b57bb108c4001f37a02ea",
-        "sha256:8023faf4e01efadfa183e863fefde0046de576c6f14659e8782065bcece22198",
-        "sha256:8758846a7e80910096950b67071243da3e5a20ed2546e6392603c096778d48e0",
-        "sha256:8afafd99945ead6e075b973fefa56379c5b5c53fd8937dad92c662da5d8fd5ee",
-        "sha256:8c41976a29d078bb235fea9b2ecd3da465df42a562910f9022f1a03107bd02be",
-        "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2",
-        "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1",
-        "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707",
-        "sha256:962f82a3086483f5e5f64dbad880d31038b698494799b097bc59c2edf392fce6",
-        "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c",
-        "sha256:9dcdfd0eaf283af041973bff14a2e143b8bd64e069f4c383416ecd79a81aab58",
-        "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823",
-        "sha256:aa7bd130efab1c280bed0f45501b7c8795f9fdbeb02e965371bbef3523627779",
-        "sha256:ab4a0df41e7c16a1392727727e7998a467472d0ad65f3ad5e6e765015df08636",
-        "sha256:ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c",
-        "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad",
-        "sha256:b076b6226fb84157e3f7c971a47ff3a679d837cf338547532ab866c57930dbee",
-        "sha256:b7ff0f54cb4ff66dd38bebd335a38e2c22c41a8ee45aa608efc890ac3e3931bc",
-        "sha256:bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2",
-        "sha256:c011a4149cfbcf9f03994ec2edffcb8b1dc2d2aede7ca243746df97a5d41ce48",
-        "sha256:c9c804664ebe8f83a211cace637506669e7890fec1b4195b505c214e50dd4eb7",
-        "sha256:ca379055a47383d02a5400cb0d110cef0a776fc644cda797db0c5696cfd7e18e",
-        "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b",
-        "sha256:cd0f502fe016460680cd20aaa5a76d241d6f35a1c3350c474bac1273803893fa",
-        "sha256:ceb01949af7121f9fc39f7d27f91be8546f3fb112c608bc4029aef0bab86a2a5",
-        "sha256:d080e0a5eb2529460b30190fcfcc4199bd7f827663f858a226a81bc27beaa97e",
-        "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb",
-        "sha256:df0be2b576a7abbf737b1575f048c23fb1d769f267ec4358296f31c2479db8f9",
-        "sha256:e09031c87a1e51556fdcb46e5bd4f59dfb743061cf93c4d6831bf894f125eb57",
-        "sha256:e4dd52d80b8c83fdce44e12478ad2e85c64ea965e75d66dbeafb0a3e77308fcc",
-        "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc",
-        "sha256:fec21693218efe39aa7f8599346e90c705afa52c5b31ae019b2e57e8f6542bb2",
-        "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"
+        "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
+        "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
+        "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
+        "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
+        "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
+        "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
+        "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
+        "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
+        "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
+        "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
+        "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
+        "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
+        "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
+        "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
+        "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
+        "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
+        "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
+        "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
+        "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
+        "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
+        "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
+        "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
+        "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
+        "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
+        "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
+        "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
+        "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
+        "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
+        "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
+        "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
+        "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
+        "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
+        "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
+        "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
+        "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
+        "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
+        "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
+        "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
+        "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
+        "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
+        "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
+        "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
+        "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
+        "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
+        "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
+        "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
+        "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
+        "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
+        "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+        "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
+        "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
+        "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
+        "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
+        "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
+        "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
+        "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
+        "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
+        "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
+        "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
+        "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
       ],
       "markers": "python_version >= '3.7'",
-      "version": "==2.1.3"
+      "version": "==2.1.5"
     },
     "mypy": {
       "hashes": [
@@ -145,7 +144,6 @@
         "sha256:fea451a3125bf0bfe716e5d7ad4b92033c471e4b5b3e154c67525539d14dc15a"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.8'",
       "version": "==1.6.0"
     },
     "mypy-extensions": {
@@ -236,16 +234,15 @@
         "sha256:fe4c15f6c9285dc54ce6553a3ce908ed37c8f3825b5a51a15c91442bb955b868"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.8'",
       "version": "==10.2.0"
     },
     "pluggy": {
       "hashes": [
-        "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
-        "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
+        "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
+        "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.3.0"
+      "version": "==1.4.0"
     },
     "pprintpp": {
       "hashes": [
@@ -260,7 +257,6 @@
         "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==7.4.2"
     },
     "pytest-asyncio": {
@@ -269,17 +265,15 @@
         "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==0.21.1"
     },
     "pytest-httpserver": {
       "hashes": [
-        "sha256:24cd3d9f6a0b927c7bfc400d0b3fda7442721b8267ce29942bf307b190f0bb09",
-        "sha256:e052f69bc8a9073db02484681e8e47004dd1fb3763b0ae833bd899e5895c559a"
+        "sha256:5c84c372564b627521784909b8c8b45c5ededbae2406f7624e201dd86ae0610a",
+        "sha256:9429f26c7ad7b1677dc2fa3bc9e928601f0e9b4ba0388edf961162be1242a662"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.8' and python_version < '4.0'",
-      "version": "==1.0.8"
+      "version": "==1.0.9"
     },
     "pytest-icdiff": {
       "hashes": [
@@ -287,7 +281,6 @@
         "sha256:8fac8667d7042270c23019580b4b5dfd81e1c3e5a9bc9d5df6ac4a49788d42f2"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==0.8"
     },
     "pytest-rerunfailures": {
@@ -296,7 +289,6 @@
         "sha256:9a1afd04e21b8177faf08a9bbbf44de7a0fe3fc29f8ddbe83b9684bd5f8f92a9"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==12.0"
     },
     "pytest-timeout": {
@@ -305,7 +297,6 @@
         "sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==2.2.0"
     },
     "syrupy": {
@@ -314,7 +305,6 @@
         "sha256:ea6a237ef374bacebbdb4049f73bf48e3dda76eabd4621a6d104d43077529de6"
       ],
       "index": "pypi",
-      "markers": "python_version < '4' and python_full_version >= '3.8.1'",
       "version": "==4.5.0"
     },
     "tomli": {
@@ -327,11 +317,11 @@
     },
     "typing-extensions": {
       "hashes": [
-        "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
-        "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
+        "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
+        "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==4.8.0"
+      "version": "==4.9.0"
     },
     "websockets": {
       "hashes": [
@@ -407,7 +397,6 @@
         "sha256:ffd7dcaf744f25f82190856bc26ed81721508fc5cbf2a330751e135ff1283564"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==11.0.3"
     },
     "werkzeug": {
@@ -422,11 +411,11 @@
   "develop": {
     "exceptiongroup": {
       "hashes": [
-        "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9",
-        "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"
+        "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
+        "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
       ],
       "markers": "python_version < '3.11'",
-      "version": "==1.1.3"
+      "version": "==1.2.0"
     },
     "execnet": {
       "hashes": [
@@ -435,6 +424,14 @@
       ],
       "markers": "python_version >= '3.7'",
       "version": "==2.0.2"
+    },
+    "importlib-metadata": {
+      "hashes": [
+        "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e",
+        "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"
+      ],
+      "markers": "python_version < '3.10'",
+      "version": "==7.0.1"
     },
     "iniconfig": {
       "hashes": [
@@ -454,19 +451,19 @@
     },
     "pluggy": {
       "hashes": [
-        "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12",
-        "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"
+        "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
+        "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.3.0"
+      "version": "==1.4.0"
     },
     "pyflakes": {
       "hashes": [
-        "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774",
-        "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"
+        "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f",
+        "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==3.1.0"
+      "version": "==3.2.0"
     },
     "pytest": {
       "hashes": [
@@ -474,7 +471,6 @@
         "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==7.4.2"
     },
     "pytest-flakefinder": {
@@ -483,7 +479,6 @@
         "sha256:e2412a1920bdb8e7908783b20b3d57e9dad590cc39a93e8596ffdd493b403e0e"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.5'",
       "version": "==1.1.0"
     },
     "pytest-flakes": {
@@ -492,7 +487,6 @@
         "sha256:d0e8602d882744fc6169247b62a51203c5a3d8f160892ff3b82f5b9c1e4bb675"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.5'",
       "version": "==4.0.5"
     },
     "pytest-instafail": {
@@ -501,7 +495,6 @@
         "sha256:6855414487e9e4bb76a118ce952c3c27d3866af15487506c4ded92eb72387819"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
       "version": "==0.5.0"
     },
     "pytest-randomly": {
@@ -510,17 +503,15 @@
         "sha256:b908529648667ba5e54723088edd6f82252f540cc340d748d1fa985539687047"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.8'",
       "version": "==3.15.0"
     },
     "pytest-xdist": {
       "hashes": [
-        "sha256:3a94a931dd9e268e0b871a877d09fe2efb6175c2c23d60d56a6001359002b832",
-        "sha256:e513118bf787677a427e025606f55e95937565e06dfaac8d87f55301e57ae607"
+        "sha256:cbb36f3d67e0c478baa57fa4edc8843887e0f6cfc42d677530a36d7472b32d8a",
+        "sha256:d075629c7e00b611df89f490a5063944bee7a4362a5ff11c7cc7824a03dfce24"
       ],
       "index": "pypi",
-      "markers": "python_version >= '3.7'",
-      "version": "==3.4.0"
+      "version": "==3.5.0"
     },
     "tomli": {
       "hashes": [
@@ -529,6 +520,14 @@
       ],
       "markers": "python_version < '3.11'",
       "version": "==2.0.1"
+    },
+    "zipp": {
+      "hashes": [
+        "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31",
+        "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+      ],
+      "markers": "python_version >= '3.8'",
+      "version": "==3.17.0"
     }
   }
 }


### PR DESCRIPTION
In hopes it might solve https://github.com/GoogleChromeLabs/chromium-bidi/issues/1610

To update locally, `pipenv install --python 3.12.2`