### PR TITLE
feat: add support for `originalOpener` in BrowsingContext.Info

### DIFF
--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -213,6 +213,7 @@ export class CdpTarget {
         this.#browsingContextStorage,
         this.#realmStorage,
         frame.url,
+        undefined,
         this.#logger
       );
     }

--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -129,6 +129,7 @@ export class CdpTargetManager {
         // At this point, we don't know the URL of the frame yet, so it will be updated
         // later.
         'about:blank',
+        undefined,
         this.#logger
       );
     }
@@ -187,6 +188,7 @@ export class CdpTargetManager {
             // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-browsing-contexts
             // TODO: check who to deal with non-null creator and its `creatorOrigin`.
             targetInfo.url === '' ? 'about:blank' : targetInfo.url,
+            targetInfo.openerId,
             this.#logger
           );
         }

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -79,6 +79,8 @@ export class BrowsingContextImpl {
   // Keeps track of the previously set viewport.
   #previousViewport: {width: number; height: number} = {width: 0, height: 0};
 
+  #originalOpener?: string;
+
   private constructor(
     id: BrowsingContext.BrowsingContext,
     parentId: BrowsingContext.BrowsingContext | null,
@@ -88,6 +90,7 @@ export class BrowsingContextImpl {
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,
     url: string,
+    originalOpener?: string,
     logger?: LoggerFn
   ) {
     this.#cdpTarget = cdpTarget;
@@ -99,6 +102,8 @@ export class BrowsingContextImpl {
     this.#realmStorage = realmStorage;
     this.#logger = logger;
     this.#url = url;
+
+    this.#originalOpener = originalOpener;
   }
 
   static create(
@@ -110,6 +115,7 @@ export class BrowsingContextImpl {
     browsingContextStorage: BrowsingContextStorage,
     realmStorage: RealmStorage,
     url: string,
+    originalOpener?: string,
     logger?: LoggerFn
   ): BrowsingContextImpl {
     const context = new BrowsingContextImpl(
@@ -121,6 +127,7 @@ export class BrowsingContextImpl {
       browsingContextStorage,
       realmStorage,
       url,
+      originalOpener,
       logger
     );
 
@@ -305,6 +312,7 @@ export class BrowsingContextImpl {
       context: this.#id,
       url: this.url,
       userContext: this.userContext,
+      originalOpener: this.#originalOpener ?? null,
       children:
         maxDepth > 0
           ? this.directChildren.map((c) =>

--- a/src/protocol-parser/generated/webdriver-bidi.ts
+++ b/src/protocol-parser/generated/webdriver-bidi.ts
@@ -460,6 +460,10 @@ export namespace BrowsingContext {
     z.object({
       children: z.union([BrowsingContext.InfoListSchema, z.null()]),
       context: BrowsingContext.BrowsingContextSchema,
+      originalOpener: z.union([
+        BrowsingContext.BrowsingContextSchema,
+        z.null(),
+      ]),
       url: z.string(),
       userContext: Browser.UserContextSchema,
       parent: z

--- a/src/protocol/generated/webdriver-bidi.ts
+++ b/src/protocol/generated/webdriver-bidi.ts
@@ -336,6 +336,7 @@ export namespace BrowsingContext {
   export type Info = {
     children: BrowsingContext.InfoList | null;
     context: BrowsingContext.BrowsingContext;
+    originalOpener: BrowsingContext.BrowsingContext | null;
     url: string;
     userContext: Browser.UserContext;
     parent?: BrowsingContext.BrowsingContext | null;

--- a/tests/browsing_context/__snapshots__/test_close.ambr
+++ b/tests/browsing_context/__snapshots__/test_close.ambr
@@ -4,6 +4,7 @@
     'method': 'browsingContext.contextDestroyed',
     'params': dict({
       'children': None,
+      'originalOpener': None,
       'parent': None,
       'url': "data:text/html,%0A        <script>%0A            window.addEventListener('beforeunload', event => {%0A                event.returnValue = 'Leave?%27;%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20event.preventDefault();%0A%20%20%20%20%20%20%20%20%20%20%20%20});%0A%20%20%20%20%20%20%20%20%3C/script%3E",
       'userContext': 'default',

--- a/tests/browsing_context/test_close.py
+++ b/tests/browsing_context/test_close.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import pytest
 from syrupy.filters import paths
-from test_helpers import (execute_command, get_tree, goto_url,
+from test_helpers import (AnyExtending, execute_command, get_tree, goto_url,
                           read_JSON_message, send_JSON_command, subscribe,
                           wait_for_event)
 
@@ -32,7 +32,7 @@ async def test_browsingContext_close(websocket, context_id):
 
     # Assert "browsingContext.contextCreated" event emitted.
     resp = await read_JSON_message(websocket)
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "browsingContext.contextDestroyed",
         "params": {
@@ -42,7 +42,7 @@ async def test_browsingContext_close(websocket, context_id):
             "children": None,
             "userContext": "default"
         }
-    }
+    })
 
     resp = await read_JSON_message(websocket)
     assert resp == {"type": "success", "id": command_id, "result": {}}

--- a/tests/browsing_context/test_create.py
+++ b/tests/browsing_context/test_create.py
@@ -67,7 +67,8 @@ async def test_browsingContext_create_eventContextCreatedEmitted(
             "url": "about:blank",
             "children": None,
             "parent": None,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }
     } == context_created_event
 
@@ -132,18 +133,21 @@ async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCr
             "parent": None,
             "url": top_level_page,
             "userContext": "default",
+            "originalOpener": None,
             "children": [
                 {
                     "context": ANY_STR,
                     # It's not guaranteed the nested page is already loaded.
                     "url": ANY_STR,
                     "userContext": "default",
+                    "originalOpener": None,
                     "children": [{
                         "context": ANY_STR,
                         # It's not guaranteed the nested page is already loaded.
                         "url": ANY_STR,
                         "userContext": "default",
-                        "children": []
+                        "children": [],
+                        "originalOpener": None
                     }]
                 },
             ]
@@ -154,7 +158,7 @@ async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCr
         "context"]
     nested_iframe_context_id = \
         tree["contexts"][0]["children"][0]["children"][0]["context"]
-    assert events[0] == {
+    assert events[0] == AnyExtending({
         'type': 'event',
         "method": "browsingContext.contextCreated",
         "params": {
@@ -164,9 +168,9 @@ async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCr
             'url': 'about:blank',
             'userContext': 'default'
         }
-    }
+    })
 
-    assert events[1] == {
+    assert events[1] == AnyExtending({
         'type': 'event',
         "method": "browsingContext.contextCreated",
         "params": {
@@ -176,7 +180,7 @@ async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCr
             'url': 'about:blank',
             'userContext': 'default'
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -235,7 +239,8 @@ async def test_browsingContext_create_withUserGesture_eventsEmitted(
             'url': 'about:blank',
             'children': None,
             'parent': None,
-            'userContext': 'default'
+            'userContext': 'default',
+            'originalOpener': ANY_STR,
         }
     }, {
         'type': 'event',
@@ -287,13 +292,13 @@ async def test_browsingContext_create_withUserContext(websocket, type):
 
     assert len(tree['contexts']) == 2
 
-    assert tree["contexts"][1] == {
+    assert tree["contexts"][1] == AnyExtending({
         'context': result['context'],
         'url': 'about:blank',
         'userContext': user_context["userContext"],
         'children': [],
         'parent': None
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -314,8 +319,8 @@ async def test_browsingContext_subscribe_to_contextCreated_emits_for_existing(
                 ],
                 # Missing "contexts" means global subscription.
                 **({} if global_subscription else {
-                       "contexts": [another_context_id]
-                   })
+                    "contexts": [another_context_id]
+                })
             }
         })
 

--- a/tests/browsing_context/test_create.py
+++ b/tests/browsing_context/test_create.py
@@ -319,8 +319,8 @@ async def test_browsingContext_subscribe_to_contextCreated_emits_for_existing(
                 ],
                 # Missing "contexts" means global subscription.
                 **({} if global_subscription else {
-                    "contexts": [another_context_id]
-                })
+                       "contexts": [another_context_id]
+                   })
             }
         })
 

--- a/tests/browsing_context/test_get_tree.py
+++ b/tests/browsing_context/test_get_tree.py
@@ -27,7 +27,8 @@ async def test_browsingContext_getTree_contextReturned(websocket, context_id):
             "children": [],
             "parent": None,
             "url": "about:blank",
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     }
 
@@ -54,7 +55,8 @@ async def test_browsingContext_getTreeWithRoot_contextReturned(websocket):
             "parent": None,
             "url": "about:blank",
             "children": [],
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     }
 
@@ -78,11 +80,13 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedCrossOriginConte
                 "context": ANY_STR,
                 "url": another_example_url,
                 "children": [],
-                "userContext": "default"
+                "userContext": "default",
+                "originalOpener": None
             }],
             "parent": None,
             "url": another_page_with_nested_iframe,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -108,11 +112,13 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_context
                 "context": ANY_STR,
                 "url": nested_iframe,
                 "children": [],
-                "userContext": "default"
+                "userContext": "default",
+                "originalOpener": None
             }],
             "parent": None,
             "url": page_with_nested_iframe,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -127,10 +133,12 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_context
                 "context": ANY_STR,
                 "url": another_nested_iframe,
                 "children": [],
-                "userContext": "default"
+                "userContext": "default",
+                "originalOpener": None
             }],
             "parent": None,
             "url": another_page_with_nested_iframe,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -235,7 +235,8 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitInteractive_na
             "children": [],
             "parent": None,
             "url": url_with_hash_1,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -251,7 +252,8 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitInteractive_na
             "children": [],
             "parent": None,
             "url": url_with_hash_2,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -277,7 +279,8 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitComplete_navig
             "children": [],
             "parent": None,
             "url": url_with_hash_1,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -292,7 +295,8 @@ async def test_browsingContext_navigateSameDocumentNavigation_waitComplete_navig
             "children": [],
             "parent": None,
             "url": url_with_hash_2,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -314,7 +318,8 @@ async def test_navigateToPageWithHash_contextInfoUpdated(
             "children": [],
             "parent": None,
             "url": url_with_hash_1,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     }
 
