### PR TITLE
feat: support `innerText` locators

### DIFF
--- a/tests/browsing_context/test_locate_nodes.py
+++ b/tests/browsing_context/test_locate_nodes.py
@@ -20,6 +20,10 @@ from test_helpers import ANY_SHARED_ID, execute_command, goto_url
 
 @pytest.mark.parametrize('locator', [
     {
+        'type': 'innerText',
+        'value': 'foobarBARbaz'
+    },
+    {
         'type': 'css',
         'value': 'div'
     },
@@ -29,11 +33,12 @@ from test_helpers import ANY_SHARED_ID, execute_command, goto_url
     },
 ])
 @pytest.mark.asyncio
-async def test_locate_nodes_locator(websocket, context_id, html, locator):
+async def test_locate_nodes_locator_found(websocket, context_id, html,
+                                          locator):
     await goto_url(
         websocket, context_id,
         html(
-            '<div data-class="one">foobarBARbaz</div><div data-class="two">foobarBARbaz</div>'
+            '<div data-class="one">foobarBARbaz</div><div data-class="two">foobarBAR<span>baz</span></div>'
         ))
     resp = await execute_command(
         websocket, {
@@ -67,7 +72,7 @@ async def test_locate_nodes_locator(websocket, context_id, html, locator):
                     'attributes': {
                         'data-class': 'two',
                     },
-                    'childNodeCount': 1,
+                    'childNodeCount': 2,
                     'localName': 'div',
                     'namespaceURI': 'http://www.w3.org/1999/xhtml',
                     'nodeType': 1,

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[innerText-\]]
-    expected: FAIL
-
   [test_params_start_nodes_dom_node_not_element[document.querySelector('input#button').attributes[0\]\]]
     expected: FAIL
 

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
@@ -1,7 +1,4 @@
 [locator.py]
-  [test_find_by_locator[innerText-foobarBARbaz\]]
-    expected: FAIL
-
   [test_find_by_inner_text[ignore_case_true_full_match_no_max_depth\]]
     expected: FAIL
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[innerText-\]]
-    expected: FAIL
-
   [test_params_start_nodes_dom_node_not_element[document.querySelector('input#button').attributes[0\]\]]
     expected: FAIL
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
@@ -1,7 +1,4 @@
 [locator.py]
-  [test_find_by_locator[innerText-foobarBARbaz\]]
-    expected: FAIL
-
   [test_find_by_inner_text[ignore_case_true_full_match_no_max_depth\]]
     expected: FAIL
 

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/invalid.py.ini
@@ -1,7 +1,4 @@
 [invalid.py]
-  [test_params_locator_value_invalid_value[innerText-\]]
-    expected: FAIL
-
   [test_params_start_nodes_dom_node_not_element[document.querySelector('input#button').attributes[0\]\]]
     expected: FAIL
 

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/locate_nodes/locator.py.ini
@@ -1,7 +1,4 @@
 [locator.py]
-  [test_find_by_locator[innerText-foobarBARbaz\]]
-    expected: FAIL
-
   [test_find_by_inner_text[ignore_case_true_full_match_no_max_depth\]]
     expected: FAIL
 


### PR DESCRIPTION
Start implement innerText locator in [`browsingContext.locateNodes`](https://w3c.github.io/webdriver-bidi/#commands-browsingcontextlocatenodes) using WebAPI.

Out of scope:
* `maxNodeCount`
* `maxDepth`