### PR TITLE
feat: support userContext is setPermission

### DIFF
--- a/src/bidiMapper/domains/permissions/PermissionsProcessor.ts
+++ b/src/bidiMapper/domains/permissions/PermissionsProcessor.ts
@@ -33,9 +33,9 @@ export class PermissionsProcessor {
     params: Permissions.SetPermissionParameters
   ): Promise<EmptyResult> {
     try {
-      const userContextId = (params as {'goog:userContext'?: string})[
-        'goog:userContext'
-      ];
+      const userContextId =
+        (params as {'goog:userContext'?: string})['goog:userContext'] ||
+        params.userContext;
       await this.#browserCdpClient.sendCommand('Browser.setPermission', {
         origin: params.origin,
         browserContextId:

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/external/permissions/set_permission/set_permission.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/external/permissions/set_permission/set_permission.py.ini
@@ -1,3 +1,0 @@
-[set_permission.py]
-  [test_set_permission_user_context]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/external/permissions/set_permission/set_permission.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/external/permissions/set_permission/set_permission.py.ini
@@ -1,3 +1,0 @@
-[set_permission.py]
-  [test_set_permission_user_context]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/external/permissions/set_permission/set_permission.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/external/permissions/set_permission/set_permission.py.ini
@@ -1,3 +1,0 @@
-[set_permission.py]
-  [test_set_permission_user_context]
-    expected: FAIL


### PR DESCRIPTION
- keep the prefixed version to maintain compatibility with Puppeteer