### PR TITLE
fix: the capability to ignore cert errors should be browser-wide 

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -108,7 +108,6 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
       this.#realmStorage,
       networkStorage,
       this.#preloadScriptStorage,
-      options?.acceptInsecureCerts ?? false,
       defaultUserContextId,
       options?.unhandledPromptBehavior,
       logger

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -154,6 +154,10 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
     const [{browserContextIds}, {targetInfos}] = await Promise.all([
       browserCdpClient.sendCommand('Target.getBrowserContexts'),
       browserCdpClient.sendCommand('Target.getTargets'),
+      // This is required to ignore certificate errors when service worker is fetched.
+      browserCdpClient.sendCommand('Security.setIgnoreCertificateErrors', {
+        ignore: options?.acceptInsecureCerts ?? false,
+      }),
     ]);
     let defaultUserContextId = 'default';
     for (const info of targetInfos) {

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -46,7 +46,6 @@ export class CdpTarget {
 
   readonly #unblocked = new Deferred<Result<void>>();
   readonly #unhandledPromptBehavior?: Session.UserPromptHandler;
-  readonly #acceptInsecureCerts: boolean;
   readonly #logger: LoggerFn | undefined;
 
   #networkDomainEnabled = false;
@@ -65,7 +64,6 @@ export class CdpTarget {
     preloadScriptStorage: PreloadScriptStorage,
     browsingContextStorage: BrowsingContextStorage,
     networkStorage: NetworkStorage,
-    acceptInsecureCerts: boolean,
     unhandledPromptBehavior?: Session.UserPromptHandler,
     logger?: LoggerFn
   ): CdpTarget {
@@ -78,7 +76,6 @@ export class CdpTarget {
       preloadScriptStorage,
       browsingContextStorage,
       networkStorage,
-      acceptInsecureCerts,
       unhandledPromptBehavior,
       logger
     );
@@ -103,7 +100,6 @@ export class CdpTarget {
     preloadScriptStorage: PreloadScriptStorage,
     browsingContextStorage: BrowsingContextStorage,
     networkStorage: NetworkStorage,
-    acceptInsecureCerts: boolean,
     unhandledPromptBehavior?: Session.UserPromptHandler,
     logger?: LoggerFn
   ) {
@@ -115,7 +111,6 @@ export class CdpTarget {
     this.#preloadScriptStorage = preloadScriptStorage;
     this.#networkStorage = networkStorage;
     this.#browsingContextStorage = browsingContextStorage;
-    this.#acceptInsecureCerts = acceptInsecureCerts;
     this.#unhandledPromptBehavior = unhandledPromptBehavior;
     this.#logger = logger;
   }
@@ -166,10 +161,6 @@ export class CdpTarget {
         this.#cdpClient.sendCommand('Runtime.enable'),
         this.#cdpClient.sendCommand('Page.setLifecycleEventsEnabled', {
           enabled: true,
-        }),
-        // Set ignore certificate errors for each target.
-        this.#cdpClient.sendCommand('Security.setIgnoreCertificateErrors', {
-          ignore: this.#acceptInsecureCerts,
         }),
         this.toggleNetworkIfNeeded(),
         this.#cdpClient.sendCommand('Target.setAutoAttach', {

--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -48,7 +48,6 @@ export class CdpTargetManager {
 
   readonly #browsingContextStorage: BrowsingContextStorage;
   readonly #networkStorage: NetworkStorage;
-  readonly #acceptInsecureCerts: boolean;
   readonly #preloadScriptStorage: PreloadScriptStorage;
   readonly #realmStorage: RealmStorage;
 
@@ -65,12 +64,10 @@ export class CdpTargetManager {
     realmStorage: RealmStorage,
     networkStorage: NetworkStorage,
     preloadScriptStorage: PreloadScriptStorage,
-    acceptInsecureCerts: boolean,
     defaultUserContextId: Browser.UserContext,
     unhandledPromptBehavior?: Session.UserPromptHandler,
     logger?: LoggerFn
   ) {
-    this.#acceptInsecureCerts = acceptInsecureCerts;
     this.#cdpConnection = cdpConnection;
     this.#browserCdpClient = browserCdpClient;
     this.#selfTargetId = selfTargetId;
@@ -256,7 +253,6 @@ export class CdpTargetManager {
       this.#preloadScriptStorage,
       this.#browsingContextStorage,
       this.#networkStorage,
-      this.#acceptInsecureCerts,
       this.#unhandledPromptBehavior,
       this.#logger
     );

--- a/tests/service_worker/test_navigate.py
+++ b/tests/service_worker/test_navigate.py
@@ -1,0 +1,49 @@
+#  Copyright 2024 Google LLC.
+#  Copyright (c) Microsoft Corporation.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from test_helpers import execute_command
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('capabilities', [{
+    'acceptInsecureCerts': True
+}],
+                         indirect=True)
+async def test_serviceWorker_acceptInsecureCertsCapability_respected(
+        websocket, context_id, url_bad_ssl, local_server):
+    await execute_command(
+        websocket, {
+            'method': 'browsingContext.navigate',
+            'params': {
+                'url': local_server.url_service_worker_bad_ssl(),
+                'wait': 'complete',
+                'context': context_id
+            }
+        })
+
+    resp = await execute_command(
+        websocket, {
+            'method': 'script.evaluate',
+            'params': {
+                'expression': 'window.registrationPromise.then(r=>r.unregister())',
+                'awaitPromise': True,
+                'target': {
+                    'context': context_id
+                }
+            }
+        })
+    assert resp['type'] == 'success'
+    assert resp['result'] == {'type': 'boolean', 'value': True}

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -44,10 +44,18 @@ class LocalHttpServer:
     __path_basic_auth = "/401"
     __path_hang_forever = "/hang_forever"
     __path_cacheable = "/cacheable"
+    # __path_sw_page_bad_ssl = "/sw_bad_ssl.html"
+    # __path_empty_script = "/empty.js"
 
     __protocol: Literal['http', 'https']
 
     content_200: str = 'default 200 page'
+    content_200_page: str = 'default 200 page'
+
+    # def __content_sw_page_bad_ssl(self) -> str:
+    #     return f"""<script>
+    #       window.registrationPromise = navigator.serviceWorker.register('{self.url_empty_script(protocol='https')}');
+    #     </script>"""
 
     def clear(self):
         self.__http_server.clear()

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -183,16 +183,18 @@ class LocalHttpServer:
         """
         return self.__http_server.url_for(self.__path_base)
 
-    def url_200(self, content=None) -> str:
+    def url_200(self, content=None, content_type="text/html") -> str:
         """Returns the url for the 200 page with the `default_200_page_content`.
         """
         if content is not None:
             path = f"{self.__path_200}/{str(uuid.uuid4())}"
+            if content_type == "text/html":
+                content = self.__html_doc(content)
             self.__http_server \
                 .expect_request(path) \
                 .respond_with_data(
-                    self.__html_doc(content),
-                    headers={"Content-Type": "text/html"})
+                    content,
+                    headers={"Content-Type": content_type})
 
             return self.__http_server.url_for(path)
 


### PR DESCRIPTION
Addressing https://github.com/GoogleChromeLabs/chromium-bidi/issues/2357
* Fix the root cause.
* Add e2e.

Prerequisite: https://github.com/GoogleChromeLabs/chromium-bidi/pull/2368