### PR TITLE
docs: break long words

### DIFF
--- a/tools/wpt-report-builder/template.html
+++ b/tools/wpt-report-builder/template.html
@@ -20,6 +20,7 @@
       line-height: 180%;
       padding: 5px 18px;
       margin: 0;
+      word-break: break-all;
     }
     .top {
       box-shadow:


### PR DESCRIPTION
Before: 
![image](https://github.com/GoogleChromeLabs/chromium-bidi/assets/34244704/43e24b44-7357-4614-82a3-2f88cd94538c)
After:
![image](https://github.com/GoogleChromeLabs/chromium-bidi/assets/34244704/61fc4022-a3b4-41fe-880c-068fafaf8a25)