@@ -448,7 +453,7 @@ async def test_browsingContext_navigateBadSsl_notNavigated(
         'acceptInsecureCerts': True
     }
 }],
-                         indirect=['websocket'])
+    indirect=['websocket'])
 async def test_browsingContext_navigateBadSslAndAcceptInsecureCerts_navigated(
         websocket, context_id, bad_ssl_url):
     await execute_command(

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -453,7 +453,7 @@ async def test_browsingContext_navigateBadSsl_notNavigated(
         'acceptInsecureCerts': True
     }
 }],
-    indirect=['websocket'])
+                         indirect=['websocket'])
 async def test_browsingContext_navigateBadSslAndAcceptInsecureCerts_navigated(
         websocket, context_id, bad_ssl_url):
     await execute_command(

--- a/tests/browsing_context/test_nested_browsing_context.py
+++ b/tests/browsing_context/test_nested_browsing_context.py
@@ -36,7 +36,8 @@ async def test_nestedBrowsingContext_navigateToPageWithHash_contextInfoUpdated(
             "children": [],
             "parent": ANY_STR,
             "url": url_with_hash_1,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -194,7 +195,8 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitInteract
             "children": [],
             "parent": ANY_STR,
             "url": url_with_hash_1,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -209,7 +211,8 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitInteract
             "children": [],
             "parent": ANY_STR,
             "url": url_with_hash_2,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -235,7 +238,8 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitComplete
             "children": [],
             "parent": ANY_STR,
             "url": url_with_hash_1,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -250,7 +254,8 @@ async def test_nestedBrowsingContext_navigateSameDocumentNavigation_waitComplete
             "children": [],
             "parent": ANY_STR,
             "url": url_with_hash_2,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -273,11 +278,13 @@ async def test_nestedBrowsingContext_afterNavigation_getTreeWithNestedCrossOrigi
                 "context": ANY_STR,
                 "url": another_example_url,
                 "children": [],
-                "userContext": "default"
+                "userContext": "default",
+                "originalOpener": None
             }],
             "parent": ANY_STR,
             "url": another_page_with_nested_iframe,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -306,10 +313,12 @@ async def test_nestedBrowsingContext_afterNavigation_getTreeWithNestedContexts_c
                 "context": ANY_STR,
                 "url": another_nested_iframe,
                 "children": [],
-                "userContext": "default"
+                "userContext": "default",
+                "originalOpener": None
             }],
             "parent": ANY_STR,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -329,11 +338,13 @@ async def test_browsingContext_addAndRemoveNestedContext_contextAddedAndRemoved(
                 "context": ANY_STR,
                 "url": url_cross_origin,
                 "children": [],
-                "userContext": "default"
+                "userContext": "default",
+                "originalOpener": None
             }],
             "parent": None,
             "url": page_with_nested_iframe,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result
 
@@ -358,6 +369,7 @@ async def test_browsingContext_addAndRemoveNestedContext_contextAddedAndRemoved(
             "children": [],
             "parent": None,
             "url": page_with_nested_iframe,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }]
     } == result

--- a/tests/session/test_subscription.py
+++ b/tests/session/test_subscription.py
@@ -124,7 +124,8 @@ async def test_subscribeWithContext_subscribesToEventsInNestedContext(
             "url": url_same_origin,
             "children": None,
             "parent": context_id,
-            "userContext": "default"
+            "userContext": "default",
+            "originalOpener": None
         }
     } == resp
 


### PR DESCRIPTION
We should wait until https://github.com/w3c/webdriver-bidi/pull/730 is resolved.

Closes #2315
Closes #2296