### PR TITLE
feat: add support for `contexts` in `addInterception`

### DIFF
--- a/src/bidiMapper/domains/context/CdpTarget.ts
+++ b/src/bidiMapper/domains/context/CdpTarget.ts
@@ -176,10 +176,10 @@ export class CdpTarget {
 
     if (
       // Only toggle interception when Network is enabled
-      !this.#networkDomainEnabled &&
-      this.#fetchDomainStages.request === stages.request &&
-      this.#fetchDomainStages.response === stages.response &&
-      this.#fetchDomainStages.auth === stages.auth
+      !this.#networkDomainEnabled ||
+      (this.#fetchDomainStages.request === stages.request &&
+        this.#fetchDomainStages.response === stages.response &&
+        this.#fetchDomainStages.auth === stages.auth)
     ) {
       return;
     }

--- a/src/bidiMapper/domains/context/CdpTarget.ts
+++ b/src/bidiMapper/domains/context/CdpTarget.ts
@@ -36,11 +36,16 @@ export class CdpTarget {
   readonly #eventManager: EventManager;
 
   readonly #preloadScriptStorage: PreloadScriptStorage;
+  readonly #networkStorage: NetworkStorage;
 
   readonly #unblocked = new Deferred<Result<void>>();
   readonly #acceptInsecureCerts: boolean;
   #networkDomainEnabled = false;
-  #fetchDomainEnabled = false;
+  #fetchDomainStages = {
+    request: false,
+    response: false,
+    auth: false,
+  };
 
   static create(
     targetId: Protocol.Target.TargetID,
@@ -59,6 +64,7 @@ export class CdpTarget {
       browserCdpClient,
       eventManager,
       preloadScriptStorage,
+      networkStorage,
       acceptInsecureCerts
     );
 
@@ -79,13 +85,15 @@ export class CdpTarget {
     browserCdpClient: CdpClient,
     eventManager: EventManager,
     preloadScriptStorage: PreloadScriptStorage,
+    networkStorage: NetworkStorage,
     acceptInsecureCerts: boolean
   ) {
     this.#id = targetId;
     this.#cdpClient = cdpClient;
+    this.#browserCdpClient = browserCdpClient;
     this.#eventManager = eventManager;
     this.#preloadScriptStorage = preloadScriptStorage;
-    this.#browserCdpClient = browserCdpClient;
+    this.#networkStorage = networkStorage;
     this.#acceptInsecureCerts = acceptInsecureCerts;
   }
 
@@ -135,9 +143,9 @@ export class CdpTarget {
           ignore: this.#acceptInsecureCerts,
         }),
         // TODO: enable Network domain for OOPiF targets.
-        enabledNetwork
-          ? this.#cdpClient.sendCommand('Network.enable')
-          : undefined,
+        this.toggleNetworkIfNeeded(enabledNetwork).then(async () => {
+          return await this.toggleFetchIfNeeded();
+        }),
         this.#cdpClient.sendCommand('Target.setAutoAttach', {
           autoAttach: true,
           waitForDebuggerOnStart: true,
@@ -163,29 +171,41 @@ export class CdpTarget {
     });
   }
 
