### PR TITLE
test: custom content in local http server

### DIFF
--- a/tests/browsing_context/test_create.py
+++ b/tests/browsing_context/test_create.py
@@ -101,10 +101,10 @@ async def test_browsingContext_create_eventContextCreatedEmitted(
 async def test_browsingContext_createWithNestedSameOriginContexts_eventContextCreatedEmitted(
         websocket, context_id, html, iframe):
     nested_iframe = html('<h1>PAGE_WITHOUT_CHILD_IFRAMES</h1>')
-    intermediate_page = html('<h1>PAGE_WITH_1_CHILD_IFRAME</h1>' +
-                             iframe(nested_iframe.replace('"', '&quot;')))
-    top_level_page = html('<h1>PAGE_WITH_2_CHILD_IFRAMES</h1>' +
-                          iframe(intermediate_page.replace('"', '&quot;')))
+    intermediate_page = html(
+        f'<h1>PAGE_WITH_1_CHILD_IFRAME</h1>{iframe(nested_iframe)}')
+    top_level_page = html(
+        f'<h1>PAGE_WITH_2_CHILD_IFRAMES</h1>{iframe(intermediate_page)}')
 
     await subscribe(websocket, ["browsingContext.contextCreated"])
 

--- a/tests/browsing_context/test_get_tree.py
+++ b/tests/browsing_context/test_get_tree.py
@@ -62,55 +62,20 @@ async def test_browsingContext_getTreeWithRoot_contextReturned(websocket):
 
 
 @pytest.mark.asyncio
-async def test_browsingContext_afterNavigation_getTreeWithNestedCrossOriginContexts_contextsReturned(
-        websocket, context_id, html, iframe, url_example, url_another_example):
-    page_with_nested_iframe = html(iframe(url_example))
-    another_page_with_nested_iframe = html(iframe(url_another_example))
+async def test_browsingContext_afterNavigation_getTree_contextsReturned(
+        websocket, context_id, html, iframe, url_all_origins):
+    page_with_nested_iframe = html(iframe(url_all_origins))
+    another_page_with_nested_iframe = html(iframe(url_all_origins))
 
     await goto_url(websocket, context_id, page_with_nested_iframe, "complete")
-    await goto_url(websocket, context_id, another_page_with_nested_iframe,
-                   "complete")
 
     result = await get_tree(websocket)
-
     assert {
         "contexts": [{
             "context": context_id,
             "children": [{
                 "context": ANY_STR,
-                "url": url_another_example,
-                "children": [],
-                "userContext": "default",
-                "originalOpener": None
-            }],
-            "parent": None,
-            "url": another_page_with_nested_iframe,
-            "userContext": "default",
-            "originalOpener": None
-        }]
-    } == result
-
-
-@pytest.mark.asyncio
-async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_contextsReturned(
-        websocket, context_id, html, iframe):
-    nested_iframe = html('<h2>IFRAME</h2>')
-    another_nested_iframe = html('<h2>ANOTHER_IFRAME</h2>')
-    page_with_nested_iframe = html('<h1>MAIN_PAGE</h1>' +
-                                   iframe(nested_iframe))
-    another_page_with_nested_iframe = html('<h1>ANOTHER_MAIN_PAGE</h1>' +
-                                           iframe(another_nested_iframe))
-
-    await goto_url(websocket, context_id, page_with_nested_iframe, "complete")
-
-    result = await get_tree(websocket)
-
-    assert {
-        "contexts": [{
-            "context": context_id,
-            "children": [{
-                "context": ANY_STR,
-                "url": nested_iframe,
+                "url": url_all_origins,
                 "children": [],
                 "userContext": "default",
                 "originalOpener": None
@@ -131,7 +96,7 @@ async def test_browsingContext_afterNavigation_getTreeWithNestedContexts_context
             "context": context_id,
             "children": [{
                 "context": ANY_STR,
-                "url": another_nested_iframe,
+                "url": url_all_origins,
                 "children": [],
                 "userContext": "default",
                 "originalOpener": None

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -73,7 +73,7 @@ async def test_browsingContext_navigateWaitNone_navigated(
             "context": context_id,
             "navigation": navigation_id,
             "timestamp": ANY_TIMESTAMP,
-            "url": html("<h2>test</h2>")
+            "url": url
         }
     }
 
@@ -119,7 +119,7 @@ async def test_browsingContext_navigateWaitInteractive_navigated(
         "type": "success",
         "result": {
             "navigation": navigation_id,
-            "url": html("<h2>test</h2>")
+            "url": url
         }
     }
 
@@ -167,7 +167,7 @@ async def test_browsingContext_navigateWaitComplete_navigated(
             "context": context_id,
             "navigation": navigation_id,
             "timestamp": ANY_TIMESTAMP,
-            "url": html("<h2>test</h2>")
+            "url": url
         }
     }
 

--- a/tests/browsing_context/test_traverse_history.py
+++ b/tests/browsing_context/test_traverse_history.py
@@ -25,6 +25,7 @@ async def test_traverse_history(websocket, context_id):
     urls = []
     for i in range(HISTORY_LENGTH + 1):
         # TODO: use `html` fixture instead.
+        #  https://github.com/GoogleChromeLabs/chromium-bidi/issues/2376
         url = f'data:text/html,{i}'
         urls.append(url)
         await goto_url(websocket, context_id, url)

--- a/tests/browsing_context/test_traverse_history.py
+++ b/tests/browsing_context/test_traverse_history.py
@@ -21,28 +21,28 @@ HISTORY_LENGTH = 2
 
 
 @pytest.mark.asyncio
-async def test_traverse_history(websocket, context_id, html):
+async def test_traverse_history(websocket, context_id, html_data):
     for i in range(HISTORY_LENGTH + 1):
-        await goto_url(websocket, context_id, html(i))
+        await goto_url(websocket, context_id, html_data(i))
 
     await subscribe(websocket, ["browsingContext.load"])
 
     await traverse_history(websocket, context_id, -2)
-    await assert_href_equals(websocket, html(HISTORY_LENGTH - 2))
+    await assert_href_equals(websocket, html_data(HISTORY_LENGTH - 2))
 
     await traverse_history(websocket, context_id, 2)
-    await assert_href_equals(websocket, html(HISTORY_LENGTH))
+    await assert_href_equals(websocket, html_data(HISTORY_LENGTH))
 
     await traverse_history(websocket, context_id, -1)
-    await assert_href_equals(websocket, html(HISTORY_LENGTH - 1))
+    await assert_href_equals(websocket, html_data(HISTORY_LENGTH - 1))
 
     await traverse_history(websocket, context_id, 1)
-    await assert_href_equals(websocket, html(HISTORY_LENGTH))
+    await assert_href_equals(websocket, html_data(HISTORY_LENGTH))
 
     # There is no event here.
     await traverse_history(websocket, context_id, 0)
     await assert_location_href_equals(websocket, context_id,
-                                      html(HISTORY_LENGTH))
+                                      html_data(HISTORY_LENGTH))
 
 
 @pytest.mark.asyncio

--- a/tests/browsing_context/test_traverse_history.py
+++ b/tests/browsing_context/test_traverse_history.py
@@ -21,28 +21,32 @@ HISTORY_LENGTH = 2
 
 
 @pytest.mark.asyncio
-async def test_traverse_history(websocket, context_id, html_data):
+async def test_traverse_history(websocket, context_id):
+    urls = []
     for i in range(HISTORY_LENGTH + 1):
-        await goto_url(websocket, context_id, html_data(i))
+        # TODO: use `html` fixture instead.
+        url = f'data:text/html,{i}'
+        urls.append(url)
+        await goto_url(websocket, context_id, url)
 
     await subscribe(websocket, ["browsingContext.load"])
 
     await traverse_history(websocket, context_id, -2)
-    await assert_href_equals(websocket, html_data(HISTORY_LENGTH - 2))
+    await assert_href_equals(websocket, urls[HISTORY_LENGTH - 2])
 
     await traverse_history(websocket, context_id, 2)
-    await assert_href_equals(websocket, html_data(HISTORY_LENGTH))
+    await assert_href_equals(websocket, urls[HISTORY_LENGTH])
 
     await traverse_history(websocket, context_id, -1)
-    await assert_href_equals(websocket, html_data(HISTORY_LENGTH - 1))
+    await assert_href_equals(websocket, urls[HISTORY_LENGTH - 1])
 
     await traverse_history(websocket, context_id, 1)
-    await assert_href_equals(websocket, html_data(HISTORY_LENGTH))
+    await assert_href_equals(websocket, urls[HISTORY_LENGTH])
 
     # There is no event here.
     await traverse_history(websocket, context_id, 0)
     await assert_location_href_equals(websocket, context_id,
-                                      html_data(HISTORY_LENGTH))
+                                      urls[HISTORY_LENGTH])
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,6 +405,16 @@ def html(local_server_http):
     return html
 
 
+# TODO: replace with `html` fixture.
+@pytest.fixture
+def html_data():
+    """Return a factory for data html with the given content."""
+    def html_data(content=""):
+        return f'data:text/html,{content}'
+
+    return html_data
+
+
 @pytest.fixture
 def iframe():
     """Return a factory for <iframe> with the given src."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,10 +397,10 @@ def activate_main_tab(websocket, context_id, get_cdp_session_id):
 
 
 @pytest.fixture
-def html():
-    """Return a factory for HTML data URL with the given content."""
+def html(local_server_http):
+    """Return a factory for URL with the given content."""
     def html(content=""):
-        return f'data:text/html,{content}'
+        return local_server_http.url_200(content=content)
 
     return html
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,19 +224,14 @@ async def sandbox_realm(websocket, context_id: str):
     return result["realm"]
 
 
-@pytest.fixture
-def url_same_origin():
-    """Return a same-origin URL."""
-    return 'about:blank'
-
-
-@pytest.fixture(
-    params=['url_example', 'url_another_example', 'html', 'about:blank'])
-def url_all_origins(request, url_example, url_another_example, html):
+@pytest.fixture(params=[
+    'url_example', 'url_example_another_origin', 'html', 'about:blank'
+])
+def url_all_origins(request, url_example, url_example_another_origin, html):
     if request.param == 'url_example':
         return url_example
-    if request.param == 'url_another_example':
-        return url_another_example
+    if request.param == 'url_example_another_origin':
+        return url_example_another_origin
     if request.param == 'html':
         return html('data:text/html,<h2>some page</h2>')
     if request.param == 'about:blank':
@@ -257,7 +252,7 @@ def url_example(local_server_http):
 
 
 @pytest.fixture
-def url_another_example(local_server_http_another_host):
+def url_example_another_origin(local_server_http_another_host):
     """Return a generic example URL with status code 200, in a domain other than
     the example_url fixture."""
     return local_server_http_another_host.url_200()
@@ -430,17 +425,11 @@ def iframe():
     return iframe
 
 
-@pytest.fixture
-def html_iframe_same_origin(html, iframe, url_same_origin):
-    """Return a page URL with an iframe of the same origin."""
-    return html(iframe(url_same_origin))
-
-
 @pytest_asyncio.fixture
-async def iframe_id(websocket, context_id: str, html_iframe_same_origin, html):
+async def iframe_id(websocket, context_id, html, iframe):
     """Navigate to a page with an iframe of the same origin, and return the
     iframe browser context id."""
-    await goto_url(websocket, context_id, html_iframe_same_origin)
+    await goto_url(websocket, context_id, html(iframe(html("<h1>FRAME</h1>"))))
     result = await get_tree(websocket, context_id)
 
     iframe_id = result["contexts"][0]["children"][0]["context"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,16 +421,6 @@ def html(local_server_http):
     return html
 
 
-# TODO: replace with `html` fixture.
-@pytest.fixture
-def html_data():
-    """Return a factory for data html with the given content."""
-    def html_data(content=""):
-        return f'data:text/html,{content}'
-
-    return html_data
-
-
 @pytest.fixture
 def iframe():
     """Return a factory for <iframe> with the given src."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,24 @@ from tools.local_http_server import LocalHttpServer
 
 @pytest_asyncio.fixture(scope='session')
 def local_server_http() -> Generator[LocalHttpServer, None, None]:
-    """ Returns an instance of a LocalHttpServer without SSL. """
+    """
+    Returns an instance of a LocalHttpServer without SSL pointing to localhost.
+    """
     server = LocalHttpServer()
+    yield server
+
+    server.clear()
+    if server.is_running():
+        server.stop()
+        return
+
+
+@pytest_asyncio.fixture(scope='session')
+def local_server_http_another_host() -> Generator[LocalHttpServer, None, None]:
+    """
+    Returns an instance of a LocalHttpServer without SSL pointing to `127.0.0.1`
+    """
+    server = LocalHttpServer('127.0.0.1')
     yield server
 
     server.clear()
@@ -241,10 +257,10 @@ def url_example(local_server_http):
 
 
 @pytest.fixture
-def url_another_example(local_server_http):
+def url_another_example(local_server_http_another_host):
     """Return a generic example URL with status code 200, in a domain other than
     the example_url fixture."""
-    return local_server_http.url_200('127.0.0.1')
+    return local_server_http_another_host.url_200()
 
 
 @pytest.fixture

--- a/tests/log/test_log_entry_added.py
+++ b/tests/log/test_log_entry_added.py
@@ -327,11 +327,12 @@ async def test_exceptionThrown_logEntryAddedEventEmitted(
         websocket, context_id, html):
     await subscribe(websocket, ["log.entryAdded"])
 
+    url = html("<script>throw new Error('some error')</script>")
     await send_JSON_command(
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "url": html("<script>throw new Error('some error')</script>"),
+                "url": url,
                 "wait": "interactive",
                 "context": context_id
             }
@@ -353,10 +354,12 @@ async def test_exceptionThrown_logEntryAddedEventEmitted(
             "timestamp": ANY_TIMESTAMP,
             "stackTrace": {
                 "callFrames": [{
-                    "url": "",
+                    "url": url,
                     "functionName": "",
                     "lineNumber": 0,
-                    "columnNumber": 14
+                    # Column number is a magical constant. It depends on the
+                    # html fixture wrapping content in document tag.
+                    "columnNumber": 127
                 }]
             },
             # ConsoleLogEntry

--- a/tests/network/test_remove_intercept.py
+++ b/tests/network/test_remove_intercept.py
@@ -220,7 +220,7 @@ async def test_remove_intercept_unblocks(websocket, context_id,
 @pytest.mark.asyncio
 async def test_remove_intercept_does_not_affect_another_intercept(
         websocket, context_id, another_context_id, url_example,
-        url_another_example):
+        url_example_another_origin):
     await subscribe(websocket, ["network.beforeRequestSent"])
 
     result = await execute_command(
@@ -246,7 +246,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
                 "phases": ["beforeRequestSent"],
                 "urlPatterns": [{
                     "type": "string",
-                    "pattern": url_another_example,
+                    "pattern": url_example_another_origin,
                 }, ]
             },
         })
@@ -293,7 +293,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "url": url_another_example,
+                "url": url_example_another_origin,
                 "context": another_context_id,
                 "wait": "complete",
             }
@@ -313,7 +313,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
             "redirectCount": 0,
             "request": {
                 "request": ANY_STR,
-                "url": url_another_example,
+                "url": url_example_another_origin,
                 "method": "GET",
                 "headers": ANY_LIST,
                 "cookies": [],
@@ -362,7 +362,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
                     "headers": ANY_LIST,
                     "method": "GET",
                     "request": network_id_2,
-                    "url": url_another_example,
+                    "url": url_example_another_origin,
                 }, ),
             "timestamp": ANY_TIMESTAMP,
         },

