### PR TITLE
fix: don't use promises for events

### DIFF
--- a/src/bidiMapper/modules/log/LogManager.ts
+++ b/src/bidiMapper/modules/log/LogManager.ts
@@ -118,24 +118,30 @@ export class LogManager {
             );
       for (const browsingContext of realm.associatedBrowsingContexts) {
         this.#eventManager.registerPromiseEvent(
-          argsPromise.then((args) => ({
-            kind: 'success',
-            value: {
-              type: 'event',
-              method: ChromiumBidi.Log.EventNames.LogEntryAdded,
-              params: {
-                level: getLogLevel(params.type),
-                source: realm.source,
-                text: getRemoteValuesText(args, true),
-                timestamp: Math.round(params.timestamp),
-                stackTrace: getBidiStackTrace(params.stackTrace),
-                type: 'console',
-                // Console method is `warn`, not `warning`.
-                method: params.type === 'warning' ? 'warn' : params.type,
-                args,
+          argsPromise.then(
+            (args) => ({
+              kind: 'success',
+              value: {
+                type: 'event',
+                method: ChromiumBidi.Log.EventNames.LogEntryAdded,
+                params: {
+                  level: getLogLevel(params.type),
+                  source: realm.source,
+                  text: getRemoteValuesText(args, true),
+                  timestamp: Math.round(params.timestamp),
+                  stackTrace: getBidiStackTrace(params.stackTrace),
+                  type: 'console',
+                  // Console method is `warn`, not `warning`.
+                  method: params.type === 'warning' ? 'warn' : params.type,
+                  args,
+                },
               },
-            },
-          })),
+            }),
+            (error) => ({
+              kind: 'error',
+              error,
+            })
+          ),
           browsingContext.id,
           ChromiumBidi.Log.EventNames.LogEntryAdded
         );


### PR DESCRIPTION
It becomes very hard to track promises when we use `.then`.
I would like to remove this and maybe try to create an EsLint rule that makes sure that `await` in `.on`  are always wrapped in `try/catch`.