### PR TITLE
chore: remove support of legacy shared id format

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -40,9 +40,6 @@ type BidiServerEvent = {
 
 export type MapperOptions = {
   acceptInsecureCerts: boolean;
-  // TODO: Remove this after ChromeDriver version sending flag `true` reaches stable.
-  //   http://go/chromedriver:weak-map
-  sharedIdWithFrame?: boolean;
 };
 
 export class BidiServer extends EventEmitter<BidiServerEvent> {
@@ -97,7 +94,6 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
       this.#browsingContextStorage,
       new RealmStorage(),
       options?.acceptInsecureCerts ?? false,
-      options?.sharedIdWithFrame ?? false,
       parser,
       this.#logger
     );

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -83,7 +83,6 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,
     acceptInsecureCerts: boolean,
-    sharedIdWithFrame: boolean,
     parser: BidiCommandParameterParser = new BidiNoOpParser(),
     logger?: LoggerFn
   ) {
@@ -110,7 +109,6 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       networkStorage,
       preloadScriptStorage,
       acceptInsecureCerts,
-      sharedIdWithFrame,
       defaultUserContextId,
       logger
     );

--- a/src/bidiMapper/domains/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextImpl.ts
@@ -75,7 +75,6 @@ export class BrowsingContextImpl {
   #loaderId?: Protocol.Network.LoaderId;
   #cdpTarget: CdpTarget;
   #maybeDefaultRealm?: Realm;
-  readonly #sharedIdWithFrame: boolean;
   readonly #logger?: LoggerFn;
 
   private constructor(
@@ -86,7 +85,6 @@ export class BrowsingContextImpl {
     userContext: string,
     eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
-    sharedIdWithFrame: boolean,
     logger?: LoggerFn
   ) {
     this.#cdpTarget = cdpTarget;
@@ -96,7 +94,6 @@ export class BrowsingContextImpl {
     this.userContext = userContext;
     this.#eventManager = eventManager;
     this.#browsingContextStorage = browsingContextStorage;
-    this.#sharedIdWithFrame = sharedIdWithFrame;
     this.#logger = logger;
   }
 
@@ -108,7 +105,6 @@ export class BrowsingContextImpl {
     userContext: string,
     eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
-    sharedIdWithFrame: boolean,
     logger?: LoggerFn
   ): BrowsingContextImpl {
     const context = new BrowsingContextImpl(
@@ -119,7 +115,6 @@ export class BrowsingContextImpl {
       userContext,
       eventManager,
       browsingContextStorage,
-      sharedIdWithFrame,
       logger
     );
 
@@ -486,8 +481,7 @@ export class BrowsingContextImpl {
           origin,
           uniqueId,
           this.#realmStorage,
-          sandbox,
-          this.#sharedIdWithFrame
+          sandbox
         );
 
         if (auxData.isDefault) {

--- a/src/bidiMapper/domains/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/domains/context/BrowsingContextProcessor.ts
@@ -53,7 +53,6 @@ export class BrowsingContextProcessor {
   readonly #browsingContextStorage: BrowsingContextStorage;
   readonly #networkStorage: NetworkStorage;
   readonly #acceptInsecureCerts: boolean;
-  readonly #sharedIdWithFrame: boolean;
   readonly #preloadScriptStorage: PreloadScriptStorage;
   readonly #realmStorage: RealmStorage;
 
@@ -70,7 +69,6 @@ export class BrowsingContextProcessor {
     networkStorage: NetworkStorage,
     preloadScriptStorage: PreloadScriptStorage,
     acceptInsecureCerts: boolean,
-    sharedIdWithFrame: boolean,
     defaultUserContextId: Browser.UserContext,
     logger?: LoggerFn
   ) {
@@ -83,7 +81,6 @@ export class BrowsingContextProcessor {
     this.#preloadScriptStorage = preloadScriptStorage;
     this.#networkStorage = networkStorage;
     this.#realmStorage = realmStorage;
-    this.#sharedIdWithFrame = sharedIdWithFrame;
     this.#defaultUserContextId = defaultUserContextId;
     this.#logger = logger;
 
@@ -373,7 +370,6 @@ export class BrowsingContextProcessor {
         parentBrowsingContext.userContext,
         this.#eventManager,
         this.#browsingContextStorage,
-        this.#sharedIdWithFrame,
         this.#logger
       );
     }
@@ -427,7 +423,6 @@ export class BrowsingContextProcessor {
               : 'default',
             this.#eventManager,
             this.#browsingContextStorage,
-            this.#sharedIdWithFrame,
             this.#logger
           );
         }

--- a/src/bidiMapper/domains/script/SharedId.spec.ts
+++ b/src/bidiMapper/domains/script/SharedId.spec.ts
@@ -25,23 +25,11 @@ describe('SharedId', () => {
     documentId: 'document_id',
     backendNodeId: 42,
   };
-  const PARSED_LEGACY_SHARED_ID = {
-    frameId: undefined,
-    documentId: 'document_id',
-    backendNodeId: 42,
-  };
   const SHARED_ID = 'f.frame_id.d.document_id.e.42';
-  const LEGACY_SHARED_ID = 'document_id_element_42';
 
   describe('parseSharedId', () => {
     it('should parse proper formatted string', () => {
       expect(parseSharedId(SHARED_ID)).to.deep.equal(PARSED_SHARED_ID);
-    });
-
-    it('should parse legacy sharedId', () => {
-      expect(parseSharedId(LEGACY_SHARED_ID)).to.deep.equal(
-        PARSED_LEGACY_SHARED_ID
-      );
     });
 
     it('should not parse incorrectly formatted string', () => {
@@ -50,28 +38,14 @@ describe('SharedId', () => {
   });
 
   describe('getSharedId', () => {
-    it('should generate new format', () => {
+    it('should generate', () => {
       expect(
         getSharedId(
           PARSED_SHARED_ID.frameId,
           PARSED_SHARED_ID.documentId,
-          PARSED_SHARED_ID.backendNodeId,
-          true
+          PARSED_SHARED_ID.backendNodeId
         )
       ).to.equal(SHARED_ID);
-    });
-  });
-
-  describe('getLegacySharedId(', () => {
-    it('should generate legacy format', () => {
-      expect(
-        getSharedId(
-          PARSED_SHARED_ID.frameId,
-          PARSED_SHARED_ID.documentId,
-          PARSED_SHARED_ID.backendNodeId,
-          false
-        )
-      ).to.equal(LEGACY_SHARED_ID);
     });
   });
 });

--- a/src/bidiMapper/domains/script/SharedId.ts
+++ b/src/bidiMapper/domains/script/SharedId.ts
@@ -20,15 +20,9 @@ const SHARED_ID_DIVIDER = '_element_';
 export function getSharedId(
   frameId: string,
   documentId: string,
-  backendNodeId: number,
-  sharedIdWithFrame: boolean
+  backendNodeId: number
 ): string {
-  if (sharedIdWithFrame) {
-    return `f.${frameId}.d.${documentId}.e.${backendNodeId}`;
-  }
-  // TODO: remove once ChromeDriver accepts sharedId in the new format:
-  //  http://go/chromedriver:weak-map
-  return `${documentId}${SHARED_ID_DIVIDER}${backendNodeId}`;
+  return `f.${frameId}.d.${documentId}.e.${backendNodeId}`;
 }
 
 function parseLegacySharedId(sharedId: string): {

--- a/src/bidiMapper/domains/script/WindowRealm.ts
+++ b/src/bidiMapper/domains/script/WindowRealm.ts
@@ -37,7 +37,6 @@ import {getSharedId, parseSharedId} from './SharedId.js';
 export class WindowRealm extends Realm {
   readonly #browsingContextId: BrowsingContext.BrowsingContext;
   readonly #browsingContextStorage: BrowsingContextStorage;
-  readonly #sharedIdWithFrame: boolean;
   readonly sandbox: string | undefined;
 
   constructor(
@@ -50,8 +49,7 @@ export class WindowRealm extends Realm {
     origin: string,
     realmId: Script.Realm,
     realmStorage: RealmStorage,
-    sandbox: string | undefined,
-    sharedIdWithFrame: boolean
+    sandbox: string | undefined
   ) {
     super(
       cdpClient,
@@ -65,7 +63,6 @@ export class WindowRealm extends Realm {
 
     this.#browsingContextId = browsingContextId;
     this.#browsingContextStorage = browsingContextStorage;
-    this.#sharedIdWithFrame = sharedIdWithFrame;
     this.sandbox = sandbox;
 
     this.initialize();
@@ -125,8 +122,7 @@ export class WindowRealm extends Realm {
           getSharedId(
             this.#getBrowsingContextId(navigableId),
             navigableId,
-            bidiValue.backendNodeId,
-            this.#sharedIdWithFrame
+            bidiValue.backendNodeId
           );
         delete bidiValue['backendNodeId'];
       }

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -449,9 +449,7 @@ export class WebSocketServer {
   #getMapperOptions(capabilities: any): MapperOptions {
     const acceptInsecureCerts =
       capabilities?.alwaysMatch?.acceptInsecureCerts ?? false;
-    const sharedIdWithFrame =
-      capabilities?.alwaysMatch?.sharedIdWithFrame ?? false;
-    return {acceptInsecureCerts, sharedIdWithFrame};
+    return {acceptInsecureCerts};
   }
 
   #getChromeOptions(capabilities: any): ChromeOptions {

--- a/tests/script/test_shared_id.py
+++ b/tests/script/test_shared_id.py
@@ -16,8 +16,7 @@
 import re
 
 import pytest
-from test_helpers import (ANY_LEGACY_SHARED_ID, ANY_NEW_SHARED_ID,
-                          execute_command, get_tree, goto_url,
+from test_helpers import (ANY_SHARED_ID, execute_command, get_tree, goto_url,
                           set_html_content)
 
 
@@ -239,7 +238,7 @@ async def test_shared_id_not_found(websocket, context_id, html):
 
 
 @pytest.mark.asyncio
-async def test_shared_id_default_format(websocket, context_id, html):
+async def test_shared_id_format(websocket, context_id, html):
     await goto_url(
         websocket, context_id,
         html(
@@ -261,79 +260,9 @@ async def test_shared_id_default_format(websocket, context_id, html):
             }
         })
     shared_id = result["result"]["sharedId"]
-    assert shared_id == ANY_LEGACY_SHARED_ID
+    assert shared_id == ANY_SHARED_ID
 
 
-@pytest.mark.parametrize('websocket', [{
-    'capabilities': {
-        'sharedIdWithFrame': True
-    }
-}],
-                         indirect=['websocket'])
-@pytest.mark.asyncio
-async def test_shared_id_new_format(websocket, context_id, html):
-    await goto_url(
-        websocket, context_id,
-        html(
-            "<div some_attr_name='some_attr_value'>some text<h2>some another text</h2></div>"
-        ))
-
-    result = await execute_command(
-        websocket, {
-            "method": "script.evaluate",
-            "params": {
-                "expression": "document.querySelector('body > div');",
-                "target": {
-                    "context": context_id
-                },
-                "awaitPromise": True,
-                "serializationOptions": {
-                    "maxDomDepth": 0
-                }
-            }
-        })
-    shared_id = result["result"]["sharedId"]
-    assert shared_id == ANY_NEW_SHARED_ID
-
-
-@pytest.mark.parametrize('websocket', [{
-    'capabilities': {
-        'sharedIdWithFrame': False
-    }
-}],
-                         indirect=['websocket'])
-@pytest.mark.asyncio
-async def test_shared_id_old_format(websocket, context_id, html):
-    await goto_url(
-        websocket, context_id,
-        html(
-            "<div some_attr_name='some_attr_value'>some text<h2>some another text</h2></div>"
-        ))
-
-    result = await execute_command(
-        websocket, {
-            "method": "script.evaluate",
-            "params": {
-                "expression": "document.querySelector('body > div');",
-                "target": {
-                    "context": context_id
-                },
-                "awaitPromise": True,
-                "serializationOptions": {
-                    "maxDomDepth": 0
-                }
-            }
-        })
-    shared_id = result["result"]["sharedId"]
-    assert shared_id == ANY_LEGACY_SHARED_ID
-
-
-@pytest.mark.parametrize('websocket', [{
-    'capabilities': {
-        'sharedIdWithFrame': True
-    }
-}],
-                         indirect=['websocket'])
 @pytest.mark.asyncio
 async def test_shared_id_uses_node_frame(websocket, context_id, html):
     # `iframe_id` does not work in this context, as it is cross-origin.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,8 +23,8 @@ import logging
 from collections.abc import Callable
 from typing import Literal
 
-from anys import (ANY_NUMBER, ANY_STR, AnyContains, AnyFullmatch, AnyGT, AnyLT,
-                  AnyMatch, AnyWithEntries)
+from anys import (ANY_NUMBER, ANY_STR, AnyFullmatch, AnyGT, AnyLT, AnyMatch,
+                  AnyWithEntries)
 from PIL import Image, ImageChops
 
 logging.basicConfig(level=logging.INFO)
@@ -193,9 +193,7 @@ async def wait_for_filtered_event(
     return await wait_for_message(websocket, filter_lambda_wrapper)
 
 
-ANY_NEW_SHARED_ID = ANY_STR & AnyMatch("f\\..*\\.d\\..*\\.e\\..*")
-ANY_LEGACY_SHARED_ID = ANY_STR & AnyContains("_element_")
-ANY_SHARED_ID = ANY_NEW_SHARED_ID | ANY_LEGACY_SHARED_ID
+ANY_SHARED_ID = ANY_STR & AnyMatch("f\\..*\\.d\\..*\\.e\\..*")
 
 # Check if the timestamp has the proper order of magnitude between
 #  - "2020-01-01 00:00:00" (1577833200000) and


### PR DESCRIPTION
As long as https://crrev.com/c/5094519 was landed in 122 which is stable now, we can remove the legacy shared id format support.