### PR TITLE
chore: WPT detailed job commits only if the tests failed

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -84,7 +84,7 @@ jobs:
   wpt-auto-commit:
     name: WPT auto-commit expectations
     needs: wpt
-    if: ${{ !cancelled() && (github.event.inputs.auto-commit == 'true' || contains(github.event.pull_request.labels.*.name, 'update-expectations')) }}
+    if: ${{ failure() && (github.event.inputs.auto-commit == 'true' || contains(github.event.pull_request.labels.*.name, 'update-expectations')) }}
     # Needed to remove the label to prevent a loop
     permissions:
       pull-requests: write


### PR DESCRIPTION
If WPT detailed task finished successfull, the expectations should not be updated. Tested in https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/9059738115