### PR TITLE
ci: show chromedriver headful results in wptreport site

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
-          name: chromedriver-headless-artifacts
+          name: chromedriver-headful-artifacts
       - name: Prepare Pages
         run: |
           mkdir -p out/site


### PR DESCRIPTION
Proposal: let's switch the dashboard to report numbers from headful instead of headless as it is a configuration that matches the user experience the most? 