### PR TITLE
refactor: move the methods to request

### DIFF
--- a/src/bidiMapper/modules/network/NetworkProcessor.ts
+++ b/src/bidiMapper/modules/network/NetworkProcessor.ts
@@ -194,24 +194,6 @@ export class NetworkProcessor {
       Network.InterceptPhase.AuthRequired,
     ]);
 
-    // We need to pass through if the request is already in
-    // AuthRequired phase
-    if (request.interceptPhase === Network.InterceptPhase.AuthRequired) {
-      // We need to use `ProvideCredentials`
-      // As `Default` may cancel the request
-      await request.continueWithAuth({
-        action: 'provideCredentials',
-      });
-      return {};
-    }
-
-    // If we don't modify the response
-    // just continue the request
-    if (!params.body && !params.headers) {
-      await request.continueRequest();
-      return {};
-    }
-
     try {
       await request.provideResponse(params);
     } catch (error) {

--- a/src/bidiMapper/modules/network/NetworkProcessor.ts
+++ b/src/bidiMapper/modules/network/NetworkProcessor.ts
@@ -111,36 +111,12 @@ export class NetworkProcessor {
       Network.InterceptPhase.ResponseStarted,
     ]);
 
-    if (request.interceptPhase === Network.InterceptPhase.AuthRequired) {
-      if (params.credentials) {
-        await Promise.all([
-          request.waitNextPhase,
-          request.continueWithAuth({
-            action: 'provideCredentials',
-            credentials: {
-              username: params.credentials.username,
-              password: params.credentials.password,
-            },
-          } as Network.ContinueWithAuthCredentials),
-        ]);
-      } else {
-        // We need to use `ProvideCredentials`
-        // As `Default` may cancel the request
-        await request.continueWithAuth({
-          action: 'provideCredentials',
-        });
-        return {};
-      }
-    }
-
-    if (request.interceptPhase === Network.InterceptPhase.ResponseStarted) {
-      // TODO: Set / expand.
-      // ; Step 10. cookies
-      try {
-        await request.continueResponse(params);
-      } catch (error) {
-        throw NetworkProcessor.wrapInterceptionError(error);
-      }
+    // TODO: Set / expand.
+    // ; Step 10. cookies
+    try {
+      await request.continueResponse(params);
+    } catch (error) {
+      throw NetworkProcessor.wrapInterceptionError(error);
     }
 
     return {};

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -475,10 +475,6 @@ export class NetworkRequest {
       }
     }
 
-    if (this.interceptPhase !== Network.InterceptPhase.ResponseStarted) {
-      return;
-    }
-
     const responseHeaders: Protocol.Fetch.HeaderEntry[] | undefined =
       cdpFetchHeadersFromBidiNetworkHeaders(overrides.headers);
 

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -484,7 +484,7 @@ export class NetworkRequest {
       const responseHeaders: Protocol.Fetch.HeaderEntry[] | undefined =
         cdpFetchHeadersFromBidiNetworkHeaders(overrides.headers);
 
-      this.#continueResponse({
+      await this.#continueResponse({
         responseCode: overrides.statusCode,
         responsePhrase: overrides.reasonPhrase,
         responseHeaders,


### PR DESCRIPTION
The main justification is we need to store the data from the interception as BiDi sends back the data for both request and response with the events. 

This PR does not introduce functional changes, Or are marked by comment.