### PR TITLE
ci: better e2e logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,23 +38,25 @@
       ]
     },
     "e2e:headful": {
-      "command": "pipenv run python -m pytest --verbose --ignore=tests/input",
-      "dependencies": [
-        "server:headful"
-      ],
+      "command": "tools/run-e2e.mjs --headless=false",
       "files": [
+        "tools/run-e2e.mjs ",
         "pytest.ini",
         "tests/**/*.py"
+      ],
+      "dependencies": [
+        "build"
       ]
     },
     "e2e:headless": {
-      "command": "pipenv run python -m pytest --verbose",
-      "dependencies": [
-        "server:headless"
-      ],
+      "command": "tools/run-e2e.mjs",
       "files": [
+        "tools/run-e2e.mjs ",
         "pytest.ini",
         "tests/**/*.py"
+      ],
+      "dependencies": [
+        "build"
       ]
     },
     "prepare": {

--- a/tools/bidi-server.mjs
+++ b/tools/bidi-server.mjs
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import child_process from 'child_process';
+import {mkdirSync} from 'fs';
+import {basename, join, resolve} from 'path';
+
+import {packageDirectorySync} from 'pkg-dir';
+import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers';
+
+function log(message) {
+  // eslint-disable-next-line no-console
+  console.log(`(${basename(process.argv[1])}) ${message}`);
+}
+
+/**
+ * @param {String} suffix
+ */
+export function createLogFile(suffix) {
+  // Changing the current work directory to the package directory.
+  process.chdir(packageDirectorySync());
+
+  const LOG_DIR = process.env.LOG_DIR || 'logs';
+  const LOG_FILE =
+    process.env.LOG_FILE ||
+    join(
+      LOG_DIR,
+      `${new Date().toISOString().replace(/[:]/g, '-')}.${suffix}.log`
+    );
+
+  mkdirSync(LOG_DIR, {recursive: true});
+
+  return LOG_FILE;
+}
+
+export function parseCommandLineArgs() {
+  return yargs(hideBin(process.argv))
+    .usage(
+      `[CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [DEBUG_COLORS=<yes | no>] [HEADLESS=<true | false>] [LOG_DIR=logs] [NODE_OPTIONS=--unhandled-rejections=strict] [PORT=8080] $0`
+    )
+    .option('headless', {
+      describe:
+        'Whether to start the server in headless or headful mode. The --headless flag takes precedence over the HEADLESS environment variable.',
+      type: 'boolean',
+      default: process.env.HEADLESS === 'true',
+    })
+    .parse();
+}
+
+/**
+ *
+ * @param {Boolean} headless
+ * @returns {child_process.ChildProcessWithoutNullStreams}
+ */
+export function createBiDiServerProcess(headless) {
+  let BROWSER_BIN = process.env.BROWSER_BIN;
+  let CHANNEL = process.env.CHANNEL || 'local';
+
+  if (BROWSER_BIN) {
+    // Need to pass valid CHANNEL to the command below
+    CHANNEL = CHANNEL === 'local' ? 'canary' : CHANNEL;
+  }
+
+  if (!BROWSER_BIN && CHANNEL === 'local') {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    BROWSER_BIN = child_process
+      .spawnSync('node', [join('tools', 'install-browser.mjs')])
+      .stdout.toString()
+      .trim();
+    // Need to pass valid CHANNEL to the command below
+    CHANNEL = 'canary';
+  }
+  // DEBUG = (empty string) is allowed.
+  const DEBUG = process.env.DEBUG ?? 'bidi:*';
+  const DEBUG_COLORS = process.env.DEBUG_COLORS || 'false';
+  const DEBUG_DEPTH = process.env.DEBUG_DEPTH || '10';
+  const NODE_OPTIONS =
+    process.env.NODE_OPTIONS ||
+    '--unhandled-rejections=strict --trace-uncaught';
+  const PORT = process.env.PORT || '8080';
+  log(`Starting BiDi Server with DEBUG='${DEBUG}'...`);
+
+  return child_process.spawn(
+    'node',
+    [
+      resolve(join('lib', 'cjs', 'bidiServer', 'index.js')),
+      `--channel`,
+      CHANNEL,
+      `--headless`,
+      headless,
+      ...process.argv.slice(2),
+    ],
+    {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        // keep-sorted start
+        BROWSER_BIN,
+        DEBUG,
+        DEBUG_COLORS,
+        DEBUG_DEPTH,
+        NODE_OPTIONS,
+        PORT,
+        VERBOSE: true,
+        // keep-sorted end
+      },
+    }
+  );
+}

