### PR TITLE
fix: openerFrameId whenever possible

### DIFF
--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -188,7 +188,7 @@ export class CdpTargetManager {
             // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-browsing-contexts
             // TODO: check who to deal with non-null creator and its `creatorOrigin`.
             targetInfo.url === '' ? 'about:blank' : targetInfo.url,
-            targetInfo.openerId,
+            targetInfo.openerFrameId ?? targetInfo.openerId,
             this.#logger
           );
         }


### PR DESCRIPTION
We should be able to track if what frame opened the new `BrowsingContext`.