### PR TITLE
fix: correctly process `NoSuchUserContextException` in cookie operations

### DIFF
--- a/tests/storage/test_delete_cookies.py
+++ b/tests/storage/test_delete_cookies.py
@@ -133,6 +133,28 @@ async def test_cookies_delete_partition_user_context(websocket, context_id,
 
 
 @pytest.mark.asyncio
+async def test_cookies_delete_partition_user_context_unknown(
+        websocket, context_id):
+    user_context_partition = {
+        'type': 'storageKey',
+        'userContext': 'UNKNOWN_USER_CONTEXT',
+    }
+
+    with pytest.raises(Exception,
+                       match=str({
+                           'error': 'no such user context',
+                           'message': '.*'
+                       })):
+        await execute_command(
+            websocket, {
+                'method': 'storage.deleteCookies',
+                'params': {
+                    'partition': user_context_partition,
+                }
+            })
+
+
+@pytest.mark.asyncio
 async def test_cookies_delete_partition_unsupported_key(websocket, context_id):
     cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, SOME_DOMAIN)
     await set_cookie(websocket, context_id, cookie)

--- a/tests/storage/test_get_cookies.py
+++ b/tests/storage/test_get_cookies.py
@@ -150,6 +150,28 @@ async def test_cookies_get_partition_user_context(websocket, context_id,
 
 
 @pytest.mark.asyncio
+async def test_cookies_get_partition_user_context_unknown(
+        websocket, context_id):
+    user_context_partition = {
+        'type': 'storageKey',
+        'userContext': 'UNKNOWN_USER_CONTEXT',
+    }
+
+    with pytest.raises(Exception,
+                       match=str({
+                           'error': 'no such user context',
+                           'message': '.*'
+                       })):
+        await execute_command(
+            websocket, {
+                'method': 'storage.getCookies',
+                'params': {
+                    'partition': user_context_partition,
+                }
+            })
+
+
+@pytest.mark.asyncio
 async def test_cookies_get_partition_unsupported_key(websocket, context_id):
     cookie = get_bidi_cookie(SOME_COOKIE_NAME, SOME_COOKIE_VALUE, SOME_DOMAIN)
     await set_cookie(websocket, context_id, cookie)

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/delete_cookies/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/delete_cookies/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_params_partition_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/get_cookies/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/get_cookies/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_params_partition_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/set_cookie/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/storage/set_cookie/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_partition_storage_key_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/delete_cookies/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/delete_cookies/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_params_partition_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/get_cookies/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/get_cookies/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_params_partition_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/set_cookie/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/storage/set_cookie/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_partition_storage_key_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/delete_cookies/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/delete_cookies/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_params_partition_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/get_cookies/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/get_cookies/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_params_partition_user_context_invalid_value]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/set_cookie/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/storage/set_cookie/invalid.py.ini
@@ -1,3 +1,0 @@
-[invalid.py]
-  [test_partition_storage_key_user_context_invalid_value]
-    expected: FAIL


### PR DESCRIPTION
Parse error when setting/getting cookies to catch `NoSuchUserContextException`.
+ updated `test_cookie_set_partition_user_context` to test what it was intended to.