### PR TITLE
ci: add label for WPT expectations update

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,34 @@
+name: Labeler CI
+
+# Declare default permissions as read only.
+permissions: read-all
+
+on:
+  pull_request:
+
+jobs:
+  add-label-to-release:
+    name: Add label to release
+    runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'release-please')
+    permissions:
+      pull-requests: write
+    steps:
+      - run: gh pr edit "$NUMBER" --add-label "puppeteer"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+
+  add-label-to-wpt-bump:
+    name: Add label to release
+    runs-on: ubuntu-latest
+    if: contains(github.head_ref, 'Bump wpt')
+    permissions:
+      pull-requests: write
+    steps:
+      - run: gh pr edit "$NUMBER" --add-label "update-expectations"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -21,19 +21,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  add-label-to-release:
-    name: Add label to release
-    runs-on: ubuntu-latest
-    if: contains(github.head_ref, 'release-please')
-    permissions:
-      pull-requests: write
-    steps:
-      - run: gh pr edit "$NUMBER" --add-label "puppeteer"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}
-
   puppeteer-test:
     name: Run Puppeteer tests
     runs-on: ubuntu-latest

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -15,6 +15,17 @@ env:
 on:
   push:
     branches: 'main'
+  pull_request:
+    types:
+      # These are the defaults. See
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+      - opened
+      - reopened
+      - synchronize
+
+      # Used for `update-expectations`
+      - labeled
+
   workflow_dispatch:
     inputs:
       auto-commit:
@@ -40,7 +51,7 @@ jobs:
   wpt-report:
     name: WPT report
     needs: wpt
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'update-expectations')  }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -69,10 +80,11 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
   wpt-auto-commit:
     name: WPT auto-commit expectations
     needs: wpt
-    if: ${{ !cancelled() && github.event.inputs.auto-commit == 'true' }}
+    if: ${{ !cancelled() && (github.event.inputs.auto-commit == 'true' || contains(github.event.pull_request.labels.*.name, 'update-expectations')) }}
     runs-on: ubuntu-latest
     # Give GITHUB_TOKEN write permission to commit and push.
     # Needed by stefanzweifel/git-auto-commit-action.
@@ -81,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        with:
+          token: ${{ secrets.BROWSER_AUTOMATION_BOT_TOKEN }}
       - run: rm -rf wpt-metadata/chromedriver/headless/*
       - run: rm -rf wpt-metadata/chromedriver/headful/*
       - run: rm -rf wpt-metadata/mapper/headless/*
@@ -103,6 +117,7 @@ jobs:
           commit_message: Update WPT expectations
           commit_options: -n --signoff
           file_pattern: 'wpt-metadata/**/*.ini'
+
   wpt:
     name: ${{ matrix.kind }}-${{ matrix.head }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding the label to the dependabot PR should work.
Updating the expectation and running the CI after committing is best guess effort. 