### PR TITLE
chore: run Update Expectations only when the run changes them

### DIFF
--- a/tools/run-wpt.mjs
+++ b/tools/run-wpt.mjs
@@ -246,7 +246,10 @@ if (RUN_TESTS === 'true') {
   }).status;
 }
 
-if (UPDATE_EXPECTATIONS === 'true') {
+if (
+  (UPDATE_EXPECTATIONS === 'true' && RUN_TESTS !== 'true') ||
+  (UPDATE_EXPECTATIONS === 'true' && RUN_TESTS === 'true' && run_status)
+) {
   log('Updating WPT expectations...');
 
   const wptRunArgs = [


### PR DESCRIPTION
If we get `result === 0` that mean the command finished without needing to update.
This saves some time locally.
If we didn't run test, but we ran the command (`RUN_TEST=false`) we try to update the expectations (needed for CI).