### PR TITLE
fix: don't encode body 2 times

### DIFF
--- a/src/bidiMapper/domains/network/NetworkRequest.ts
+++ b/src/bidiMapper/domains/network/NetworkRequest.ts
@@ -441,7 +441,7 @@ export class NetworkRequest {
       responseCode,
       responsePhrase,
       responseHeaders,
-      ...(body ? {body: btoa(body)} : {}), // TODO: Double-check if btoa usage is correct.
+      body,
     });
     this.#interceptPhase = undefined;
   }


### PR DESCRIPTION
We already check the encoding in the `NetworkProcessor`, not sure if we should move the logic to the `NetworkRequest`.