-  async enableFetchIfNeeded(params: Protocol.Fetch.EnableRequest) {
-    if (!this.#networkDomainEnabled || this.#fetchDomainEnabled) {
+  async toggleFetchIfNeeded() {
+    const stages = this.#networkStorage.getInterceptionStages(this.id);
+
+    if (
+      // Only toggle interception when Network is enabled
+      !this.#networkDomainEnabled &&
+      this.#fetchDomainStages.request === stages.request &&
+      this.#fetchDomainStages.response === stages.response &&
+      this.#fetchDomainStages.auth === stages.auth
+    ) {
       return;
     }
+    const patterns: Protocol.Fetch.EnableRequest['patterns'] = [];
 
-    this.#fetchDomainEnabled = true;
-    try {
-      await this.#cdpClient.sendCommand('Fetch.enable', params);
-    } catch (err) {
-      this.#fetchDomainEnabled = false;
+    this.#fetchDomainStages = stages;
+    if (stages.request || stages.auth) {
+      // CDP quirk we need request interception when we intercept auth
+      patterns.push({
+        urlPattern: '*',
+        requestStage: 'Request',
+      });
     }
-  }
-
-  async disableFetchIfNeeded() {
-    if (!this.#fetchDomainEnabled) {
-      return;
+    if (stages.response) {
+      patterns.push({
+        urlPattern: '*',
+        requestStage: 'Response',
+      });
     }
-
-    this.#fetchDomainEnabled = false;
-    try {
+    if (patterns.length) {
+      await this.#cdpClient.sendCommand('Fetch.enable', {
+        patterns,
+        handleAuthRequests: stages.auth,
+      });
+    } else {
       await this.#cdpClient.sendCommand('Fetch.disable');
-    } catch (err) {
-      this.#fetchDomainEnabled = true;
     }
   }
 
@@ -196,9 +216,12 @@ export class CdpTarget {
 
     this.#networkDomainEnabled = enabled;
     try {
-      await this.#cdpClient.sendCommand(
-        this.#networkDomainEnabled ? 'Network.enable' : 'Network.disable'
-      );
+      await Promise.all([
+        this.#cdpClient.sendCommand(
+          enabled ? 'Network.enable' : 'Network.disable'
+        ),
+        this.toggleFetchIfNeeded(),
+      ]);
     } catch (err) {
       this.#networkDomainEnabled = !enabled;
     }

--- a/src/bidiMapper/domains/context/CdpTarget.ts
+++ b/src/bidiMapper/domains/context/CdpTarget.ts
@@ -130,6 +130,7 @@ export class CdpTarget {
         BiDiModule.Network,
         this.#id
       );
+    this.#networkDomainEnabled = enabledNetwork;
 
     try {
       await Promise.all([
@@ -143,9 +144,10 @@ export class CdpTarget {
           ignore: this.#acceptInsecureCerts,
         }),
         // TODO: enable Network domain for OOPiF targets.
-        this.toggleNetworkIfNeeded(enabledNetwork).then(async () => {
-          return await this.toggleFetchIfNeeded();
-        }),
+        enabledNetwork
+          ? this.#cdpClient.sendCommand('Network.enable')
+          : undefined,
+        this.toggleFetchIfNeeded(),
         this.#cdpClient.sendCommand('Target.setAutoAttach', {
           autoAttach: true,
           waitForDebuggerOnStart: true,

--- a/src/bidiMapper/domains/network/NetworkRequest.ts
+++ b/src/bidiMapper/domains/network/NetworkRequest.ts
@@ -150,6 +150,10 @@ export class NetworkRequest {
     return this.#redirectCount;
   }
 
+  get cdpTarget() {
+    return this.#cdpTarget;
+  }
+
   get cdpClient() {
     return this.#cdpTarget.cdpClient;
   }

--- a/src/bidiMapper/domains/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/domains/network/NetworkStorage.spec.ts
@@ -125,7 +125,7 @@ describe('NetworkStorage', () => {
 
     it('should work interception', async () => {
       const request = new MockCdpNetworkEvents(cdpClient);
-      const interception = await networkStorage.addIntercept({
+      const interception = networkStorage.addIntercept({
         urlPatterns: [{type: 'string', pattern: request.url}],
         phases: [Network.InterceptPhase.BeforeRequestSent],
       });
@@ -144,7 +144,7 @@ describe('NetworkStorage', () => {
 
     it('should work interception pause first', async () => {
       const request = new MockCdpNetworkEvents(cdpClient);
-      const interception = await networkStorage.addIntercept({
+      const interception = networkStorage.addIntercept({
         urlPatterns: [{type: 'string', pattern: request.url}],
         phases: [Network.InterceptPhase.BeforeRequestSent],
       });
@@ -162,7 +162,7 @@ describe('NetworkStorage', () => {
     });
 
     it('should work non blocking interception', async () => {
-      await networkStorage.addIntercept({
+      networkStorage.addIntercept({
         urlPatterns: [{type: 'string', pattern: 'http://not.correct.com'}],
         phases: [Network.InterceptPhase.BeforeRequestSent],
       });
@@ -182,7 +182,7 @@ describe('NetworkStorage', () => {
 
     it('should work with non blocking interception and fail response', async () => {
       const request = new MockCdpNetworkEvents(cdpClient);
-      await networkStorage.addIntercept({
+      networkStorage.addIntercept({
         urlPatterns: [{type: 'string', pattern: 'http://not.correct.com'}],
         phases: [Network.InterceptPhase.BeforeRequestSent],
       });
@@ -238,7 +238,7 @@ describe('NetworkStorage', () => {
 
     it('should work interception', async () => {
       const request = new MockCdpNetworkEvents(cdpClient);
-      const interception = await networkStorage.addIntercept({
+      const interception = networkStorage.addIntercept({
         urlPatterns: [{type: 'string', pattern: request.url}],
         phases: [Network.InterceptPhase.ResponseStarted],
       });
@@ -259,7 +259,7 @@ describe('NetworkStorage', () => {
     });
 
     it('should work non blocking interception', async () => {
-      await networkStorage.addIntercept({
+      networkStorage.addIntercept({
         urlPatterns: [{type: 'string', pattern: 'http://not.correct.com'}],
         phases: [Network.InterceptPhase.ResponseStarted],
       });

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/add_intercept/contexts.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/add_intercept/contexts.py.ini
@@ -1,6 +1,0 @@
-[contexts.py]
-  [test_other_context_with_event_subscription]
-    expected: FAIL
-
-  [test_two_contexts_global_intercept]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/add_intercept/contexts.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/add_intercept/contexts.py.ini
@@ -1,6 +1,0 @@
-[contexts.py]
-  [test_other_context_with_event_subscription]
-    expected: FAIL
-
-  [test_two_contexts_global_intercept]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/add_intercept/contexts.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/add_intercept/contexts.py.ini
@@ -1,6 +1,0 @@
-[contexts.py]
-  [test_other_context_with_event_subscription]
-    expected: FAIL
-
-  [test_two_contexts_global_intercept]
-    expected: FAIL


### PR DESCRIPTION
This PR move the logic to for when to enable the Fetch Domain to the CdpTarget. That way we can manage interception more gradually. 

Also fixes an issue where if we `network.addInterception` then `network.subscribe`, the interception would have not been enabled.
Also fixes an issue if a CdpTarget is created later but network interception was enable globally before that.