### PR TITLE
ci: don't run WPT quick on main

### DIFF
--- a/.github/workflows/wpt-quick.yml
+++ b/.github/workflows/wpt-quick.yml
@@ -15,8 +15,6 @@ env:
 on:
   merge_group:
   pull_request:
-  push:
-    branches: 'main'
   workflow_dispatch:
     inputs:
       tests:


### PR DESCRIPTION
We should have ran this check to merge a PR, so running it here does not give any value as we already run `WPT detailed` action. This should make allocating runners quicker for our other PRs. 