### PR TITLE
docs: quick failures button

### DIFF
--- a/tools/wpt-report-builder/template.html
+++ b/tools/wpt-report-builder/template.html
@@ -117,6 +117,7 @@
     <div class="header">
       <chromium-bidi-header />
       <div>
+        <button class="failures button" type="button">Failures</button>
         <button class="expand button" type="button">Expand</button>
         <button class="toggle button" type="button">Long</button>
       </div>
@@ -157,6 +158,35 @@
           expandState = 'expand';
         } else {
           expandState = 'collapse';
+        }
+      });
+
+      const failures = document.querySelector('.failures');
+      let failureState = 'all';
+      const summaryQuery = '.test-card:has(> details > .path.pass)';
+      const summaryDividerQuery = `${summaryQuery} + .divider`;
+      const passingTestQuery = '.test-card.test-card-subtest.pass';
+      const passingTestDividerQuery = `${passingTestQuery} + .divider`;
+      failures.addEventListener('click', () => {
+        failures.innerText =
+          failureState.charAt(0).toUpperCase() + failureState.slice(1);
+        if (failureState === 'all') {
+          failureState = 'failures';
+        } else {
+          failureState = 'all';
+        }
+        for (const query of [
+          summaryQuery,
+          summaryDividerQuery,
+          passingTestQuery,
+          passingTestDividerQuery,
+        ]) {
+          document
+            .querySelectorAll(query)
+            .forEach(
+              (element) =>
+                (element.style.display = failureState === 'all' ? '' : 'none')
+            );
         }
       });
     </script>


### PR DESCRIPTION
After pressing shows only failing tests.
![image](https://github.com/GoogleChromeLabs/chromium-bidi/assets/34244704/ddd45d77-78f9-47ed-896a-19dea1799c73)
And deep as well
![image](https://github.com/GoogleChromeLabs/chromium-bidi/assets/34244704/97b5ef86-ec1a-4942-96d9-9cca9910f35d)
