### PR TITLE
fix: workaround issue with Script.Target

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -371,6 +371,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
     if (
       typeof params === 'object' &&
       'target' in params &&
+      typeof params.target === 'object' &&
       'context' in params.target
     ) {
       delete (params.target as any)['realm'];

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -369,7 +369,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
   // https://github.com/w3c/webdriver-bidi/issues/635
   #processTargetParams(params: {target: Script.Target}) {
     if (
-      typeof params.target === 'object' &&
+      typeof params === 'object' &&
       'target' in params &&
       'context' in params.target
     ) {

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -370,8 +370,10 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
   #processTargetParams(params: {target: Script.Target}) {
     if (
       typeof params === 'object' &&
+      params &&
       'target' in params &&
       typeof params.target === 'object' &&
+      params.target &&
       'context' in params.target
     ) {
       delete (params.target as any)['realm'];

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -24,6 +24,7 @@ import {
   UnsupportedOperationException,
   type ChromiumBidi,
   type Browser,
+  type Script,
 } from '../protocol/protocol.js';
 import {EventEmitter} from '../utils/EventEmitter.js';
 import {LogType, type LoggerFn} from '../utils/log.js';
@@ -299,15 +300,21 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
         );
       case 'script.callFunction':
         return await this.#scriptProcessor.callFunction(
-          this.#parser.parseCallFunctionParams(command.params)
+          this.#parser.parseCallFunctionParams(
+            this.#processTargetParams(command.params)
+          )
         );
       case 'script.disown':
         return await this.#scriptProcessor.disown(
-          this.#parser.parseDisownParams(command.params)
+          this.#parser.parseDisownParams(
+            this.#processTargetParams(command.params)
+          )
         );
       case 'script.evaluate':
         return await this.#scriptProcessor.evaluate(
-          this.#parser.parseEvaluateParams(command.params)
+          this.#parser.parseEvaluateParams(
+            this.#processTargetParams(command.params)
+          )
         );
       case 'script.getRealms':
         return this.#scriptProcessor.getRealms(
@@ -356,6 +363,15 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
     // ESLint @typescript-eslint/switch-exhaustiveness-check triggers if a new
     // command is added.
     throw new UnknownCommandException(`Unknown command '${command.method}'.`);
+  }
+
+  // Workaround for as zod.union always take the first schema
+  // https://github.com/w3c/webdriver-bidi/issues/635
+  #processTargetParams(params: {target: Script.Target}) {
+    if ('context' in params.target) {
+      delete (params.target as any)['realm'];
+    }
+    return params;
   }
 
   async processCommand(command: ChromiumBidi.Command): Promise<void> {

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -368,7 +368,11 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
   // Workaround for as zod.union always take the first schema
   // https://github.com/w3c/webdriver-bidi/issues/635
   #processTargetParams(params: {target: Script.Target}) {
-    if ('context' in params.target) {
+    if (
+      typeof params.target === 'object' &&
+      'target' in params &&
+      'context' in params.target
+    ) {
       delete (params.target as any)['realm'];
     }
     return params;

--- a/src/bidiMapper/domains/script/ScriptProcessor.ts
+++ b/src/bidiMapper/domains/script/ScriptProcessor.ts
@@ -152,12 +152,12 @@ export class ScriptProcessor {
   }
 
   async #getRealm(target: Script.Target): Promise<Realm> {
-    if ('realm' in target) {
-      return this.#realmStorage.getRealm({
-        realmId: target.realm,
-      });
+    if ('context' in target) {
+      const context = this.#browsingContextStorage.getContext(target.context);
+      return await context.getOrCreateSandbox(target.sandbox);
     }
-    const context = this.#browsingContextStorage.getContext(target.context);
-    return await context.getOrCreateSandbox(target.sandbox);
+    return this.#realmStorage.getRealm({
+      realmId: target.realm,
+    });
   }
 }

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/script/call_function/target.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/script/call_function/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/script/evaluate/target.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/script/evaluate/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/call_function/target.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/call_function/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/evaluate/target.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/script/evaluate/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/call_function/target.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/call_function/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/evaluate/target.py.ini
+++ b/wpt-metadata/mapper/headful/webdriver/tests/bidi/script/evaluate/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/call_function/target.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/call_function/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/evaluate/target.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/evaluate/target.py.ini
@@ -1,3 +1,0 @@
-[target.py]
-  [test_target_context_and_realm]
-    expected: FAIL


### PR DESCRIPTION
Limitation to Zod.union is that i check the first one and cuts the object in its shape if it passes so we only get the `Realm`.
This works around this until we add a `type: 'realm'` and `type: 'context'` to the Script.Target https://github.com/w3c/webdriver-bidi/issues/635