### PR TITLE
feat: include vendor-prefixed security details

### DIFF
--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -818,6 +818,8 @@ export class NetworkRequest {
         size: 0,
       },
       ...(authChallenges ? {authChallenges} : {}),
+      // @ts-expect-error this is a CDP-specific extension.
+      'goog:securityDetails': this.#response.info?.securityDetails,
     };
   }
 


### PR DESCRIPTION
This PR adds vendor-prefixed security details to support Puppeteer use case until an alternative is part of the standard. The testing is planned via Puppeteer test suite.