### PR TITLE
fix: keep radius and force of input

### DIFF
--- a/src/bidiMapper/modules/input/InputSource.ts
+++ b/src/bidiMapper/modules/input/InputSource.ts
@@ -78,6 +78,9 @@ export class PointerSource {
   pressed = new Set<number>();
   x = 0;
   y = 0;
+  radiusX?: number;
+  radiusY?: number;
+  force?: number;
 
   constructor(id: number, subtype: Input.PointerType) {
     this.pointerId = id;


### PR DESCRIPTION
In order to provide proper DOM `touchend` event params, need to keep track of pressure and touch size of touch input events.

Tested via Puppeteer. To test e2e, extending http server with static page is required, so out of scope.