### PR TITLE
test: enable skipped tests

### DIFF
--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,2 +1,0 @@
-[invalid.py]
-  disabled: Issue-1903

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,2 +1,0 @@
-[invalid.py]
-  disabled: Issue-1903

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,2 +1,0 @@
-[invalid.py]
-  disabled: Issue-1903

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  disabled: Disable as we spawn a browser for each test


### PR DESCRIPTION
Will skip the test for `mapper` as they spawn a browser and that makes it slow