### PR TITLE
chore: add label at PR create time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    labels:
+      - 'dependencies'
+      - 'submodules'
+      - 'update-expectations'
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -25,16 +25,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.pull_request.number }}
-
-  add-label-to-wpt-bump:
-    name: Add label to release
-    runs-on: ubuntu-latest
-    if: ${{ contains(github.head_ref, 'dependabot') && contains(github.head_ref, 'wpt') }}
-    permissions:
-      pull-requests: write
-    steps:
-      - run: gh pr edit "$NUMBER" --add-label "update-expectations"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Currently the label is added too late so that the GitHub Action event does not contain it.
This should add it as before that so the trigger will already have it in the JSON event struct. 