### PR TITLE
fix: support for cookies in ContinueRequest

### DIFF
--- a/src/bidiMapper/modules/network/NetworkProcessor.ts
+++ b/src/bidiMapper/modules/network/NetworkProcessor.ts
@@ -88,8 +88,6 @@ export class NetworkProcessor {
       Network.InterceptPhase.BeforeRequestSent,
     ]);
 
-    // TODO: Set / expand.
-    // ; Step 9. cookies
     try {
       await request.continueRequest(params);
     } catch (error) {
@@ -111,8 +109,6 @@ export class NetworkProcessor {
       Network.InterceptPhase.ResponseStarted,
     ]);
 
-    // TODO: Set / expand.
-    // ; Step 10. cookies
     try {
       await request.continueResponse(params);
     } catch (error) {
@@ -162,8 +158,6 @@ export class NetworkProcessor {
       NetworkProcessor.validateHeaders(params.headers);
     }
 
-    // TODO: Set / expand.
-    // ; Step 10. cookies
     const request = this.#getBlockedRequestOrFail(params.request, [
       Network.InterceptPhase.BeforeRequestSent,
       Network.InterceptPhase.ResponseStarted,

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -173,7 +173,7 @@ export class NetworkRequest {
     return Boolean(this.#request.info);
   }
 
-  isDataUrl(): boolean {
+  #isDataUrl(): boolean {
     return this.url.startsWith('data:');
   }
 
@@ -219,7 +219,7 @@ export class NetworkRequest {
   }
 
   get #bodySize() {
-    let bodySize: number = 0;
+    let bodySize = 0;
     if (typeof this.#requestOverrides?.bodySize === 'number') {
       bodySize = this.#requestOverrides.bodySize;
     } else {
@@ -353,7 +353,7 @@ export class NetworkRequest {
       // Flush redirects
       options.wasRedirected ||
       options.hasFailed ||
-      this.isDataUrl() ||
+      this.#isDataUrl() ||
       Boolean(this.#request.extraInfo) ||
       // Requests from cache don't have extra info
       this.#servedFromCache ||
@@ -363,7 +363,7 @@ export class NetworkRequest {
 
     const noInterceptionExpected =
       // We can't intercept data urls from CDP
-      this.isDataUrl() ||
+      this.#isDataUrl() ||
       // Cached requests never hit the network
       this.#servedFromCache;
 
@@ -380,8 +380,7 @@ export class NetworkRequest {
       (requestInterceptionExpected
         ? requestInterceptionCompleted
         : requestExtraInfoCompleted)
-    ) {
-      this.#emitEvent(this.#getBeforeRequestEvent.bind(this));
+    ) {ODO.bind(this));
     }
 
     const responseExtraInfoCompleted =
@@ -695,8 +694,6 @@ export class NetworkRequest {
       return await this.#continueRequest();
     }
 
-    // TODO: Step 6
-    // https://w3c.github.io/webdriver-bidi/#command-network-continueResponse
     const overrideHeaders = this.#getOverrideHeader(
       overrides.headers,
       overrides.cookies

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -380,9 +380,9 @@ export class NetworkRequest {
       (requestInterceptionExpected
         ? requestInterceptionCompleted
         : requestExtraInfoCompleted)
-    ) {ODO.bind(this));
+    ) {
+      this.#emitEvent(this.#getBeforeRequestEvent.bind(this));
     }
-
     const responseExtraInfoCompleted =
       Boolean(this.#response.extraInfo) ||
       // Response from cache don't have extra info
@@ -906,7 +906,7 @@ export class NetworkRequest {
     cookies: Network.CookieHeader[] | undefined
   ): Network.Header[] | undefined {
     if (!headers && !cookies) {
-      return [];
+      return undefined;
     }
     let overrideHeaders: Network.Header[] | undefined = headers;
     const cookieHeader = networkHeaderFromCookieHeaders(cookies);

--- a/src/bidiMapper/modules/network/NetworkUtils.ts
+++ b/src/bidiMapper/modules/network/NetworkUtils.ts
@@ -115,6 +115,35 @@ export function cdpFetchHeadersFromBidiNetworkHeaders(
   }));
 }
 
+export function networkHeaderFromCookieHeaders(
+  headers?: Network.CookieHeader[]
+): Network.Header | undefined {
+  if (headers === undefined) {
+    return undefined;
+  }
+
+  const value = headers.reduce((acc, value, index) => {
+    if (index > 0) {
+      acc += ';';
+    }
+    const cookieValue =
+      value.value.type === 'base64'
+        ? btoa(value.value.value)
+        : value.value.value;
+    acc += `${value.name}=${cookieValue}`;
+
+    return acc;
+  }, '');
+
+  return {
+    name: 'Cookie',
+    value: {
+      type: 'string',
+      value,
+    },
+  };
+}
+
 /** Converts from Bidi auth action to CDP auth challenge response. */
 export function cdpAuthChallengeResponseFromBidiAuthContinueWithAuthAction(
   action: 'default' | 'cancel' | 'provideCredentials'


### PR DESCRIPTION
I still need to see why the data is not surfacing on the request correctly, but the feature should now work.
The WPT test will pass once we fix the `request->headers`.