### PR TITLE
test: make test fail faster

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -39,7 +39,7 @@ function usage() {
       [HEADLESS=<true | default: false>]
       [MANIFEST=<default: 'MANIFEST.json'>]
       [RUN_TESTS=<default: true | false>]
-      [TIMEOUT_MULTIPLIER=<number, default: 4>]
+      [TIMEOUT_MULTIPLIER=<number, default: 1>]
       [THIS_CHUNK=<number, default: 1>]
       [TOTAL_CHUNKS=<number, default: 1>]
       [UPDATE_EXPECTATIONS=<true | default: false>]

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -82,7 +82,7 @@ const PRODUCT = process.env.PRODUCT || 'chrome';
 const RUN_TESTS = process.env.RUN_TESTS || 'true';
 
 // Multiplier relative to standard test timeout to use.
-const TIMEOUT_MULTIPLIER = process.env.TIMEOUT_MULTIPLIER || '4';
+const TIMEOUT_MULTIPLIER = process.env.TIMEOUT_MULTIPLIER || '1';
 
 // The current chunk number. Required for shard testing.
 const THIS_CHUNK = process.env.THIS_CHUNK || '1';

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  disabled: Issue-1903

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  disabled: Issue-1903

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  disabled: Issue-1903


### PR DESCRIPTION
Currently if we encounter the WPT fixture that does `fetch` we wait for 12 sec before it fails, which is absurd amount of time.  
Extracting from other PR to see if anything fails.