### PR TITLE
feat: support xpath locators

### DIFF
--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -1067,8 +1067,9 @@ export class BrowsingContextImpl {
             XPathResult.ORDERED_NODE_SNAPSHOT_TYPE
           );
           const result = [];
-          for (let i = 0; i < xPathResult.snapshotLength; i++)
+          for (let i = 0; i < xPathResult.snapshotLength; i++) {
             result.push(xPathResult.snapshotItem(i));
+          }
           return result;
         });
       default:

--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -1043,34 +1043,50 @@ export class BrowsingContextImpl {
 
     const realm = await this.getOrCreateSandbox(params.sandbox);
 
-    switch (params.locator.type) {
+    return await this.#locateNodesBySelector(realm, params.locator);
+  }
+
+  #getLocatorFunction(selector: BrowsingContext.Locator): string {
+    switch (selector.type) {
       case 'css':
-        return await this.#locateNodesByCssSelector(
-          realm,
-          params.locator.value
-        );
+        return String((selector: string) => {
+          const results = document.querySelectorAll(selector);
+          const array = [];
+          for (const item of results) {
+            array.push(item);
+          }
+          return array;
+        });
+      case 'xpath':
+        return String((xPathSelector: string) => {
+          // https://w3c.github.io/webdriver-bidi/#locate-nodes-using-xpath
+          const evaluator = new XPathEvaluator();
+          const expression = evaluator.createExpression(xPathSelector);
+          const xPathResult = expression.evaluate(
+            document,
+            XPathResult.ORDERED_NODE_SNAPSHOT_TYPE
+          );
+          const result = [];
+          for (let i = 0; i < xPathResult.snapshotLength; i++)
+            result.push(xPathResult.snapshotItem(i));
+          return result;
+        });
       default:
         throw new UnsupportedOperationException(
-          `locateNodes does not support ${params.locator.type} locator type.`
+          `locateNodes does not support ${selector.type} locator type.`
         );
     }
   }
 
-  async #locateNodesByCssSelector(
+  async #locateNodesBySelector(
     realm: Realm,
