### PR TITLE
test: support e2e running via `chromedriver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ If you need to see the logs for all test run the command with `VERBOSE=true`.
 Simply pass `npm run e2e -- tests/<PathOrFile>` and the e2e will run only the selected one.
 You run a specific test by running `npm run e2e -- -k <TestName>`.
 
+Use `CHROMEDRIVER` environment to run tests in `chromedriver` instead of NodeJS runner:
+
+```shell
+CHROMEDRIVER=true npm run e2e
+```
+
 Use the `PORT` environment variable to connect to another port:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       ],
       "service": {
         "readyWhen": {
-          "lineMatches": "BiDi server is listening on port \\d+"
+          "lineMatches": "(BiDi server|ChromeDriver) was started successfully\\."
         }
       },
       "dependencies": [

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -68,10 +68,15 @@ export class WebSocketServer {
     void this.#listen();
   }
 
+  #logServerStarted() {
+    debugInfo('BiDi server is listening on port', this.#port);
+    debugInfo('BiDi server was started successfully.');
+  }
+
   async #listen() {
     try {
       this.#server.listen(this.#port, () => {
-        debugInfo('BiDi server is listening on port', this.#port);
+        this.#logServerStarted();
       });
     } catch (error) {
       if (
@@ -85,7 +90,7 @@ export class WebSocketServer {
         });
         debugInfo('Retrying to run BiDi server');
         this.#server.listen(this.#port, () => {
-          debugInfo('BiDi server is listening on port', this.#port);
+          this.#logServerStarted();
         });
       }
       throw error;

--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -28,6 +28,7 @@ import {
   parseCommandLineArgs,
   createLogFile,
 } from './bidi-server.mjs';
+import {installAndGetChromePath} from './path-getter/path-getter.mjs';
 // Changing the current work directory to the package directory.
 process.chdir(packageDirectorySync());
 
@@ -49,7 +50,9 @@ async function matchLine(process) {
   let stdout = '';
   function check() {
     for (const line of stdout.split(/\n/g)) {
-      if (/.*BiDi server is listening on port \d+/.test(line)) {
+      if (
+        /.*(BiDi server|ChromeDriver) was started successfully\./.test(line)
+      ) {
         process.off('exit', onExit);
         process.stdout.off('data', onStdout);
         process.stderr.off('data', onStdout);
@@ -152,6 +155,10 @@ if (argv.k) {
 
 const e2eProcess = child_process.spawn('pipenv', e2eArgs, {
   stdio: ['inherit', 'pipe', 'pipe'],
+  env: {
+    BROWSER_BIN: installAndGetChromePath(),
+    ...process.env,
+  },
 });
 
 if (e2eProcess.stderr) {


### PR DESCRIPTION
Out of scope: running e2e chromedriver in CI, as some tests are failing