--- a/tests/script/test_realm.py
+++ b/tests/script/test_realm.py
@@ -21,7 +21,8 @@ from test_helpers import (execute_command, read_JSON_message,
 
 
 @pytest.mark.asyncio
-async def test_realm_realmCreated(websocket, context_id, html):
+async def test_realm_realmCreated(websocket, context_id, html,
+                                  local_server_http):
     url = html()
 
     await subscribe(websocket, ["script.realmCreated"])
@@ -43,7 +44,7 @@ async def test_realm_realmCreated(websocket, context_id, html):
         "method": "script.realmCreated",
         "params": {
             "type": "window",
-            "origin": "null",
+            "origin": local_server_http.origin(),
             "realm": ANY_STR,
             "context": context_id,
         }

--- a/tests/session/test_subscription.py
+++ b/tests/session/test_subscription.py
@@ -100,7 +100,7 @@ async def test_subscribeWithContext_subscribesToEventsInGivenContext(
 
 @pytest.mark.asyncio
 async def test_subscribeWithContext_subscribesToEventsInNestedContext(
-        websocket, context_id, html_iframe_same_origin, url_same_origin):
+        websocket, context_id, html, iframe, url_all_origins):
     await subscribe(websocket, ["browsingContext.contextCreated"])
 
     # Navigate to some page.
@@ -108,7 +108,7 @@ async def test_subscribeWithContext_subscribesToEventsInNestedContext(
         websocket, {
             "method": "browsingContext.navigate",
             "params": {
-                "url": html_iframe_same_origin,
+                "url": html(iframe(url_all_origins)),
                 "wait": "complete",
                 "context": context_id
             }
@@ -121,7 +121,9 @@ async def test_subscribeWithContext_subscribesToEventsInNestedContext(
         "method": "browsingContext.contextCreated",
         "params": {
             "context": ANY_STR,
-            "url": url_same_origin,
+            # The `url` is always `about:blank`, as the navigation has not
+            # happened yet. https://github.com/w3c/webdriver-bidi/issues/220.
+            "url": "about:blank",
             "children": None,
             "parent": context_id,
             "userContext": "default",

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -183,13 +183,18 @@ class LocalHttpServer:
         :param host: the host to use in the url. Default is ``localhost``.
         :return: the full url which refers to the server
         """
-        if not suffix.startswith("/"):
+        if not suffix.startswith("/") and suffix != "":
             suffix = "/" + suffix
 
         host = self.__http_server.format_host(host)
 
         return "{}://{}:{}{}".format(self.__protocol, host,
                                      self.__http_server.port, suffix)
+
+    def origin(self) -> str:
+        """Returns the url for the base page to navigate and prevent CORS.
+        """
+        return self._url_for("")
 
     def url_base(self, host='localhost') -> str:
         """Returns the url for the base page to navigate and prevent CORS.

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -46,7 +46,6 @@ class LocalHttpServer:
     __path_cacheable = "/cacheable"
 
     __protocol: Literal['http', 'https']
-    __content_map: dict[str, str] = {}
 
     content_200: str = 'default 200 page'
 

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -14,7 +14,6 @@
 #  limitations under the License.
 
 import base64
-import re
 import ssl
 import uuid
 from datetime import datetime
@@ -27,8 +26,12 @@ from werkzeug.wrappers import Request, Response
 
 
 class LocalHttpServer:
-    """A wrapper of `pytest_httpserver.httpserver` to simplify the usage. Sets
-    up common use cases and provides url for them."""
+    """
+    A wrapper of `pytest_httpserver.httpserver` to simplify the usage. Sets up
+    common use cases and provides url for them.
+    NOTE: the server does not support concurrent requests to different origins.
+    If needed, use a instance of the server per origin.
+    """
 
     __http_server: HTTPServer
 
@@ -57,7 +60,12 @@ class LocalHttpServer:
         self.hang_forever_stop()
         self.__http_server.stop()
 
-    def __init__(self, protocol: Literal['http', 'https'] = 'http') -> None:
+    def __html_doc(self, content):
+        return f"<!DOCTYPE html><html><head><link rel='shortcut icon' href='data:image/x-icon;,' type='image/x-icon'></head><body>{content}</body></html>"
+
+    def __init__(self,
+                 host: str = 'localhost',
+                 protocol: Literal['http', 'https'] = 'http') -> None:
         super().__init__()
 
         self.__protocol = protocol
@@ -71,20 +79,17 @@ class LocalHttpServer:
         elif protocol != 'http':
             raise ValueError(f"Unsupported protocol: {protocol}")
 
-        self.__http_server = HTTPServer(ssl_context=ssl_context)
+        self.__http_server = HTTPServer(host=host, ssl_context=ssl_context)
 
         self.__http_server.start()
         self.__http_server.clear()
 
         self.__start_time = datetime.now()
 
-        def html_doc(content):
-            return f"<!DOCTYPE html><html><head><link rel='shortcut icon' href='data:image/x-icon;,' type='image/x-icon'></head><body>{content}</body></html>"
-
         self.__http_server \
             .expect_request(self.__path_base) \
             .respond_with_data(
-                html_doc("I prevent CORS"),
+                self.__html_doc("I prevent CORS"),
                 headers={"Content-Type": "text/html"})
 
         self.__http_server \
@@ -93,22 +98,11 @@ class LocalHttpServer:
                 "",
                 headers={"Content-Type": "image/x-icon"})
 
-        def custom_content_handler(request: Request):
-            content_id = request.path.split(self.__path_200 + "/")[1]
-            if self.__content_map.get(content_id) is not None:
-                return Response(html_doc(self.__content_map[content_id]),
-                                200,
-                                content_type="text/html")
-            return Response('not found', 404, content_type="text/html")
-
-        self.__http_server.expect_request(
-            re.compile("/200/.+")).respond_with_handler(custom_content_handler)
-
         # Set up 200 page.
         self.__http_server \
             .expect_request(self.__path_200) \
             .respond_with_data(
-                html_doc(self.content_200),
+                self.__html_doc(self.content_200),
                 headers={"Content-Type": "text/html"})
 
         # Set up permanent redirect.
@@ -149,7 +143,7 @@ class LocalHttpServer:
             .respond_with_handler(hang_forever)
 
         def cache(request: Request):
-            content = html_doc(self.content_200)
+            content = self.__html_doc(self.content_200)
             if_modified_since = request.headers.get("If-Modified-Since")
 
             if if_modified_since is not None:
@@ -172,58 +166,44 @@ class LocalHttpServer:
         if self.hang_forever_stop_flag is not None:
             self.hang_forever_stop_flag.set()
 
-    def _url_for(self, suffix: str, host: str = 'localhost') -> str:
-        """
-        Return an url for a given suffix.
-
-        Implementation is the same as the original one, but with a customizable
-        host: https://github.com/csernazs/pytest-httpserver/blob/8110d9d543de3b7c151bc1b5c8e85c01b05b226d/pytest_httpserver/httpserver.py#L665
-        :param suffix: the suffix which will be added to the base url. It can
-            start with ``/`` (slash) or not, the url will be the same.
-        :param host: the host to use in the url. Default is ``localhost``.
-        :return: the full url which refers to the server
-        """
-        if not suffix.startswith("/") and suffix != "":
-            suffix = "/" + suffix
-
-        host = self.__http_server.format_host(host)
-
-        return "{}://{}:{}{}".format(self.__protocol, host,
-                                     self.__http_server.port, suffix)
-
     def origin(self) -> str:
         """Returns the url for the base page to navigate and prevent CORS.
         """
-        return self._url_for("")
+        return self.url_base()[:-1]
 
-    def url_base(self, host='localhost') -> str:
+    def url_base(self) -> str:
         """Returns the url for the base page to navigate and prevent CORS.
         """
-        return self._url_for(self.__path_base, host)
+        return self.__http_server.url_for(self.__path_base)
 
-    def url_200(self, host='localhost', content=None) -> str:
+    def url_200(self, content=None) -> str:
         """Returns the url for the 200 page with the `default_200_page_content`.
         """
         if content is not None:
-            content_id = str(uuid.uuid4())
-            self.__content_map[content_id] = content
-            return self._url_for(f"{self.__path_200}/{content_id}", host)
+            path = f"{self.__path_200}/{str(uuid.uuid4())}"
+            self.__http_server \
+                .expect_request(path) \
+                .respond_with_data(
+                    self.__html_doc(content),
+                    headers={"Content-Type": "text/html"})
 
-        return self._url_for(self.__path_200, host)
+            return self.__http_server.url_for(path)
+
+        return self.__http_server.url_for(self.__path_200)
 
     def url_permanent_redirect(self) -> str:
         """Returns the url for the permanent redirect page, redirecting to the
         200 page."""
-        return self._url_for(self.__path_permanent_redirect)
+        return self.__http_server.url_for(self.__path_permanent_redirect)
 
     def url_basic_auth(self) -> str:
         """Returns the url for the page with a basic auth."""
-        return self._url_for(self.__path_basic_auth)
+        return self.__http_server.url_for(self.__path_basic_auth)
 
     def url_hang_forever(self) -> str:
         """Returns the url for the page, request to which will never be finished."""
-        return self._url_for(self.__path_hang_forever)
+        return self.__http_server.url_for(self.__path_hang_forever)
 
-    def url_cacheable(self, host='localhost') -> str:
+    def url_cacheable(self) -> str:
         """Returns the url for the cacheable page with the `default_200_page_content`."""
-        return self._url_for(self.__path_cacheable, host)
+        return self.__http_server.url_for(self.__path_cacheable)

--- a/tests/tools/test_local_http_server.py
+++ b/tests/tools/test_local_http_server.py
@@ -51,6 +51,14 @@ async def test_local_server_200(websocket, context_id, local_server_http):
 
 
 @pytest.mark.asyncio
+async def test_local_server_custom_content(websocket, context_id,
+                                           local_server_http):
+    some_custom_content = 'some custom content'
+    assert await get_content(websocket, context_id, local_server_http.url_200(content=some_custom_content)) \
+           == some_custom_content
+
+
+@pytest.mark.asyncio
 async def test_local_server_redirect(websocket, context_id, local_server_http):
     assert await get_content(websocket, context_id,
                              local_server_http.url_permanent_redirect()) \

--- a/tools/run_local_http_server.py
+++ b/tools/run_local_http_server.py
@@ -28,6 +28,7 @@ local_server_bad_ssl = local_http_server.LocalHttpServer(protocol='https')
 
 print(f"""Local http server started...
   - 200: {local_server_http.url_200()}
+  - custom content: {local_server_http.url_200(content='<h1>some custom content</h1>')}
   - 301 / permanent redirect: {local_server_http.url_permanent_redirect()}
   - 401 / basic auth: {local_server_http.url_basic_auth()}
   - hangs forever: {local_server_http.url_hang_forever()}

--- a/tools/run_local_http_server.py
+++ b/tools/run_local_http_server.py
@@ -24,11 +24,13 @@ sys.path.append(str(Path(__file__).resolve().parent.parent / 'tests/tools/'))
 import local_http_server  # noqa: E402
 
 local_server_http = local_http_server.LocalHttpServer()
+local_server_http_another_origin = local_http_server.LocalHttpServer(
+    host='127.0.0.1')
 local_server_bad_ssl = local_http_server.LocalHttpServer(protocol='https')
 
 print(f"""Local http server started...
   - 200: {local_server_http.url_200()}
-  - custom content: {local_server_http.url_200(content='<h1>some custom content</h1>')}
+  - oopif: {local_server_http.url_200(content='<iframe src='+local_server_http_another_origin.url_200()+'></iframe>')}
   - 301 / permanent redirect: {local_server_http.url_permanent_redirect()}
   - 401 / basic auth: {local_server_http.url_basic_auth()}
   - hangs forever: {local_server_http.url_hang_forever()}


### PR DESCRIPTION
* Add possibility to provide a URL with a custom content.
* Remove `data:text/html` fixture
* Address concurrency issue in local http server by adding several instances.
