### PR TITLE
chore: user prompt before the mapper tab closed

### DIFF
--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -160,6 +160,13 @@ export class MapperServerCdpConnection {
 
     const mapperCdpClient = cdpConnection.getCdpClient(mapperSessionId);
 
+    // Click on the body to interact with the page in order to "beforeunload" being
+    // triggered when the tab is closed.
+    await mapperCdpClient.sendCommand('Runtime.evaluate', {
+      expression: 'document.body.click()',
+      userGesture: true,
+    });
+
     const bidiSession = new SimpleTransport(
       async (message) => await this.#sendMessage(mapperCdpClient, message)
     );

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -48,6 +48,11 @@ declare global {
 
     // Set from the server side if verbose logging is required.
     sendDebugMessage?: ((message: string) => void) | null;
+
+    // Required to prevent the user from closing the tab.
+    onbeforeunload:
+      | ((this: WindowEventHandlers, ev: BeforeUnloadEvent) => any)
+      | null;
   }
 }
 

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -26,6 +26,10 @@ export function generatePage() {
     return;
   }
   globalThis.document.documentElement.innerHTML = mapperPageSource;
+
+  // Show a confirmation dialog when the user tries to leave the Mapper tab.
+  globalThis.window.onbeforeunload = () =>
+    'Closing or reloading this tab will stop the BiDi process. Are you sure you want to leave?';
 }
 
 function stringify(message: unknown) {


### PR DESCRIPTION
1. Add `onbeforeunload` handler to the mapper tab.
2. Click on the mapper tab, so that the `onbeforeunload` will be triggered.

Required follow up:
* [ ] add user gesture click on the tab in ChromeDriver.