### PR TITLE
fix: wait for DOMContentLoad when requesting Realm

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -275,6 +275,8 @@ export class BrowsingContextImpl {
 
   async getOrCreateSandbox(sandbox: string | undefined): Promise<Realm> {
     if (sandbox === undefined || sandbox === '') {
+      await this.#lifecycle.DOMContentLoaded;
+
       // Default realm is not guaranteed to be created at this point, so return a deferred.
       return await this.#defaultRealmDeferred;
     }


### PR DESCRIPTION
Not sure it this is the correct fix. 
What happens is that whenever we get a context that was not created by us:
`window.open` or `<a target=_blank>` we don't wait for the context to be fully loaded and emit while it's on the `about:blank` page transition.

The other option would be to wait for the DomContentLoad whenever we emit the event  via `registerPromiseEvent`.

Also open to suggestions.

Current situation:
`targetCreated` (`contextCreated`) event, then we get `executionContextCreated` for the inital `about:blank`, Puppeteer makes a `script.evaluate` here, then `exectionContextsCleared`,  `evalute` fails here, `executionContextCreated` for navigated page.