### PR TITLE
fix: wait for the first pain of the page beofre taking screenshot

### DIFF
--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
@@ -1,4 +1,5 @@
 [capture_screenshot.py]
+  expected: TIMEOUT
   [test_capture]
     expected: [FAIL, PASS]
 

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/clip.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/clip.py.ini
@@ -7,9 +7,3 @@
 
   [test_clip_element_outside_of_window_viewport]
     expected: FAIL
-
-  [test_clip_box_outside_of_window_viewport[viewport\]]
-    expected: FAIL
-
-  [test_clip_element_outside_of_window_viewport[viewport\]]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,4 +1,5 @@
 [frame.py]
+  expected: TIMEOUT
   [test_iframe]
     expected: FAIL
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
@@ -1,4 +1,5 @@
 [capture_screenshot.py]
+  expected: TIMEOUT
   [test_capture]
     expected: [FAIL, PASS]
 

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,3 +1,4 @@
 [frame.py]
+  expected: TIMEOUT
   [test_iframe]
     expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/capture_screenshot.py.ini
@@ -1,0 +1,2 @@
+[capture_screenshot.py]
+  expected: TIMEOUT

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/frame.py.ini
@@ -1,3 +1,4 @@
 [frame.py]
+  expected: TIMEOUT
   [test_iframe]
     expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/capture_screenshot/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  expected: TIMEOUT


### PR DESCRIPTION
When taking screenshot right after the navigation the viewport can be not yet resized, which makes the result of `window.visualViewport` incorrect. Waiting for the `firstPaint` lifecycle event should prevent this race condition.

Probably this is related to this spec of [`browsingContext.captureScreenshot`](https://w3c.github.io/webdriver-bidi/#command-browsingContext-captureScreenshot):
> 4. Immediately after the next invocation of the [run the animation frame callbacks](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks) algorithm for document...

Alternatively, the `wait: complete` condition can be adjusted, but this can not work in background not-active pages.

This fixes WPT tests `test_clip_box_outside_of_window_viewport[viewport]` and `test_clip_element_outside_of_window_viewport[viewport]`.

Example CDP logs BEFORE the change (simplified):
```
> window.innerHeight: 469

cdp:RECV ◂ { "method": "Page.frameResized", "params": {} }
cdp:RECV ◂ { "method": "Page.lifecycleEvent", "params": { "name": "firstPaint" } }
cdp:RECV ◂ { "method": "Page.lifecycleEvent", "params": { "name": "firstMeaningfulPaintCandidate" } }

> window.innerHeight: 417
```

Open question: should it be `firstMeaningfulPaintCandidate` instead?