### PR TITLE
fix: emit `network.responseCompleted` for redirects

### DIFF
--- a/src/bidiMapper/modules/network/NetworkModuleMocks.spec.ts
+++ b/src/bidiMapper/modules/network/NetworkModuleMocks.spec.ts
@@ -110,6 +110,83 @@ export class MockCdpNetworkEvents {
     });
   }
 
+  requestWillBeSentRedirect() {
+    this.cdpClient.emit('Network.requestWillBeSent', {
+      requestId: this.requestId,
+      loaderId: this.loaderId,
+      documentURL: this.url,
+      request: {
+        url: this.url,
+        method: 'GET',
+        headers: {
+          'Upgrade-Insecure-Requests': '1',
+          'User-Agent':
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/125.0.0.0 Safari/537.36',
+          'sec-ch-ua': '"Chromium";v="125", "Not.A/Brand";v="24"',
+          'sec-ch-ua-mobile': '?0',
+          'sec-ch-ua-platform': '"Linux"',
+        },
+        mixedContentType: 'none',
+        initialPriority: 'VeryHigh',
+        referrerPolicy: 'strict-origin-when-cross-origin',
+        isSameSite: true,
+      },
+      timestamp: 584528.247548,
+      wallTime: 1712063242.363687,
+      initiator: {type: 'other'},
+      redirectHasExtraInfo: true,
+      redirectResponse: {
+        url: this.url,
+        status: 302,
+        statusText: 'Found',
+        headers: {
+          Connection: 'keep-alive',
+          Date: 'Tue, 02 Apr 2024 13:07:22 GMT',
+          'Transfer-Encoding': 'chunked',
+          location: '/redirect',
+        },
+        mimeType: '',
+        charset: '',
+        connectionReused: true,
+        connectionId: 41,
+        remoteIPAddress: '[::1]',
+        remotePort: 36387,
+        fromDiskCache: false,
+        fromServiceWorker: false,
+        fromPrefetchCache: false,
+        encodedDataLength: 134,
+        timing: {
+          requestTime: 584528.242766,
+          proxyStart: -1,
+          proxyEnd: -1,
+          dnsStart: -1,
+          dnsEnd: -1,
+          connectStart: -1,
+          connectEnd: -1,
+          sslStart: -1,
+          sslEnd: -1,
+          workerStart: -1,
+          workerReady: -1,
+          workerFetchStart: -1,
+          workerRespondWithSettled: -1,
+          sendStart: 0.199,
+          sendEnd: 0.258,
+          pushStart: 0,
+          pushEnd: 0,
+          receiveHeadersStart: 4.199,
+          receiveHeadersEnd: 4.304,
+        },
+        responseTime: 1.712063242363088e12,
+        protocol: 'http/1.1',
+        alternateProtocolUsage: 'unspecifiedReason',
+        securityState: 'secure',
+      },
+      type: this.type,
+      frameId: this.frameId,
+      hasUserGesture: false,
+    });
+  }
+
   requestWillBeSentExtraInfo() {
     this.cdpClient.emit('Network.requestWillBeSentExtraInfo', {
       requestId: this.requestId,

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -192,7 +192,9 @@ export class NetworkRequest {
   }
 
   handleRedirect(event: Protocol.Network.RequestWillBeSentEvent) {
-    this.#response.hasExtraInfo = event.redirectHasExtraInfo;
+    // TODO: use event.redirectResponse;
+    // Temporary workaround to emit ResponseCompleted event for redirects
+    this.#response.hasExtraInfo = false;
     this.#response.info = event.redirectResponse!;
     this.#emitEventsIfReady({
       wasRedirected: true,

--- a/src/bidiMapper/modules/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/modules/network/NetworkStorage.spec.ts
@@ -377,5 +377,16 @@ describe('NetworkStorage', () => {
       const event = await getEvent('network.responseCompleted');
       expect(event).to.exist;
     });
+
+    it('should work with redirect', async () => {
+      const request = new MockCdpNetworkEvents(cdpClient, {
+        url: 'data:text/html,<div>yo</div>',
+      });
+
+      request.requestWillBeSent();
+      request.requestWillBeSentRedirect();
+      const event = await getEvent('network.responseCompleted');
+      expect(event).to.exist;
+    });
   });
 });


### PR DESCRIPTION
Currently we never await the `responseReceivedExtraInfo` as we destroy the BiDi `NetworkRequest` as soon as we see the redirect happening. This means that the conditions for emitting are never met.
We should eventually change this but having the `responseCompleted` event with missing headers is better then not having it at all.
Such change would mean that can never have order that matches the expectations
`beforeRequestSent` -> `responseCompleted` -> `beforeRequestSent`
As the `responseReceivedExtraInfo` comes after the second CDP `requestWillBeSent`
https://github.com/GoogleChromeLabs/chromium-bidi/issues/2035