### PR TITLE
test: apply timeouts to test functions only

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ testpaths = tests
 
 # https://pypi.org/project/pytest-timeout/
 # timeout in seconds
-timeout = 20
+timeout = 5
+timeout_func_only = true


### PR DESCRIPTION
>  timeout_func_only (bool):
>                        When set to True, defers the timeout evaluation to only the test function body, ignoring the time it takes when evaluating any fixtures used in the test.
                        
For fixture evaluation, we should rely on the inner timeouts for fixture setup and teardown and most of them are already configured properly via the timeout for the execute_command and wait_for_command.