### PR TITLE
test: fix headful mode actually using new headless in WPT

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -123,7 +123,6 @@ if (RUN_TESTS === 'true') {
   const wptRunArgs = [
     '--binary',
     BROWSER_BIN,
-    `--webdriver-arg=--headless=${HEADLESS}`,
     '--log-wptreport',
     WPT_REPORT,
     '--manifest',
@@ -167,6 +166,8 @@ if (RUN_TESTS === 'true') {
     if (HEADLESS === 'true') {
       chromeDriverLogs = join('logs', 'chromedriver-headless.log');
       wptRunArgs.push('--binary-arg=--headless=new');
+    } else {
+      wptRunArgs.push('--no-headless');
     }
     wptRunArgs.push(
       '--install-webdriver',
@@ -181,7 +182,7 @@ if (RUN_TESTS === 'true') {
     );
   } else {
     wptRunArgs.push(
-      `--webdriver-arg=--headless=${HEADLESS}`,
+      `--webdriver-arg=--headless=${HEADLESS}`, // only used by bidi-server.mjs.
       '--webdriver-binary',
       join('tools', 'run-bidi-server.mjs')
     );
@@ -210,6 +211,8 @@ if (RUN_TESTS === 'true') {
     test
   );
 
+  // TODO: escaping here is not quite correct.
+  log(`${wptBinary} run ${wptRunArgs.map((arg) => `'${arg}'`).join(' ')}`);
   run_status = spawnSync(wptBinary, ['run', ...wptRunArgs], {
     stdio: 'inherit',
   }).status;

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/activate/activate.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/activate/activate.py.ini
@@ -1,3 +1,0 @@
-[activate.py]
-  [test_activate_window]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
@@ -1,9 +1,0 @@
-[capture_screenshot.py]
-  [test_capture]
-    expected: [FAIL, PASS]
-
-  [test_capture[with activate\]]
-    expected: [FAIL, PASS]
-
-  [test_capture[without activate\]]
-    expected: [FAIL, PASS]

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/clip.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/clip.py.ini
@@ -7,3 +7,9 @@
 
   [test_clip_element_outside_of_window_viewport]
     expected: FAIL
+
+  [test_clip_box_outside_of_window_viewport[viewport\]]
+    expected: FAIL
+
+  [test_clip_element_outside_of_window_viewport[viewport\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,3 +1,9 @@
 [frame.py]
   [test_iframe]
     expected: FAIL
+
+  [test_context_origin[same_origin\]]
+    expected: FAIL
+
+  [test_context_origin[cross_origin\]]
+    expected: FAIL


### PR DESCRIPTION
With this PR, the headful mode actually runs the headful mode:

1) removed some failed test expectations that pass in headful
2) drive-by: full logging for wpt commands