### PR TITLE
fix: apply existing context check to default user context too

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
@@ -77,6 +77,10 @@ export class BrowsingContextProcessor {
       userContext = params.userContext;
     }
 
+    const existingContexts = this.#browsingContextStorage
+      .getAllContexts()
+      .filter((context) => context.userContext === userContext);
+
     let newWindow = false;
     switch (params.type) {
       case BrowsingContext.CreateType.Tab:
@@ -87,16 +91,10 @@ export class BrowsingContextProcessor {
         break;
     }
 
-    if (userContext !== 'default') {
-      const existingContexts = this.#browsingContextStorage
-        .getAllContexts()
-        .filter((context) => context.userContext === userContext);
-
-      if (!existingContexts.length) {
-        // If there are no contexts in the given user context, we need to set
-        // newWindow to true as newWindow=false will be rejected.
-        newWindow = true;
-      }
+    if (!existingContexts.length) {
+      // If there are no contexts in the given user context, we need to set
+      // newWindow to true as newWindow=false will be rejected.
+      newWindow = true;
     }
 
     let result: Protocol.Target.CreateTargetResponse;


### PR DESCRIPTION
The test covering this is `[browser.spec] Browser specs Browser.process should keep connected after the last page is closed`