### PR TITLE
fix: handle `registerPromiseEvent` with errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,15 @@ module.exports = {
             devDependencies: false,
           },
         ],
+        'no-restricted-syntax': [
+          'error',
+          {
+            message:
+              'When `registerPromiseEvent` the `then` need to have a second catch argument',
+            selector:
+              'CallExpression[callee.property.name="registerPromiseEvent"] > :first-child[callee.property.name="then"][arguments.length<2]',
+          },
+        ],
         // keep-sorted start block=yes sticky_comments=yes
         '@typescript-eslint/array-type': 'warn',
         '@typescript-eslint/consistent-generic-constructors': 'warn',

--- a/src/bidiMapper/modules/log/LogManager.ts
+++ b/src/bidiMapper/modules/log/LogManager.ts
@@ -163,23 +163,29 @@ export class LogManager {
 
       for (const browsingContext of realm.associatedBrowsingContexts) {
         this.#eventManager.registerPromiseEvent(
-          LogManager.#getExceptionText(params, realm).then((text) => ({
-            kind: 'success',
-            value: {
-              type: 'event',
-              method: ChromiumBidi.Log.EventNames.LogEntryAdded,
-              params: {
-                level: Log.Level.Error,
-                source: realm.source,
-                text,
-                timestamp: Math.round(params.timestamp),
-                stackTrace: getBidiStackTrace(
-                  params.exceptionDetails.stackTrace
-                ),
-                type: 'javascript',
+          LogManager.#getExceptionText(params, realm).then(
+            (text) => ({
+              kind: 'success',
+              value: {
+                type: 'event',
+                method: ChromiumBidi.Log.EventNames.LogEntryAdded,
+                params: {
+                  level: Log.Level.Error,
+                  source: realm.source,
+                  text,
+                  timestamp: Math.round(params.timestamp),
+                  stackTrace: getBidiStackTrace(
+                    params.exceptionDetails.stackTrace
+                  ),
+                  type: 'javascript',
+                },
               },
-            },
-          })),
+            }),
+            (error) => ({
+              kind: 'error',
+              error,
+            })
+          ),
           browsingContext.id,
           ChromiumBidi.Log.EventNames.LogEntryAdded
         );


### PR DESCRIPTION
Closes #2317.
Closes #2320.

I missed the this in my last PR, but I added a EsLint rule to catch similar issue in the feature.
It's not 100% robust but it does the job if there is `then` in the called function.