--- a/tools/bidi-server.mjs
+++ b/tools/bidi-server.mjs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run-bidi-server.mjs
+++ b/tools/run-bidi-server.mjs
@@ -17,95 +17,27 @@
  * limitations under the License.
  */
 
-import {spawn, spawnSync} from 'child_process';
-import {createWriteStream, mkdirSync} from 'fs';
-import {basename, join, resolve} from 'path';
+import {createWriteStream} from 'fs';
 
-import {packageDirectorySync} from 'pkg-dir';
-import yargs from 'yargs';
-import {hideBin} from 'yargs/helpers';
+import {
+  createBiDiServerProcess,
+  parseCommandLineArgs,
+  createLogFile,
+} from './bidi-server.mjs';
 
-// Changing the current work directory to the package directory.
-process.chdir(packageDirectorySync());
-
-function log(message) {
-  // eslint-disable-next-line no-console
-  console.log(`(${basename(process.argv[1])}) ${message}`);
-}
-
-const argv = yargs(hideBin(process.argv))
-  .usage(
-    `[CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [DEBUG_COLORS=<yes | no>] [HEADLESS=<true | false>] [LOG_DIR=logs] [NODE_OPTIONS=--unhandled-rejections=strict] [PORT=8080] $0`
-  )
-  .option('headless', {
-    describe:
-      'Whether to start the server in headless or headful mode. The --headless flag takes precedence over the HEADLESS environment variable.',
-    type: 'boolean',
-    default: process.env.HEADLESS === 'true',
-  })
-  .parse();
-
-let BROWSER_BIN = process.env.BROWSER_BIN;
-let CHANNEL = process.env.CHANNEL || 'local';
-if (CHANNEL === 'local') {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  BROWSER_BIN = spawnSync('node', [join('tools', 'install-browser.mjs')])
-    .stdout.toString()
-    .trim();
-  // Need to pass valid CHANNEL to the command below
-  CHANNEL = 'canary';
-}
-
-// DEBUG = (empty string) is allowed.
-const DEBUG = process.env.DEBUG ?? 'bidi:*';
-const DEBUG_COLORS = process.env.DEBUG_COLORS || 'false';
-const DEBUG_DEPTH = process.env.DEBUG_DEPTH || '10';
-const LOG_DIR = process.env.LOG_DIR || 'logs';
-const LOG_FILE =
-  process.env.LOG_FILE ||
-  join(LOG_DIR, `${new Date().toISOString().replace(/[:]/g, '-')}.log`);
-const NODE_OPTIONS =
-  process.env.NODE_OPTIONS || '--unhandled-rejections=strict';
-const PORT = process.env.PORT || '8080';
-
-log(`Starting BiDi Server with DEBUG='${DEBUG}'...`);
-
-mkdirSync(LOG_DIR, {recursive: true});
-
-const subprocess = spawn(
-  'node',
-  [
-    resolve(join('lib', 'cjs', 'bidiServer', 'index.js')),
-    `--channel`,
-    CHANNEL,
-    `--headless`,
-    argv.headless,
-    ...process.argv.slice(2),
-  ],
-  {
-    stdio: ['inherit', 'pipe', 'pipe'],
-    env: {
-      ...process.env,
-      // keep-sorted start
-      BROWSER_BIN,
-      DEBUG,
-      DEBUG_COLORS,
-      DEBUG_DEPTH,
-      NODE_OPTIONS,
-      PORT,
-      // keep-sorted end
-    },
-  }
-);
+const argv = parseCommandLineArgs();
+const LOG_FILE = createLogFile('server');
+const fileWriteStream = createWriteStream(LOG_FILE);
+const subprocess = createBiDiServerProcess(argv.headless);
 
 if (subprocess.stderr) {
   subprocess.stderr.pipe(process.stdout);
-  subprocess.stderr.pipe(createWriteStream(LOG_FILE));
+  subprocess.stderr.pipe(fileWriteStream);
 }
 
 if (subprocess.stdout) {
   subprocess.stdout.pipe(process.stdout);
-  subprocess.stdout.pipe(createWriteStream(LOG_FILE));
+  subprocess.stdout.pipe(fileWriteStream);
 }
 
 subprocess.on('exit', (status) => {

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright 2023 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import child_process from 'child_process';
+import {createWriteStream} from 'fs';
+import {Transform} from 'stream';
+
+import {packageDirectorySync} from 'pkg-dir';
+
+import {
+  createBiDiServerProcess,
+  parseCommandLineArgs,
+  createLogFile,
+} from './bidi-server.mjs';
+// Changing the current work directory to the package directory.
+process.chdir(packageDirectorySync());
+
+const argv = parseCommandLineArgs();
+const LOG_FILE = createLogFile('e2e');
+
+/**
+ *
+ * @param {import('child_process').ChildProcessWithoutNullStreams} process
+ * @returns
+ */
+async function matchLine(process) {
+  let resolver;
+  let rejecter;
+  const promise = new Promise((resolve, reject) => {
+    resolver = resolve;
+    rejecter = reject;
+  });
+  let stdout = '';
+  function check() {
+    for (const line of stdout.split(/\n/g)) {
+      if (/.*BiDi server is listening on port \d+/.test(line)) {
+        process.off('exit', onExit);
+        process.stdout.off('data', onStdout);
+        process.stderr.off('data', onStdout);
+
+        resolver();
+        break;
+      }
+    }
+  }
+
+  function onStdout(data) {
+    stdout = stdout + String(data);
+    check();
+  }
+  function onExit() {
+    process.off('exit', onExit);
+    process.stdout.off('data', onStdout);
+    process.stderr.off('data', onStdout);
+    rejecter();
+  }
+  process.stdout.on('data', onStdout);
+  process.stderr.on('data', onStdout);
+  process.on('exit', onExit);
+
+  return await promise;
+}
+
+const addPrefix = () =>
+  new Transform({
+    transform(chunk, _, callback) {
+      let line = String(chunk);
+      if (line.startsWith('\n')) {
+        line = line.replace('\n', '');
+      }
+      this.push(Buffer.from([`\nPyTest: `, line, '\n'].join('')));
+      callback(null);
+    },
+  });
+
+const fileWriteStream = createWriteStream(LOG_FILE);
+const serverProcess = createBiDiServerProcess(argv);
+
+if (serverProcess.stderr) {
+  serverProcess.stdout.pipe(process.stdout);
+  serverProcess.stderr.pipe(fileWriteStream);
+}
+
+if (serverProcess.stdout) {
+  serverProcess.stdout.pipe(fileWriteStream);
+}
+
+await matchLine(serverProcess).catch(() => {
+  // eslint-disable-next-line no-console
+  console.log('Could not match line exiting...');
+  process.exit(1);
+});
+
+const e2eArgs = ['run', 'pytest', '--verbose', '-vv'];
+if (!argv.headless) {
+  e2eArgs.push('--ignore=tests/input');
+}
+const e2eProcess = child_process.spawn('pipenv', e2eArgs, {
+  stdio: ['inherit', 'pipe', 'pipe'],
+});
+
+if (e2eProcess.stderr) {
+  e2eProcess.stderr.pipe(process.stdout);
+  e2eProcess.stderr.pipe(addPrefix()).pipe(fileWriteStream);
+}
+
+if (e2eProcess.stdout) {
+  e2eProcess.stdout.pipe(process.stdout);
+  e2eProcess.stdout.pipe(addPrefix()).pipe(fileWriteStream);
+}
+
+e2eProcess.on('exit', (status) => {
+  serverProcess.kill();
+  process.exit(status ?? 0);
+});

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Copyright 2023 Google LLC.
+ * Copyright 2024 Google LLC.
  * Copyright (c) Microsoft Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Creates a separate E2E runner file. That way we can sync the output of `bidi-server.mjs` and `pytest`, which make is easier to see where a test starts and end in the logs.

E2E runs will only print PyTest output to reduce the time need to see what fails. The message logs will be uploaded as artifacts which can be downloaded. The `VERBOSE` is set to `true` always so we get the `CDP` logs as well. 