### PR TITLE
chore: fall back in case of not supported key input

### DIFF
--- a/src/bidiMapper/modules/input/keyUtils.ts
+++ b/src/bidiMapper/modules/input/keyUtils.ts
@@ -33,8 +33,9 @@ export function getNormalizedKey(value: string): string {
       return 'Tab';
     case '\uE005':
       return 'Clear';
+    // Specification declares the '\uE006' to be `Return`, but it is not supported by
+    // Chrome, so fall back to `Enter`, which aligns with WPT.
     case '\uE006':
-      return 'Return';
     case '\uE007':
       return 'Enter';
     case '\uE008':

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
@@ -1,3 +1,0 @@
-[key_events.py]
-  [test_key_special_key_sends_keydown[RETURN-expected46\]]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
@@ -1,3 +1,0 @@
-[key_events.py]
-  [test_key_special_key_sends_keydown[RETURN-expected46\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
@@ -1,3 +1,0 @@
-[key_events.py]
-  [test_key_special_key_sends_keydown[RETURN-expected46\]]
-    expected: FAIL


### PR DESCRIPTION
The "Return" key code is not specified in https://www.w3.org/TR/uievents-key/ nor implemented in [Chrome](https://source.chromium.org/chromium/chromium/src/+/main:ui/events/keycodes/dom/dom_key_data.inc). Fall back to `Enter`.