### PR TITLE
chore: support string `unhandledPromptBehavior` in NodeJS runner

### DIFF
--- a/tests/browsing_context/test_user_prompt.py
+++ b/tests/browsing_context/test_user_prompt.py
@@ -19,6 +19,10 @@ from test_helpers import send_JSON_command, subscribe, wait_for_event
 @pytest.mark.asyncio
 @pytest.mark.parametrize("prompt_type", ["alert", "confirm", "prompt"])
 @pytest.mark.parametrize('capabilities', [{}, {
+    'unhandledPromptBehavior': 'dismiss'
+}, {
+    'unhandledPromptBehavior': 'dismiss and notify'
+}, {
     'unhandledPromptBehavior': {
         'default': 'dismiss'
     }
@@ -38,6 +42,10 @@ from test_helpers import send_JSON_command, subscribe, wait_for_event
         'default': 'ignore'
     }
 }, {
+    'unhandledPromptBehavior': 'accept'
+}, {
+    'unhandledPromptBehavior': 'accept and notify'
+}, {
     'unhandledPromptBehavior': {
         'default': 'accept'
     }
@@ -56,6 +64,8 @@ from test_helpers import send_JSON_command, subscribe, wait_for_event
         'prompt': 'accept',
         'default': 'ignore'
     }
+}, {
+    'unhandledPromptBehavior': 'ignore'
 }, {
     'unhandledPromptBehavior': {
         'default': 'ignore'
@@ -102,7 +112,10 @@ async def test_browsingContext_userPromptOpened_userPromptClosed(
 
     expected_handler = 'dismiss'
     if 'unhandledPromptBehavior' in capabilities:
-        if prompt_type in capabilities['unhandledPromptBehavior']:
+        if isinstance(capabilities['unhandledPromptBehavior'], str):
+            expected_handler = capabilities['unhandledPromptBehavior'].replace(
+                ' and notify', '')
+        elif prompt_type in capabilities['unhandledPromptBehavior']:
             expected_handler = capabilities['unhandledPromptBehavior'][
                 prompt_type]
         elif 'default' in capabilities['unhandledPromptBehavior']:

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/user_prompt_opened/handler.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/user_prompt_opened/handler.py.ini
@@ -1,9 +1,0 @@
-[handler.py]
-  [test_accept[capabilities0\]]
-    expected: FAIL
-
-  [test_accept_and_notify[capabilities0\]]
-    expected: FAIL
-
-  [test_ignore[capabilities0\]]
-    expected: FAIL


### PR DESCRIPTION
Respect string value in `unhandledPromptBehavior`. Required to test backward compatibility with WebDriver Classic.