### PR TITLE
test: increase e2e test timeout to fight the flakiness

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,13 @@ addopts = --doctest-modules
 minversion = 7.0
 testpaths = tests
 
+# https://pypi.org/project/pytest-rerunfailures/
+# Try each test up to 2 times.
+# We prefer to configure this in PYTEST_ADDOPTS instead of pytest.ini.
+# So that this configuration is only applied in CI environments.
+# It's still listed here for documentation and discoverability purposes.
+# reruns = 1
+
 # https://pypi.org/project/pytest-timeout/
 # timeout in seconds
-timeout = 20
+timeout = 10

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,13 +4,6 @@ addopts = --doctest-modules
 minversion = 7.0
 testpaths = tests
 
-# https://pypi.org/project/pytest-rerunfailures/
-# Try each test up to 2 times.
-# We prefer to configure this in PYTEST_ADDOPTS instead of pytest.ini.
-# So that this configuration is only applied in CI environments.
-# It's still listed here for documentation and discoverability purposes.
-# reruns = 1
-
 # https://pypi.org/project/pytest-timeout/
 # timeout in seconds
 timeout = 10

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,13 +4,6 @@ addopts = --doctest-modules
 minversion = 7.0
 testpaths = tests
 
-# https://pypi.org/project/pytest-rerunfailures/
-# Try each test up to 2 times.
-# We prefer to configure this in PYTEST_ADDOPTS instead of pytest.ini.
-# So that this configuration is only applied in CI environments.
-# It's still listed here for documentation and discoverability purposes.
-# reruns = 1
-
 # https://pypi.org/project/pytest-timeout/
 # timeout in seconds
-timeout = 10
+timeout = 20

--- a/tests/script/test_realm.py
+++ b/tests/script/test_realm.py
@@ -149,6 +149,9 @@ async def test_realm_realmDestroyed_sandbox(websocket, context_id):
     } == response
 
 
+# This test is flaky, as it take some time before the `script.realmDestroyed`
+# event. Increase the timeout to avoid flakiness.
+@pytest.mark.timeout(30)
 @pytest.mark.asyncio
 async def test_realm_dedicated_worker(websocket, context_id, html):
     worker_url = 'data:application/javascript,while(true){}'


### PR DESCRIPTION
Out of last `12` failures of e2e in main, `5` are because of the `test_realm_dedicated_worker` timeout. This is because of the worker's realm is not destroyed immediately. Increasing timeout of the test `test_realm_dedicated_worker` should address the flakiness.