### PR TITLE
build: remove `update-expectations` label after successful pass

### DIFF
--- a/.github/workflows/wpt-quick.yml
+++ b/.github/workflows/wpt-quick.yml
@@ -246,3 +246,21 @@ jobs:
           commit_user_email: browser-automation-bot@google.com
           commit_author: Browser Automation Bot <browser-automation-bot@google.com>
           file_pattern: 'wpt-metadata/**/*.ini'
+
+  remove-label:
+    # If WPT tests passed, remove the `update-expectations` label.
+    name: Update WPT expectations (if required)
+    permissions:
+      # Required to remove the label.
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: [wpt]
+    # Remove the label if the WPT tests passed.
+    if: ${{ success() && contains(github.event.pull_request.labels.*.name, 'update-expectations') }}
+    steps:
+      - name: Remove update-expectations label
+        run: gh pr edit "$NUMBER" --remove-label "update-expectations"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Remove `update-expectations` label after successful WPT pass