### PR TITLE
chore: move deps and add rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,12 @@ module.exports = {
         project: './tsconfig.base.json',
       },
       rules: {
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: false,
+          },
+        ],
         // keep-sorted start block=yes sticky_comments=yes
         '@typescript-eslint/array-type': 'warn',
         '@typescript-eslint/consistent-generic-constructors': 'warn',
@@ -129,6 +135,13 @@ module.exports = {
         '@typescript-eslint/return-await': ['error', 'always'],
         '@typescript-eslint/switch-exhaustiveness-check': 'error',
         // keep-sorted end
+      },
+    },
+    {
+      // Disable rules for non production code
+      files: ['*.spec.ts', './src/bidiServer/*'],
+      rules: {
+        'import/no-extraneous-dependencies': 'off',
       },
     },
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.22.4"
       },
       "devDependencies": {
         "@actions/core": "1.10.1",
@@ -61,8 +62,7 @@
         "websocket": "1.0.34",
         "wireit": "0.14.4",
         "ws": "8.16.0",
-        "yargs": "17.7.2",
-        "zod": "3.22.4"
+        "yargs": "17.7.2"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -3721,14 +3721,15 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       },
       "engines": {
@@ -4246,6 +4247,27 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+      "dev": true
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -4322,6 +4344,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/execa": {
@@ -10476,7 +10508,6 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -216,11 +216,11 @@
     "websocket": "1.0.34",
     "wireit": "0.14.4",
     "ws": "8.16.0",
-    "yargs": "17.7.2",
-    "zod": "3.22.4"
+    "yargs": "17.7.2"
   },
   "dependencies": {
     "mitt": "3.0.1",
-    "urlpattern-polyfill": "10.0.0"
+    "urlpattern-polyfill": "10.0.0",
+    "zod": "3.22.4"
   }
 }


### PR DESCRIPTION
This should prevent our production code from pulling `devDependencies`. 