### PR TITLE
test: add dedicated e2e runner for new and old headless modes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         # TODO(#876): Add Windows CI.
         os: [ubuntu-latest, macos-latest]
-        head: [headful, headless]
+        head: [headful, 'new-headless', 'old-headless']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -85,7 +85,7 @@ jobs:
           BROWSER_BIN: ${{ steps.browser.outputs.executablePath }}
           VERBOSE: ${{ github.event.inputs.verbose }}
       - name: Run E2E tests
-        if: matrix.os != 'ubuntu-latest' || (matrix.os == 'ubuntu-latest' && matrix.head == 'headless')
+        if: matrix.os != 'ubuntu-latest' || matrix.head != 'headful'
         timeout-minutes: 20
         run: npm run e2e:${{ matrix.head }}
         # For verbose logging, set `DEBUG: 'bidi:mapper:*'` and `VERBOSE: true`.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,11 @@ jobs:
         # TODO(#876): Add Windows CI.
         os: [ubuntu-latest, macos-latest]
         head: [headful, 'new-headless', 'old-headless']
+        exclude:
+          - os: macos-latest
+            head: new-headless
+          - os: macos-latest
+            head: old-headless
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -203,12 +203,6 @@ Use the `DEBUG_DEPTH` (default: `10`) environment variable to see debug deeply n
 DEBUG_DEPTH=100 DEBUG=* npm run server
 ```
 
-Use the CLI argument `--headless=false` to run browser in headful mode:
-
-```sh
-npm run server -- --headless=false
-```
-
 Use the `CHANNEL=...` environment variable or `--channel=...` argument with one of
 the following values to run the specific Chrome channel: `stable`,
 `beta`, `canary`, `dev`.
@@ -297,6 +291,13 @@ Use the `PORT` environment variable to connect to another port:
 
 ```sh
 PORT=8081 npm run e2e
+```
+
+Use the `HEADLESS` to run the tests in headless (new or old) or headful modes.
+Values: `new`, `old`, `false`, default: `new`.
+
+```sh
+HEADLESS=new npm run e2e
 ```
 
 #### Updating snapshots

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "build": "wireit",
     "clean": "node tools/clean.mjs",
-    "e2e:headful": "wireit",
-    "e2e:headless": "wireit",
-    "e2e": "npm run e2e:headless --",
+    "e2e:headful": "HEADLESS=false npm run e2e --",
+    "e2e:headless": "npm run e2e:new-headless --",
+    "e2e:new-headless": "HEADLESS=new npm run e2e --",
+    "e2e:old-headless": "HEADLESS=old npm run e2e --",
+    "e2e": "wireit",
     "flake8": "flake8 examples/ tests/",
     "format": "npm run pre-commit --",
     "format:eslint": "eslint --ext js --ext mjs --ext ts --fix .",
@@ -35,21 +37,7 @@
         "tsc"
       ]
     },
-    "e2e:headful": {
-      "command": "tools/run-e2e.mjs --headless=false",
-      "files": [
-        "tools/run-e2e.mjs ",
-        "pytest.ini",
-        "tests/**/*.py"
-      ],
-      "dependencies": [
-        "build"
-      ],
-      "env": {
-        "HEADLESS": "false"
-      }
-    },
-    "e2e:headless": {
+    "e2e": {
       "command": "tools/run-e2e.mjs",
       "files": [
         "tools/run-e2e.mjs ",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,9 +74,14 @@ async def websocket(request, _websocket_connection):
     # If the HEADLESS environment variable IS NOT set to "false", then add
     # capabilities to run chrome in headless mode.
     if maybe_headless != "false":
-        capabilities["goog:chromeOptions"]["args"] = [
-            "--headless=new", '--hide-scrollbars', '--mute-audio'
-        ]
+        if maybe_headless == "old":
+            capabilities["goog:chromeOptions"]["args"] = [
+                "--headless=old", '--hide-scrollbars', '--mute-audio'
+            ]
+        else:
+            # Default to new headless mode.
+            capabilities["goog:chromeOptions"]["args"] = ["--headless=new"]
+
     capabilities.update(request.param['capabilities'])
 
     await execute_command(

--- a/tools/bidi-server.mjs
+++ b/tools/bidi-server.mjs
@@ -51,7 +51,7 @@ export function parseCommandLineArgs() {
   return yargs(hideBin(process.argv))
     .usage(
       `$0 [fileOrFolder]`,
-      `[CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [DEBUG_COLORS=<yes | no>] [HEADLESS=<true | false>] [LOG_DIR=logs] [NODE_OPTIONS=--unhandled-rejections=strict] [PORT=8080]`,
+      `[CHANNEL=<stable | beta | canary | dev>] [DEBUG=*] [DEBUG_COLORS=<yes | no>] [LOG_DIR=logs] [NODE_OPTIONS=--unhandled-rejections=strict] [PORT=8080]`,
       (yargs) => {
         yargs.positional('fileOrFolder', {
           describe: 'Provide a sub E2E file or folder to filter by',
@@ -59,12 +59,6 @@ export function parseCommandLineArgs() {
         });
       }
     )
-    .option('headless', {
-      describe:
-        'Whether to start the server in headless or headful mode. The --headless flag takes precedence over the HEADLESS environment variable.',
-      type: 'boolean',
-      default: (process.env.HEADLESS ?? 'true') === 'true',
-    })
     .option('k', {
       describe: 'Provide a test name to filter by',
       type: 'string',
@@ -74,10 +68,9 @@ export function parseCommandLineArgs() {
 
 /**
  *
- * @param {Boolean} headless
  * @returns {child_process.ChildProcessWithoutNullStreams}
  */
-export function createBiDiServerProcess(headless) {
+export function createBiDiServerProcess() {
   let BROWSER_BIN = process.env.BROWSER_BIN;
   let CHANNEL = process.env.CHANNEL || 'local';
 
@@ -111,8 +104,6 @@ export function createBiDiServerProcess(headless) {
       resolve(join('lib', 'cjs', 'bidiServer', 'index.js')),
       `--channel`,
       CHANNEL,
-      `--headless`,
-      headless,
       ...process.argv.slice(2),
     ],
     {

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -143,7 +143,7 @@ e2eArgs.push('--verbose', '-vv');
 if (argv.fileOrFolder) {
   e2eArgs.push(argv.fileOrFolder);
 }
-if (!argv.headless && !argv.k) {
+if (process.env.HEADLESS === 'false' && !argv.k) {
   e2eArgs.push('--ignore=tests/input');
 }
 if (argv.k) {

--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -157,13 +157,13 @@ if (RUN_TESTS === 'true') {
 
   if (HEADLESS === 'true') {
     if (CHROMEDRIVER === 'true') {
-      // For chroemdriver use new headless.
+      // For chromedriver use new headless.
       wptRunArgs.push('--binary-arg=--headless=new');
     } else {
       // TODO: switch to new headless.
       // https://github.com/GoogleChromeLabs/chromium-bidi/issues/949.
       // For nodejs mapper runner supports only old headless.
-      wptRunArgs.push('--binary-arg=--headless');
+      wptRunArgs.push('--binary-arg=--headless=old');
       wptRunArgs.push('--binary-arg=--hide-scrollbars');
       wptRunArgs.push('--binary-arg=--mute-audio');
     }


### PR DESCRIPTION
Add ability to e2e tests run both with an **old** and a **new** headless. Do that on Ubuntu, and run only headful on macos. The CI combinations are:
* ubuntu, headful **4m 37s**
* ubuntu, new headless **3m 0s**
* ubuntu, old-headless **1m 56s**
* macos, headful **8m 49s**

Closes #1862