### PR TITLE
fix: when reconnecting, save context's url

### DIFF
--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -126,6 +126,9 @@ export class CdpTargetManager {
         this.#eventManager,
         this.#browsingContextStorage,
         this.#realmStorage,
+        // At this point, we don't know the URL of the frame yet, so it will be updated
+        // later.
+        'about:blank',
         this.#logger
       );
     }
@@ -175,6 +178,7 @@ export class CdpTargetManager {
             this.#eventManager,
             this.#browsingContextStorage,
             this.#realmStorage,
+            targetInfo.url,
             this.#logger
           );
         }

--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -178,7 +178,15 @@ export class CdpTargetManager {
             this.#eventManager,
             this.#browsingContextStorage,
             this.#realmStorage,
-            targetInfo.url,
+            // Hack: when a new target created, CDP emits targetInfoChanged with an empty
+            // url, and navigates it to about:blank later. When the event is emitted for
+            // an existing target (reconnect), the url is already known, and navigation
+            // events will not be emitted anymore. Replacing empty url with `about:blank`
+            // allows to handle both cases in the same way.
+            // "7.3.2.1 Creating browsing contexts".
+            // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-browsing-contexts
+            // TODO: check who to deal with non-null creator and its `creatorOrigin`.
+            targetInfo.url === '' ? 'about:blank' : targetInfo.url,
             this.#logger
           );
         }

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -68,7 +68,7 @@ export class BrowsingContextImpl {
     withinDocument: new Deferred<void>(),
   };
 
-  #url = 'about:blank';
+  #url: string;
   readonly #eventManager: EventManager;
   readonly #realmStorage: RealmStorage;
   #loaderId?: Protocol.Network.LoaderId;
@@ -86,6 +86,7 @@ export class BrowsingContextImpl {
     eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,
+    url: string,
     logger?: LoggerFn
   ) {
     this.#cdpTarget = cdpTarget;
@@ -96,6 +97,7 @@ export class BrowsingContextImpl {
     this.#browsingContextStorage = browsingContextStorage;
     this.#realmStorage = realmStorage;
     this.#logger = logger;
+    this.#url = url;
   }
 
   static create(
@@ -106,6 +108,7 @@ export class BrowsingContextImpl {
     eventManager: EventManager,
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,
+    url: string,
     logger?: LoggerFn
   ): BrowsingContextImpl {
     const context = new BrowsingContextImpl(
@@ -116,6 +119,7 @@ export class BrowsingContextImpl {
       eventManager,
       browsingContextStorage,
       realmStorage,
+      url,
       logger
     );
 


### PR DESCRIPTION
When target is attached, save it's url. This should address [puppeteer test](https://github.com/puppeteer/puppeteer/blob/88df4075171cdd87ad60241dd77028c96b1a7d9b/test/src/launcher.spec.ts#L890).