### PR TITLE
fix: add `cdp.resolveRealm` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ CdpGetSessionResult = {
 
 The command returns the default CDP session for the selected browsing context.
 
+### Command `cdp.resolveRealm`
+
+```cddl
+CdpResolveRealmCommand = {
+   method: "cdp.resolveRealm",
+   params: ScriptEvaluateParameters,
+}
+
+CdpResolveRealmParameters = {
+   realm: Script.Realm,
+}
+
+CdpResolveRealmResult = {
+   executionContextId: text,
+}
+```
+
+The command returns resolves a BiDi realm to its CDP execution context ID.
+
 ### Events `cdp`
 
 ```cddl

--- a/src/bidiMapper/BidiNoOpParser.ts
+++ b/src/bidiMapper/BidiNoOpParser.ts
@@ -79,6 +79,9 @@ export class BidiNoOpParser implements BidiCommandParameterParser {
   parseGetSessionParams(params: unknown): Cdp.GetSessionParameters {
     return params as Cdp.GetSessionParameters;
   }
+  parseResolveRealmParams(params: unknown): Cdp.ResolveRealmParameters {
+    return params as Cdp.ResolveRealmParameters;
+  }
   parseSendCommandParams(params: unknown): Cdp.SendCommandParameters {
     return params as Cdp.SendCommandParameters;
   }

--- a/src/bidiMapper/BidiParser.ts
+++ b/src/bidiMapper/BidiParser.ts
@@ -53,6 +53,7 @@ export interface BidiCommandParameterParser {
   // CDP domain
   // keep-sorted start block=yes
   parseGetSessionParams(params: unknown): Cdp.GetSessionParameters;
+  parseResolveRealmParams(params: unknown): Cdp.ResolveRealmParameters;
   parseSendCommandParams(params: unknown): Cdp.SendCommandParameters;
   // keep-sorted end
 

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -112,6 +112,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
     );
     this.#cdpProcessor = new CdpProcessor(
       browsingContextStorage,
+      realmStorage,
       cdpConnection,
       browserCdpClient
     );
@@ -216,6 +217,10 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       case 'cdp.getSession':
         return this.#cdpProcessor.getSession(
           this.#parser.parseGetSessionParams(command.params)
+        );
+      case 'cdp.resolveRealm':
+        return this.#cdpProcessor.resolveRealm(
+          this.#parser.parseResolveRealmParams(command.params)
         );
       case 'cdp.sendCommand':
         return await this.#cdpProcessor.sendCommand(

--- a/src/bidiTab/BidiParser.ts
+++ b/src/bidiTab/BidiParser.ts
@@ -78,6 +78,9 @@ export class BidiParser implements BidiCommandParameterParser {
   parseGetSessionParams(params: unknown): Cdp.GetSessionParameters {
     return Parser.Cdp.parseGetSessionRequest(params);
   }
+  parseResolveRealmParams(params: unknown): Cdp.ResolveRealmParameters {
+    return Parser.Cdp.parseResolveRealmRequest(params);
+  }
   parseSendCommandParams(params: unknown): Cdp.SendCommandParameters {
     return Parser.Cdp.parseSendCommandRequest(params);
   }

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -330,6 +330,10 @@ export namespace Cdp {
     context: WebDriverBidi.BrowsingContext.BrowsingContextSchema,
   });
 
+  const ResolveRealmRequestSchema = z.object({
+    realm: WebDriverBidi.Script.RealmSchema,
+  });
+
   export function parseSendCommandRequest(
     params: unknown
   ): Protocol.Cdp.SendCommandParameters {
@@ -343,6 +347,12 @@ export namespace Cdp {
     params: unknown
   ): Protocol.Cdp.GetSessionParameters {
     return parseObject(params, GetSessionRequestSchema);
+  }
+
+  export function parseResolveRealmRequest(
+    params: unknown
+  ): Protocol.Cdp.ResolveRealmParameters {
+    return parseObject(params, ResolveRealmRequestSchema);
   }
 }
 

--- a/src/protocol/cdp.ts
+++ b/src/protocol/cdp.ts
@@ -17,7 +17,11 @@
 import type {Protocol} from 'devtools-protocol';
 import type {ProtocolMapping} from 'devtools-protocol/types/protocol-mapping.js';
 
-import type {BrowsingContext, JsUint} from './generated/webdriver-bidi.js';
+import type {
+  BrowsingContext,
+  JsUint,
+  Script,
+} from './generated/webdriver-bidi.js';
 
 export type EventNames = Event['method'];
 
@@ -26,14 +30,20 @@ export type Message = CommandResponse | Event;
 export type Command = {
   id: JsUint;
 } & CommandData;
-export type CommandData = SendCommandCommand | GetSessionCommand;
+export type CommandData =
+  | SendCommandCommand
+  | GetSessionCommand
+  | ResolveRealmCommand;
 
 export type CommandResponse = {
   type: 'success';
   id: JsUint;
   result: ResultData;
 };
-export type ResultData = SendCommandResult | GetSessionResult;
+export type ResultData =
+  | SendCommandResult
+  | GetSessionResult
+  | ResolveRealmResult;
 
 export type SendCommandCommand = {
   method: 'cdp.sendCommand';
@@ -65,6 +75,19 @@ export type GetSessionParameters = {
 
 export type GetSessionResult = {
   session?: Protocol.Target.SessionID;
+};
+
+export type ResolveRealmCommand = {
+  method: 'cdp.resolveRealm';
+  params: ResolveRealmParameters;
+};
+
+export type ResolveRealmParameters = {
+  realm: Script.Realm;
+};
+
+export type ResolveRealmResult = {
+  executionContextId: Protocol.Runtime.ExecutionContextId;
 };
 
 export type Event = {


### PR DESCRIPTION
`cdp.resolveRealm` resolves a realm ID to an executionContextId.

This is needed for Puppeteer to adopt nodes from ARIA queries.

This is a workaround for https://crbug.com/326258571