### PR TITLE
test: control head mode via capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pre-commit": "pre-commit run --hook-stage manual --all-files",
     "prepare": "wireit",
     "rollup": "wireit",
-    "server": "npm run server --",
+    "server": "wireit",
     "test": "wireit",
     "tsc": "wireit",
     "unit": "wireit",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "pre-commit": "pre-commit run --hook-stage manual --all-files",
     "prepare": "wireit",
     "rollup": "wireit",
-    "server": "npm run server:headless --",
-    "server:headful": "wireit",
-    "server:headless": "wireit",
+    "server": "npm run server --",
     "test": "wireit",
     "tsc": "wireit",
     "unit": "wireit",
@@ -46,7 +44,10 @@
       ],
       "dependencies": [
         "build"
-      ]
+      ],
+      "env": {
+        "HEADLESS": "false"
+      }
     },
     "e2e:headless": {
       "command": "tools/run-e2e.mjs",
@@ -77,19 +78,8 @@
         "lib/iife/mapperTab.js"
       ]
     },
-    "server:headful": {
-      "command": "npm run server:headless -- --headless=false",
-      "service": {
-        "readyWhen": {
-          "lineMatches": "BiDi server is listening on port \\d+"
-        }
-      },
-      "dependencies": [
-        "rollup"
-      ]
-    },
-    "server:headless": {
-      "command": "tools/run-bidi-server.mjs --headless=true",
+    "server": {
+      "command": "tools/run-bidi-server.mjs",
       "files": [
         "tools/run-bidi-server.mjs"
       ],

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -45,7 +45,6 @@ type ChromeOptions = {
   chromeArgs: string[];
   chromeBinary?: string;
   channel: ChromeReleaseChannel;
-  headless: boolean;
 };
 
 /**
@@ -71,9 +70,6 @@ export class BrowserInstance {
     );
     // See https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
     const chromeArguments = [
-      ...(chromeOptions.headless
-        ? ['--headless', '--hide-scrollbars', '--mute-audio']
-        : []),
       // keep-sorted start
       '--allow-browser-signin=false',
       '--disable-component-update',
@@ -91,9 +87,7 @@ export class BrowserInstance {
       '--use-mock-keychain',
       `--user-data-dir=${profileDir}`,
       // keep-sorted end
-      ...chromeOptions.chromeArgs.filter(
-        (arg) => !arg.startsWith('--headless')
-      ),
+      ...chromeOptions.chromeArgs,
       'about:blank',
     ];
 
@@ -109,11 +103,15 @@ export class BrowserInstance {
       throw new Error('Could not find Chrome binary');
     }
 
-    const browserProcess = launch({
+    const launchArguments = {
       executablePath,
       args: chromeArguments,
       env: process.env,
-    });
+    };
+
+    debugInternal(`Launching browser`, launchArguments);
+
+    const browserProcess = launch(launchArguments);
 
     const cdpEndpoint = await browserProcess.waitForLineOutput(
       CDP_WEBSOCKET_ENDPOINT_REGEX

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -22,7 +22,6 @@ import {debugInfo, WebSocketServer} from './WebSocketServer.js';
 
 function parseArguments(): {
   channel: ChromeReleaseChannel;
-  headless: string;
   port: number;
   verbose: boolean;
 } {
@@ -37,11 +36,6 @@ function parseArguments(): {
       'instead of one pointed by Puppeteer version',
     choices: Object.values(ChromeReleaseChannel),
     default: ChromeReleaseChannel.DEV,
-  });
-
-  parser.add_argument('--headless', {
-    help: 'Sets if browser should run in headless or headful mode. Default is true.',
-    default: true,
   });
 
   parser.add_argument('-p', '--port', {
@@ -63,12 +57,11 @@ function parseArguments(): {
   try {
     const args = parseArguments();
     const {channel, port} = args;
-    const headless = args.headless !== 'false';
     const verbose = args.verbose === true;
 
     debugInfo('Launching BiDi server...');
 
-    new WebSocketServer(port, channel, headless, verbose);
+    new WebSocketServer(port, channel, verbose);
     debugInfo('BiDi server launched');
   } catch (e) {
     debugInfo('Error launching BiDi server', e);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,20 @@ async def _websocket_connection():
 @pytest_asyncio.fixture(params=[{"capabilities": {}}])
 async def websocket(request, _websocket_connection):
     """Return a websocket with an active BiDi session."""
-    capabilities = request.param['capabilities']
+    capabilities = {"webSocketUrl": True, "goog:chromeOptions": {}}
+    maybe_browser_bin = os.getenv("BROWSER_BIN")
+    if maybe_browser_bin:
+        capabilities["goog:chromeOptions"]["binary"] = maybe_browser_bin
+    maybe_headless = os.getenv("HEADLESS")
+
+    # If the HEADLESS environment variable IS NOT set to "false", then add
+    # capabilities to run chrome in headless mode.
+    if maybe_headless != "false":
+        capabilities["goog:chromeOptions"]["args"] = [
+            "--headless=new", '--hide-scrollbars', '--mute-audio'
+        ]
+    capabilities.update(request.param['capabilities'])
+
     await execute_command(
         _websocket_connection, {
             "method": "session.new",

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -156,10 +156,17 @@ if (RUN_TESTS === 'true') {
   }
 
   if (HEADLESS === 'true') {
-    // Pass `--headless=new` to the browser to force it to start in headless mode.
-    wptRunArgs.push('--binary-arg=--headless=new');
-    wptRunArgs.push('--binary-arg=--hide-scrollbars');
-    wptRunArgs.push('--binary-arg=--mute-audio');
+    if (CHROMEDRIVER === 'true') {
+      // For chroemdriver use new headless.
+      wptRunArgs.push('--binary-arg=--headless=new');
+    } else {
+      // TODO: switch to new headless.
+      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/949.
+      // For nodejs mapper runner supports only old headless.
+      wptRunArgs.push('--binary-arg=--headless');
+      wptRunArgs.push('--binary-arg=--hide-scrollbars');
+      wptRunArgs.push('--binary-arg=--mute-audio');
+    }
   } else {
     // Pass `--no-headless` to the WPT runner to enable headful mode.
     wptRunArgs.push('--no-headless');

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -160,9 +160,6 @@ if (RUN_TESTS === 'true') {
     wptRunArgs.push('--binary-arg=--headless=new');
     wptRunArgs.push('--binary-arg=--hide-scrollbars');
     wptRunArgs.push('--binary-arg=--mute-audio');
-
-    // Pass `--headless` to the WPT runner to enable headless mode.
-    wptRunArgs.push('--headless');
   } else {
     // Pass `--no-headless` to the WPT runner to enable headful mode.
     wptRunArgs.push('--no-headless');

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -36,7 +36,7 @@ function usage() {
     `Usage:
       [BROWSER_BIN=<path, default: download pinned chrome>]
       [CHROMEDRIVER=<true | default: false>]
-      [HEADLESS=<true | default: false>]
+      [HEADLESS=<default: true | false>]
       [MANIFEST=<default: 'MANIFEST.json'>]
       [RUN_TESTS=<default: true | false>]
       [TIMEOUT_MULTIPLIER=<number, default: 1>]
@@ -155,20 +155,30 @@ if (RUN_TESTS === 'true') {
     );
   }
 
+  if (HEADLESS === 'true') {
+    // Pass `--headless=new` to the browser to force it to start in headless mode.
+    wptRunArgs.push('--binary-arg=--headless=new');
+    wptRunArgs.push('--binary-arg=--hide-scrollbars');
+    wptRunArgs.push('--binary-arg=--mute-audio');
+
+    // Pass `--headless` to the WPT runner to enable headless mode.
+    wptRunArgs.push('--headless');
+  } else {
+    // Pass `--no-headless` to the WPT runner to enable headful mode.
+    wptRunArgs.push('--no-headless');
+  }
+
   if (CHROMEDRIVER === 'true') {
     if (!existsSync(join('logs'))) {
       mkdirSync(join('logs'));
     }
 
-    let chromeDriverLogs = join('logs', 'chromedriver.log');
+    const chromeDriverLogs = join(
+      'logs',
+      HEADLESS === 'true' ? 'chromedriver-headless.log' : 'chromedriver.log'
+    );
 
     log('Using chromedriver with mapper...');
-    if (HEADLESS === 'true') {
-      chromeDriverLogs = join('logs', 'chromedriver-headless.log');
-      wptRunArgs.push('--binary-arg=--headless=new');
-    } else {
-      wptRunArgs.push('--no-headless');
-    }
     wptRunArgs.push(
       '--install-webdriver',
       `--webdriver-arg=--bidi-mapper-path=${join(
@@ -181,12 +191,8 @@ if (RUN_TESTS === 'true') {
       '--yes'
     );
   } else {
-    wptRunArgs.push(
-      `--webdriver-arg=--headless=${HEADLESS}`, // only used by bidi-server.mjs.
-      '--webdriver-binary',
-      join('tools', 'run-bidi-server.mjs')
-    );
     log('Using pure mapper...');
+    wptRunArgs.push('--webdriver-binary', join('tools', 'run-bidi-server.mjs'));
   }
 
   const restArgs = process.argv.slice(2);


### PR DESCRIPTION
This is a step towards e2e via chromedriver testing.

Head{less|ful} mode is now controlled via browser bin arguments passed in session capabilities.