### PR TITLE
chore: provide browser bin via capabilities or env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,15 +203,14 @@ Use the `DEBUG_DEPTH` (default: `10`) environment variable to see debug deeply n
 DEBUG_DEPTH=100 DEBUG=* npm run server
 ```
 
-Use the `CHANNEL=...` environment variable or `--channel=...` argument with one of
-the following values to run the specific Chrome channel: `stable`,
-`beta`, `canary`, `dev`.
-
-The requested Chrome version should be installed.
+Use the `CHANNEL=...` environment variable with one of the following values to run
+the specific Chrome channel: `stable`, `beta`, `canary`, `dev`, `local`. Default is
+`local`. The `local` channel means the pinned in `.browser` Chrome version will be
+downloaded if it is not yet in cache. Otherwise, the requested Chrome version should
+be installed.
 
 ```sh
 CHANNEL=dev npm run server
-npm run server -- --channel=dev
 ```
 
 Use the CLI argument `--verbose` to have CDP events printed to the console. Note: you have to enable debugging output `bidi:mapper:debug:*` as well.

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -21,10 +21,7 @@ import os from 'os';
 import path from 'path';
 
 import {
-  Browser,
   CDP_WEBSOCKET_ENDPOINT_REGEX,
-  type ChromeReleaseChannel,
-  computeSystemExecutablePath,
   launch,
   type Process,
 } from '@puppeteer/browsers';
@@ -41,10 +38,9 @@ import type {SimpleTransport} from './SimpleTransport.js';
 
 const debugInternal = debug('bidi:mapper:internal');
 
-type ChromeOptions = {
+export type ChromeOptions = {
   chromeArgs: string[];
   chromeBinary?: string;
-  channel: ChromeReleaseChannel;
 };
 
 /**
@@ -92,12 +88,7 @@ export class BrowserInstance {
     ];
 
     const executablePath =
-      chromeOptions.chromeBinary ??
-      process.env['BROWSER_BIN'] ??
-      computeSystemExecutablePath({
-        browser: Browser.CHROME,
-        channel: chromeOptions.channel,
-      });
+      chromeOptions.chromeBinary ?? process.env['BROWSER_BIN'];
 
     if (!executablePath) {
       throw new Error('Could not find Chrome binary');

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -15,27 +15,17 @@
  * limitations under the License.
  */
 
-import {ChromeReleaseChannel} from '@puppeteer/browsers';
 import {ArgumentParser} from 'argparse';
 
 import {debugInfo, WebSocketServer} from './WebSocketServer.js';
 
 function parseArguments(): {
-  channel: ChromeReleaseChannel;
   port: number;
   verbose: boolean;
 } {
   const parser = new ArgumentParser({
     add_help: true,
     exit_on_error: true,
-  });
-
-  parser.add_argument('-c', '--channel', {
-    help:
-      'If set, the given installed Chrome Release Channel will be used ' +
-      'instead of one pointed by Puppeteer version',
-    choices: Object.values(ChromeReleaseChannel),
-    default: ChromeReleaseChannel.DEV,
   });
 
   parser.add_argument('-p', '--port', {
@@ -56,12 +46,12 @@ function parseArguments(): {
 (() => {
   try {
     const args = parseArguments();
-    const {channel, port} = args;
+    const {port} = args;
     const verbose = args.verbose === true;
 
     debugInfo('Launching BiDi server...');
 
-    new WebSocketServer(port, channel, verbose);
+    new WebSocketServer(port, verbose);
     debugInfo('BiDi server launched');
   } catch (e) {
     debugInfo('Error launching BiDi server', e);

--- a/tools/path-getter/path-getter.mjs
+++ b/tools/path-getter/path-getter.mjs
@@ -18,40 +18,54 @@
 import {execSync} from 'child_process';
 import {join} from 'path';
 
+import {Browser, computeSystemExecutablePath} from '@puppeteer/browsers';
+
 /**
  * Either return a value of `BROWSER_BIN` environment variable or gets the path
- * to the browser version defined in `.browser` file, downloading the required
- * version if needed.
+ * to the browser specified in `CHANNEL` environment variable if specified. If
+ * no channel or browser bin is provided in environment variable,
+ * returns defined in `.browser` file, downloading the required version if
+ * needed.
  * @return {string}
  */
 export function installAndGetChromePath() {
-  let BROWSER_BIN = process.env.BROWSER_BIN;
-  if (!BROWSER_BIN) {
-    BROWSER_BIN = execSync(
-      ['node', join('tools', 'install-browser.mjs')].join(' ')
-    )
+  if (process.env.BROWSER_BIN) return process.env.BROWSER_BIN;
+
+  const channel = getChannel();
+
+  if (channel === 'local') {
+    return execSync(['node', join('tools', 'install-browser.mjs')].join(' '))
       .toString()
       .trim();
   }
-  return BROWSER_BIN;
+
+  return computeSystemExecutablePath({
+    browser: Browser.CHROME,
+    channel,
+  });
 }
 
 /**
  * Either return a value of `CHROMEDRIVER_BIN` environment variable or gets the
  * path to the ChromeDriver for the browser version defined in `.browser` file,
- * downloading the required version if needed.
+ * downloading the required version if needed. Throws an error if the channel is
+ * not `local` and the `CHROMEDRIVER_BIN` environment variable is not set.
  * @return {string}
  */
 export function installAndGetChromeDriverPath() {
-  let CHROMEDRIVER_BIN = process.env.CHROMEDRIVER_BIN;
-  if (!CHROMEDRIVER_BIN) {
-    CHROMEDRIVER_BIN = execSync(
-      ['node', join('tools', 'install-browser.mjs'), '--chromedriver'].join(' ')
-    )
-      .toString()
-      .trim();
+  if (process.env.CHROMEDRIVER_BIN) return process.env.CHROMEDRIVER_BIN;
+
+  if (getChannel() !== 'local') {
+    throw new Error(
+      'Auto download of chromedriver is supported only for `local` channel. Either use `CHANNEL=local` or set `CHROMEDRIVER_BIN` environment variable to the path of the chromedriver binary matching required Chrome channel.'
+    );
   }
-  return CHROMEDRIVER_BIN;
+
+  return execSync(
+    ['node', join('tools', 'install-browser.mjs'), '--chromedriver'].join(' ')
+  )
+    .toString()
+    .trim();
 }
 
 /**
@@ -60,4 +74,8 @@ export function installAndGetChromeDriverPath() {
  */
 export function getBidiMapperPath() {
   return join('lib', 'iife', 'mapperTab.js');
+}
+
+function getChannel() {
+  return process.env.CHANNEL || 'local';
 }

--- a/tools/path-getter/path-getter.mjs
+++ b/tools/path-getter/path-getter.mjs
@@ -29,7 +29,9 @@ import {Browser, computeSystemExecutablePath} from '@puppeteer/browsers';
  * @return {string}
  */
 export function installAndGetChromePath() {
-  if (process.env.BROWSER_BIN) return process.env.BROWSER_BIN;
+  if (process.env.BROWSER_BIN) {
+    return process.env.BROWSER_BIN;
+  }
 
   const channel = getChannel();
 
@@ -53,7 +55,9 @@ export function installAndGetChromePath() {
  * @return {string}
  */
 export function installAndGetChromeDriverPath() {
-  if (process.env.CHROMEDRIVER_BIN) return process.env.CHROMEDRIVER_BIN;
+  if (process.env.CHROMEDRIVER_BIN) {
+    return process.env.CHROMEDRIVER_BIN;
+  }
 
   if (getChannel() !== 'local') {
     throw new Error(

--- a/tools/run-bidi-server.mjs
+++ b/tools/run-bidi-server.mjs
@@ -19,16 +19,11 @@
 
 import {createWriteStream} from 'fs';
 
-import {
-  createBiDiServerProcess,
-  parseCommandLineArgs,
-  createLogFile,
-} from './bidi-server.mjs';
+import {createBiDiServerProcess, createLogFile} from './bidi-server.mjs';
 
-const argv = parseCommandLineArgs();
 const LOG_FILE = createLogFile('server');
 const fileWriteStream = createWriteStream(LOG_FILE);
-const subprocess = createBiDiServerProcess(argv.headless);
+const subprocess = createBiDiServerProcess();
 
 if (subprocess.stderr) {
   subprocess.stderr.pipe(process.stdout);

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -119,7 +119,7 @@ const syncFileStreams =
   process.env.VERBOSE === 'true' ? new PassThrough() : new SyncFileStreams();
 syncFileStreams.pipe(fileWriteStream);
 
-const serverProcess = createBiDiServerProcess(argv);
+const serverProcess = createBiDiServerProcess();
 
 if (serverProcess.stderr) {
   serverProcess.stdout.pipe(process.stdout);


### PR DESCRIPTION
Required for running e2e via chromedriver, as chromedriver uses browser binary form capabilities.