-    selector: string
+    selector: BrowsingContext.Locator
   ): Promise<BrowsingContext.LocateNodesResult> {
+    const selectorFunction = this.#getLocatorFunction(selector);
     const selectorScriptResult = await realm.callFunction(
-      String((selector: string) => {
-        const results = document.querySelectorAll(selector);
-        const array = [];
-        for (const item of results) {
-          array.push(item);
-        }
-        return array;
-      }),
+      selectorFunction,
       {type: 'undefined'},
-      [{type: 'string', value: selector}],
+      [{type: 'string', value: selector.value}],
       false,
       Script.ResultOwnership.None,
       {},
@@ -1084,16 +1100,20 @@ export class BrowsingContextImpl {
     );
 
     if (selectorScriptResult.type !== 'success') {
-      // Heuristic to detect invalid selector.
+      // Heuristic to detect invalid selector for different types of selectors.
       if (
-        selectorScriptResult.exceptionDetails.text?.startsWith(
-          'SyntaxError:'
-        ) &&
+        // CSS selector.
         selectorScriptResult.exceptionDetails.text?.endsWith(
           'is not a valid selector.'
+        ) ||
+        // XPath selector.
+        selectorScriptResult.exceptionDetails.text?.endsWith(
+          'is not a valid XPath expression.'
         )
       ) {
-        throw new InvalidSelectorException(`Not valid selector ${selector}`);
+        throw new InvalidSelectorException(
+          `Not valid selector ${selector.value}`
+        );
       }
       throw new UnknownErrorException(
         `Unexpected error in selector script: ${selectorScriptResult.exceptionDetails.text}`

--- a/tests/browsing_context/test_locate_nodes.py
+++ b/tests/browsing_context/test_locate_nodes.py
@@ -18,27 +18,34 @@ import pytest
 from test_helpers import ANY_SHARED_ID, execute_command, goto_url
 
 
+@pytest.mark.parametrize('locator', [
+    {
+        'type': 'css',
+        'value': 'div'
+    },
+    {
+        'type': 'xpath',
+        'value': '//div'
+    },
+])
 @pytest.mark.asyncio
-async def test_locate_nodes_css_locator(websocket, context_id, html):
+async def test_locate_nodes_locator(websocket, context_id, html, locator):
     await goto_url(
         websocket, context_id,
         html(
-            """<div data-class="one">foobarBARbaz</div><div data-class="two">foobarBARbaz</div>"""
+            '<div data-class="one">foobarBARbaz</div><div data-class="two">foobarBARbaz</div>'
         ))
     resp = await execute_command(
         websocket, {
-            "method": "browsingContext.locateNodes",
-            "params": {
-                "context": context_id,
-                "locator": {
-                    "type": "css",
-                    "value": "div"
-                }
+            'method': 'browsingContext.locateNodes',
+            'params': {
+                'context': context_id,
+                'locator': locator
             }
         })
 
     assert resp == {
-        "nodes": [
+        'nodes': [
             {
                 'sharedId': ANY_SHARED_ID,
                 'type': 'node',
@@ -71,24 +78,31 @@ async def test_locate_nodes_css_locator(websocket, context_id, html):
     }
 
 
+@pytest.mark.parametrize('locator', [
+    {
+        'type': 'css',
+        'value': 'a*b'
+    },
+    {
+        'type': 'xpath',
+        'value': ''
+    },
+])
 @pytest.mark.asyncio
-async def test_locate_nodes_css_locator_invalid(websocket, context_id, html):
-    invalid_css_selector = 'a*b'
+async def test_locate_nodes_locator_invalid(websocket, context_id, html,
+                                            locator):
     with pytest.raises(Exception,
                        match=re.escape(
                            str({
                                'error': 'invalid selector',
                                'message': 'Not valid selector ' +
-                                          invalid_css_selector
+                                          locator['value']
                            }))):
         await execute_command(
             websocket, {
                 'method': 'browsingContext.locateNodes',
                 'params': {
                     'context': context_id,
-                    'locator': {
-                        'type': 'css',
-                        'value': invalid_css_selector
-                    }
+                    'locator': locator
                 }
             })

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[xpath-\]]
-    expected: FAIL
-
   [test_params_locator_value_invalid_value[innerText-\]]
     expected: FAIL
 
@@ -18,7 +15,4 @@
     expected: FAIL
 
   [test_params_start_nodes_dom_node_not_element[document.doctype\]]
-    expected: FAIL
-
-  [test_params_locator_xpath_unknown_error]
     expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
@@ -1,7 +1,4 @@
 [locator.py]
-  [test_find_by_locator[xpath-//div\]]
-    expected: FAIL
-
   [test_find_by_locator[innerText-foobarBARbaz\]]
     expected: FAIL
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[xpath-\]]
-    expected: FAIL
-
   [test_params_locator_value_invalid_value[innerText-\]]
     expected: FAIL
 
@@ -18,7 +15,4 @@
     expected: FAIL
 
   [test_params_start_nodes_dom_node_not_element[document.doctype\]]
-    expected: FAIL
-
-  [test_params_locator_xpath_unknown_error]
     expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
@@ -1,7 +1,4 @@
 [locator.py]
-  [test_find_by_locator[xpath-//div\]]
-    expected: FAIL
-
   [test_find_by_locator[innerText-foobarBARbaz\]]
     expected: FAIL
 

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[xpath-\]]
-    expected: FAIL
-
   [test_params_locator_value_invalid_value[innerText-\]]
     expected: FAIL
 
@@ -18,7 +15,4 @@
     expected: FAIL
 
   [test_params_start_nodes_dom_node_not_element[document.doctype\]]
-    expected: FAIL
-
-  [test_params_locator_xpath_unknown_error]
     expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
@@ -1,7 +1,4 @@
 [locator.py]
-  [test_find_by_locator[xpath-//div\]]
-    expected: FAIL
-
   [test_find_by_locator[innerText-foobarBARbaz\]]
     expected: FAIL
 


### PR DESCRIPTION
Implement XPath locator in [`browsingContext.locateNodes`](https://w3c.github.io/webdriver-bidi/#commands-browsingcontextlocatenodes) via [`XPathEvaluator`](https://developer.mozilla.org/en-US/docs/Web/API/XPathEvaluator) WebApi.