### PR TITLE
feat: `invalid selector` error

### DIFF
--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -22,6 +22,7 @@ import {
   BrowsingContext,
   ChromiumBidi,
   InvalidArgumentException,
+  InvalidSelectorException,
   NoSuchElementException,
   NoSuchHistoryEntryException,
   Script,
@@ -1083,6 +1084,16 @@ export class BrowsingContextImpl {
     );
 
     if (selectorScriptResult.type !== 'success') {
+      // Heuristic to detect invalid selector.
+      if (
+        selectorScriptResult.exceptionDetails.text?.endsWith(
+          'is not a valid selector.'
+        )
+      ) {
+        throw new InvalidSelectorException(
+          `Not valid css selector ${selector}`
+        );
+      }
       throw new UnknownErrorException(
         `Unexpected error in selector script: ${selectorScriptResult.exceptionDetails.text}`
       );

--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -1086,13 +1086,14 @@ export class BrowsingContextImpl {
     if (selectorScriptResult.type !== 'success') {
       // Heuristic to detect invalid selector.
       if (
+        selectorScriptResult.exceptionDetails.text?.startsWith(
+          'SyntaxError:'
+        ) &&
         selectorScriptResult.exceptionDetails.text?.endsWith(
           'is not a valid selector.'
         )
       ) {
-        throw new InvalidSelectorException(
-          `Not valid css selector ${selector}`
-        );
+        throw new InvalidSelectorException(`Not valid selector ${selector}`);
       }
       throw new UnknownErrorException(
         `Unexpected error in selector script: ${selectorScriptResult.exceptionDetails.text}`

--- a/src/protocol-parser/generated/webdriver-bidi.ts
+++ b/src/protocol-parser/generated/webdriver-bidi.ts
@@ -111,6 +111,7 @@ export const JsUintSchema = z
 export const ErrorCodeSchema = z.lazy(() =>
   z.enum([
     'invalid argument',
+    'invalid selector',
     'invalid session id',
     'move target out of bounds',
     'no such alert',

--- a/src/protocol/ErrorResponse.spec.ts
+++ b/src/protocol/ErrorResponse.spec.ts
@@ -25,6 +25,7 @@ describe('Exception', () => {
   } = {
     // keep-sorted start
     [ErrorCode.InvalidArgument]: undefined,
+    [ErrorCode.InvalidSelector]: undefined,
     [ErrorCode.InvalidSessionId]: undefined,
     [ErrorCode.MoveTargetOutOfBounds]: undefined,
     [ErrorCode.NoSuchAlert]: undefined,

--- a/src/protocol/ErrorResponse.ts
+++ b/src/protocol/ErrorResponse.ts
@@ -41,6 +41,12 @@ export class InvalidArgumentException extends Exception {
   }
 }
 
+export class InvalidSelectorException extends Exception {
+  constructor(message: string, stacktrace?: string) {
+    super(ErrorCode.InvalidSelector, message, stacktrace);
+  }
+}
+
 export class InvalidSessionIdException extends Exception {
   constructor(message: string, stacktrace?: string) {
     super(ErrorCode.InvalidSessionId, message, stacktrace);

--- a/src/protocol/generated/webdriver-bidi.ts
+++ b/src/protocol/generated/webdriver-bidi.ts
@@ -79,6 +79,7 @@ export type JsInt = number;
 export type JsUint = number;
 export const enum ErrorCode {
   InvalidArgument = 'invalid argument',
+  InvalidSelector = 'invalid selector',
   InvalidSessionId = 'invalid session id',
   MoveTargetOutOfBounds = 'move target out of bounds',
   NoSuchAlert = 'no such alert',

--- a/tests/browsing_context/test_locate_nodes.py
+++ b/tests/browsing_context/test_locate_nodes.py
@@ -78,7 +78,7 @@ async def test_locate_nodes_css_locator_invalid(websocket, context_id, html):
                        match=re.escape(
                            str({
                                'error': 'invalid selector',
-                               'message': 'Not valid css selector ' +
+                               'message': 'Not valid selector ' +
                                           invalid_css_selector
                            }))):
         await execute_command(

--- a/tests/browsing_context/test_locate_nodes.py
+++ b/tests/browsing_context/test_locate_nodes.py
@@ -12,6 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import re
 
 import pytest
 from test_helpers import ANY_SHARED_ID, execute_command, goto_url
@@ -68,3 +69,26 @@ async def test_locate_nodes_css_locator(websocket, context_id, html):
             },
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_locate_nodes_css_locator_invalid(websocket, context_id, html):
+    invalid_css_selector = 'a*b'
+    with pytest.raises(Exception,
+                       match=re.escape(
+                           str({
+                               'error': 'invalid selector',
+                               'message': 'Not valid css selector ' +
+                                          invalid_css_selector
+                           }))):
+        await execute_command(
+            websocket, {
+                'method': 'browsingContext.locateNodes',
+                'params': {
+                    'context': context_id,
+                    'locator': {
+                        'type': 'css',
+                        'value': invalid_css_selector
+                    }
+                }
+            })

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[css-a*b\]]
-    expected: FAIL
-
   [test_params_locator_value_invalid_value[xpath-\]]
     expected: FAIL
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[css-a*b\]]
-    expected: FAIL
-
   [test_params_locator_value_invalid_value[xpath-\]]
     expected: FAIL
 

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[css-a*b\]]
-    expected: FAIL
-
   [test_params_locator_value_invalid_value[xpath-\]]
     expected: FAIL
 


### PR DESCRIPTION
Support `invalid selector` error code in [`browsingContext.locateNodes`](https://w3c.github.io/webdriver-bidi/#commands-browsingcontextlocatenodes).

This PR only partly updates the generated types with only relevant change.