### PR TITLE
test: disable flaky `test_network_before_request_sent_event_with_cookies_emitted`

### DIFF
--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -145,6 +145,9 @@ async def test_network_global_subscription_enabled_in_new_context(
 @pytest.mark.asyncio
 async def test_network_before_request_sent_event_with_cookies_emitted(
         websocket, context_id, base_url, example_url):
+    pytest.xfail(
+        "TODO: Fix flaky test https://github.com/GoogleChromeLabs/chromium-bidi/issues/2263"
+    )
     await goto_url(websocket, context_id, base_url)
 
     await execute_command(


### PR DESCRIPTION
https://github.com/GoogleChromeLabs/chromium-bidi/issues/2263