### PR TITLE
test: disable flaky network interception tests

### DIFF
--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -38,6 +38,7 @@ async def test_continue_request_non_existent_request(websocket):
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_request_invalid_phase_response_started(
         websocket, context_id, example_url):
@@ -63,6 +64,7 @@ async def test_continue_request_invalid_phase_response_started(
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_request_invalid_phase_auth_required(
         websocket, context_id, base_url, auth_required_url):
@@ -90,6 +92,7 @@ async def test_continue_request_invalid_phase_auth_required(
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_request_invalid_url(websocket, context_id,
                                             example_url):

--- a/tests/network/test_continue_response.py
+++ b/tests/network/test_continue_response.py
@@ -40,6 +40,7 @@ async def test_continue_response_non_existent_request(websocket):
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_response_invalid_phase(websocket, context_id,
                                                example_url):
@@ -73,6 +74,7 @@ async def test_continue_response_invalid_phase(websocket, context_id,
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_response_invalid_status_code(websocket, context_id,
                                                      example_url):
@@ -98,6 +100,7 @@ async def test_continue_response_invalid_status_code(websocket, context_id,
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_response_invalid_reason_phrase(websocket, context_id,
                                                        example_url):
@@ -122,6 +125,7 @@ async def test_continue_response_invalid_reason_phrase(websocket, context_id,
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_continue_response_invalid_headers(websocket, context_id,
                                                  example_url):

--- a/tests/network/test_continue_with_auth.py
+++ b/tests/network/test_continue_with_auth.py
@@ -39,6 +39,7 @@ async def test_continue_with_auth_non_existent_request(websocket):
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("phase", ["beforeRequestSent", "responseStarted"])
 async def test_continue_with_auth_invalid_phase(websocket, context_id,
@@ -111,6 +112,7 @@ async def test_continue_with_auth_non_blocked_request(
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("credentials", [{}, {
     "type": "notapassword",

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -163,6 +163,7 @@ async def test_fail_request_twice(websocket, context_id, example_url):
         })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_fail_request_with_auth_required_phase(websocket, context_id,
                                                      auth_required_url,

--- a/tests/network/test_provide_response.py
+++ b/tests/network/test_provide_response.py
@@ -40,6 +40,7 @@ async def test_provide_response_non_existent_request(websocket):
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_provide_response_beforeRequestSent_is_valid_phase(
         websocket, context_id, example_url):
@@ -59,6 +60,7 @@ async def test_provide_response_beforeRequestSent_is_valid_phase(
         })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_provide_response_invalid_status_code(websocket, context_id,
                                                     example_url):
@@ -84,6 +86,7 @@ async def test_provide_response_invalid_status_code(websocket, context_id,
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_provide_response_invalid_reason_phrase(websocket, context_id,
                                                       example_url):
@@ -108,6 +111,7 @@ async def test_provide_response_invalid_reason_phrase(websocket, context_id,
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_provide_response_invalid_headers(websocket, context_id,
                                                 example_url):
@@ -132,6 +136,7 @@ async def test_provide_response_invalid_headers(websocket, context_id,
             })
 
 
+@pytest.mark.skip(reason="TODO: #1883")
 @pytest.mark.asyncio
 async def test_provide_response_invalid_body(websocket, context_id,
                                              example_url):


### PR DESCRIPTION
4 out of 12 last e2e failures in main was due to this problem in the following tests:
* test_continue_response_invalid_reason_phrase
* test_fail_request_with_auth_required_phase
* test_continue_request_invalid_phase_response_started

But this issue not specific for this tests. So disabling all the tests using `create_blocked_request` until the #1883 is addressed.