### PR TITLE
build: in JS runner, activate the blank tab, not the mapper tab

### DIFF
--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -147,12 +147,15 @@ export class MapperServerCdpConnection {
 
     const browserClient = await cdpConnection.createBrowserSession();
 
-    const {targetId: mapperTabTargetId} = await browserClient.sendCommand(
-      'Target.createTarget',
-      {
-        url: 'about:blank',
-      }
-    );
+    // Run mapper in the first open tab.
+    const targets = (await cdpConnection.sendCommand(
+      'Target.getTargets',
+      {}
+    )) as Protocol.Target.GetTargetsResponse;
+    const mapperTabTargetId = targets.targetInfos.filter(
+      (target) => target.type === 'page'
+    )[0]!.targetId;
+
     const {sessionId: mapperSessionId} = await browserClient.sendCommand(
       'Target.attachToTarget',
       {targetId: mapperTabTargetId, flatten: true}
@@ -211,6 +214,11 @@ export class MapperServerCdpConnection {
         mapperOptions
       )})`,
       awaitPromise: true,
+    });
+
+    // Create and activate new tab with a blank page.
+    await browserClient.sendCommand('Target.createTarget', {
+      url: 'about:blank',
     });
 
     debugInternal('Mapper is launched!');

--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -170,6 +170,11 @@ export class MapperServerCdpConnection {
       userGesture: true,
     });
 
+    // Create and activate new tab with a blank page.
+    await browserClient.sendCommand('Target.createTarget', {
+      url: 'about:blank',
+    });
+
     const bidiSession = new SimpleTransport(
       async (message) => await this.#sendMessage(mapperCdpClient, message)
     );
@@ -214,11 +219,6 @@ export class MapperServerCdpConnection {
         mapperOptions
       )})`,
       awaitPromise: true,
-    });
-
-    // Create and activate new tab with a blank page.
-    await browserClient.sendCommand('Target.createTarget', {
-      url: 'about:blank',
     });
 
     debugInternal('Mapper is launched!');


### PR DESCRIPTION
As long as bidi tab is transparent for clients, having it active is unexpected. Required for input tests.