### PR TITLE
ci: in wpt html report sort tests by path and name

### DIFF
--- a/tools/wpt-report-builder/formatter.mjs
+++ b/tools/wpt-report-builder/formatter.mjs
@@ -67,7 +67,11 @@ export function flattenTests(report) {
   return report.results
     .filter(excludeTentativeTests)
     .map(flattenSingleTest)
-    .flat();
+    .flat()
+    .sort(
+      (a, b) =>
+        a.path?.localeCompare(b.path) || a.name?.localeCompare(b.name) || 0
+    );
 }
 
 export function groupTests(tests) {


### PR DESCRIPTION
Sort tests in the html WPT test report to align with [wpt.fyi](https://wpt.fyi/results/webdriver/tests/bidi?label=master&label=experimental&aligned) and to ease analyses.