### PR TITLE
ci: BiDi server logs only when test fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ npm run e2e:headful
 npm run e2e:headless
 ```
 
+This commands will run `./tools/run-e2e.mjs`, which will log the PyTest output to console,
+Additionally the output is also recorded under `./logs/<DATE>.e2e.log`, this will contain
+both the PyTest logs and in the event of `FAILED` test all the Chromium-BiDi logs.
+
+If you need to see the logs for all test run the command with `VERBOSE=true`.
+
 Use the `PORT` environment variable to connect to another port:
 
 ```sh

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -90,9 +90,8 @@ const addPrefix = () =>
   });
 
 class SyncFileStreams extends Transform {
-  // Patches lines like `PyTest: FAILED [ 39%]`
+  // Matches lines like `PyTest: XXX [ 39%]` or
   static percentRegEx = /\[ \d+%\]/;
-  testRunning = false;
   serverLogs = Buffer.from('');
 
   _transform(chunk, _, callback) {
@@ -104,9 +103,6 @@ class SyncFileStreams extends Transform {
           this.push(this.serverLogs);
         }
         this.serverLogs = Buffer.from('');
-        this.testRunning = false;
-      } else {
-        this.testRunning = true;
       }
       this.push(chunk);
       // Handles output from BiDi server

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -115,9 +115,8 @@ class SyncFileStreams extends Transform {
 }
 
 const fileWriteStream = createWriteStream(LOG_FILE);
-const syncFileStreams = process.env.LOG_ALL
-  ? new PassThrough()
-  : new SyncFileStreams();
+const syncFileStreams =
+  process.env.VERBOSE === 'true' ? new PassThrough() : new SyncFileStreams();
 syncFileStreams.pipe(fileWriteStream);
 
 const serverProcess = createBiDiServerProcess(argv);


### PR DESCRIPTION
When running `npm run e2e` we only collect `Chromium-BiDi` log when the test fails rather then all the time. 
This reduces the overall size of logs to just a few KB compare to 7-8MB  previously, also this improves readability.