### PR TITLE
ci: don't commit for cancelled runs

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -70,7 +70,7 @@ jobs:
   wpt-auto-commit:
     name: WPT auto-commit expectations
     needs: wpt
-    if: ${{ always() && github.event.inputs.auto-commit == 'true' }}
+    if: ${{ !cancelled() && github.event.inputs.auto-commit == 'true' }}
     runs-on: ubuntu-latest
     # Give GITHUB_TOKEN write permission to commit and push.
     # Needed by stefanzweifel/git-auto-commit-action.
@@ -171,7 +171,7 @@ jobs:
           name: ${{ matrix.kind }}-${{ matrix.head }}-wpt-metadata
           path: wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}
       - name: Upload artifacts
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: ${{ matrix.kind }}-${{ matrix.head }}-artifacts


### PR DESCRIPTION
https://docs.github.com/en/actions/learn-github-actions/expressions#always
Currently if you cancel a run it will commit expectations which is bad as it make the PR useless.