### PR TITLE
feat: include vendor-prefixed additional request data

### DIFF
--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -835,6 +835,10 @@ export class NetworkRequest {
       headersSize: computeHeadersSize(headers),
       bodySize: this.#bodySize,
       timings: this.#timings,
+      // @ts-expect-error CDP-specific attribute.
+      'goog:postData': this.#request.info?.request?.postData,
+      'goog:hasPostData': this.#request.info?.request?.hasPostData,
+      'goog:resourceType': this.#request.info?.type,
     };
   }
 

--- a/tests/network/test_add_intercept.py
+++ b/tests/network/test_add_intercept.py
@@ -16,8 +16,9 @@ import re
 
 import pytest
 from anys import ANY_DICT, ANY_LIST, ANY_NUMBER, ANY_STR
-from test_helpers import (ANY_TIMESTAMP, ANY_UUID, execute_command,
-                          send_JSON_command, subscribe, wait_for_event)
+from test_helpers import (ANY_TIMESTAMP, ANY_UUID, AnyExtending,
+                          execute_command, send_JSON_command, subscribe,
+                          wait_for_event)
 
 
 @pytest.mark.asyncio
@@ -306,7 +307,7 @@ async def test_add_intercept_blocks(
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "intercepts": [result["intercept"]],
@@ -330,4 +331,4 @@ async def test_add_intercept_blocks(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })

--- a/tests/network/test_continue_request.py
+++ b/tests/network/test_continue_request.py
@@ -14,9 +14,9 @@
 #  limitations under the License.
 import pytest
 from anys import ANY_DICT, ANY_LIST, ANY_NUMBER, ANY_STR
-from test_helpers import (ANY_TIMESTAMP, ANY_UUID, create_request_via_fetch,
-                          execute_command, goto_url, send_JSON_command,
-                          subscribe, wait_for_event)
+from test_helpers import (ANY_TIMESTAMP, ANY_UUID, AnyExtending,
+                          create_request_via_fetch, execute_command, goto_url,
+                          send_JSON_command, subscribe, wait_for_event)
 
 from . import create_blocked_request
 
@@ -182,7 +182,7 @@ async def test_continue_request_completes(websocket, context_id, url_example):
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -207,7 +207,7 @@ async def test_continue_request_completes(websocket, context_id, url_example):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await execute_command(
@@ -266,7 +266,7 @@ async def test_continue_request_twice(websocket, context_id, url_example):
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -290,7 +290,7 @@ async def test_continue_request_twice(websocket, context_id, url_example):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await execute_command(
@@ -353,7 +353,7 @@ async def test_continue_request_remove_intercept_inflight_request(
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -377,7 +377,7 @@ async def test_continue_request_remove_intercept_inflight_request(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
 
     result = await execute_command(
         websocket, {

--- a/tests/network/test_continue_response.py
+++ b/tests/network/test_continue_response.py
@@ -385,7 +385,7 @@ async def test_continue_response_twice(websocket, context_id, url_example):
         })
 
     event_response = await wait_for_event(websocket, "network.responseStarted")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.responseStarted",
         "params": {
             "context": context_id,
@@ -407,7 +407,7 @@ async def test_continue_response_twice(websocket, context_id, url_example):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await execute_command(

--- a/tests/network/test_continue_with_auth.py
+++ b/tests/network/test_continue_with_auth.py
@@ -14,8 +14,9 @@
 #  limitations under the License.
 import pytest
 from anys import ANY_DICT, ANY_LIST, ANY_NUMBER, ANY_STR
-from test_helpers import (ANY_TIMESTAMP, ANY_UUID, execute_command, goto_url,
-                          send_JSON_command, subscribe, wait_for_event)
+from test_helpers import (ANY_TIMESTAMP, ANY_UUID, AnyExtending,
+                          execute_command, goto_url, send_JSON_command,
+                          subscribe, wait_for_event)
 
 from . import create_blocked_request
 
@@ -175,7 +176,7 @@ async def test_continue_with_auth_completes(websocket, context_id,
         })
 
     event_response = await wait_for_event(websocket, "network.authRequired")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.authRequired",
         "params": {
             "context": context_id,
@@ -197,7 +198,7 @@ async def test_continue_with_auth_completes(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await execute_command(
@@ -256,7 +257,7 @@ async def test_continue_with_auth_twice(websocket, context_id,
         })
 
     event_response = await wait_for_event(websocket, "network.authRequired")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.authRequired",
         "params": {
             "context": context_id,
@@ -278,7 +279,7 @@ async def test_continue_with_auth_twice(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await execute_command(

--- a/tests/network/test_fail_request.py
+++ b/tests/network/test_fail_request.py
@@ -114,7 +114,7 @@ async def test_fail_request_twice(websocket, context_id, url_example):
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -138,7 +138,7 @@ async def test_fail_request_twice(websocket, context_id, url_example):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     result = await execute_command(websocket, {
@@ -220,7 +220,7 @@ async def test_fail_request_completes(websocket, context_id, url_example):
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -244,7 +244,7 @@ async def test_fail_request_completes(websocket, context_id, url_example):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await subscribe(websocket, ["network.fetchError"])
@@ -331,7 +331,7 @@ async def test_fail_request_completes_new_request_still_blocks(
 
     event_response2 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response2 == {
+    assert event_response2 == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -356,7 +356,7 @@ async def test_fail_request_completes_new_request_still_blocks(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id_2 = event_response2["params"]["request"]["request"]
 
     # The second request should have a different ID.
@@ -397,7 +397,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
 
     event_response1 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response1 == {
+    assert event_response1 == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -421,7 +421,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id_1 = event_response1["params"]["request"]["request"]
 
     # Navigation in second context.
@@ -437,7 +437,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
 
     event_response2 = await wait_for_event(websocket,
                                            "network.beforeRequestSent")
-    assert event_response2 == {
+    assert event_response2 == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": another_context_id,
@@ -461,7 +461,7 @@ async def test_fail_request_multiple_contexts(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id_2 = event_response2["params"]["request"]["request"]
 
     assert network_id_1 != network_id_2
@@ -563,7 +563,7 @@ async def test_fail_request_remove_intercept_inflight_request(
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -587,7 +587,7 @@ async def test_fail_request_remove_intercept_inflight_request(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     result = await execute_command(

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -43,7 +43,7 @@ async def test_network_before_request_sent_event_emitted(
 
     resp = await read_JSON_message(websocket)
 
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.beforeRequestSent",
         "params": {
@@ -66,7 +66,7 @@ async def test_network_before_request_sent_event_emitted(
             },
             "timestamp": ANY_TIMESTAMP
         }
-    }
+    })
     navigation_id = resp["params"]["navigation"]
 
     resp = await read_JSON_message(websocket)
@@ -100,7 +100,7 @@ async def test_network_before_request_sent_event_emitted_with_url_fragment(
 
     resp = await read_JSON_message(websocket)
 
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.beforeRequestSent",
         "params": {
@@ -123,7 +123,7 @@ async def test_network_before_request_sent_event_emitted_with_url_fragment(
             },
             "timestamp": ANY_TIMESTAMP
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -187,7 +187,7 @@ async def test_network_before_request_sent_event_with_cookies_emitted(
         })
 
     resp = await read_JSON_message(websocket)
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.beforeRequestSent",
         "params": {
@@ -224,7 +224,7 @@ async def test_network_before_request_sent_event_with_cookies_emitted(
             },
             "timestamp": ANY_TIMESTAMP
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -246,7 +246,7 @@ async def test_network_response_completed_event_emitted(
     headersSize = compute_response_headers_size(
         resp["params"]["response"]["headers"])
 
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.responseCompleted",
         "params": {
@@ -281,7 +281,7 @@ async def test_network_response_completed_event_emitted(
                 }
             }
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -303,7 +303,7 @@ async def test_network_response_started_event_emitted(websocket, context_id,
     headersSize = compute_response_headers_size(
         resp["params"]["response"]["headers"])
 
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.responseStarted",
         "params": {
@@ -338,7 +338,7 @@ async def test_network_response_started_event_emitted(websocket, context_id,
                 }
             }
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -356,7 +356,7 @@ async def test_network_bad_ssl(websocket, context_id, url_bad_ssl):
         })
 
     resp = await read_JSON_message(websocket)
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.fetchError",
         "params": {
@@ -377,7 +377,7 @@ async def test_network_bad_ssl(websocket, context_id, url_bad_ssl):
             "timestamp": ANY_TIMESTAMP,
             "errorText": "net::ERR_CERT_AUTHORITY_INVALID"
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -395,7 +395,7 @@ async def test_network_before_request_sent_event_with_data_url_emitted(
             }
         })
     resp = await read_JSON_message(websocket)
-    assert resp == {
+    assert resp == AnyExtending({
         'type': 'event',
         "method": "network.beforeRequestSent",
         "params": {
@@ -418,7 +418,7 @@ async def test_network_before_request_sent_event_with_data_url_emitted(
             },
             "timestamp": ANY_TIMESTAMP
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -483,7 +483,7 @@ async def test_network_sends_only_included_cookies(websocket, context_id,
         })
 
     response = await wait_for_event(websocket, "network.beforeRequestSent")
-    assert response == {
+    assert response == AnyExtending({
         'type': 'event',
         "method": "network.beforeRequestSent",
         "params": {
@@ -506,7 +506,7 @@ async def test_network_sends_only_included_cookies(websocket, context_id,
             },
             "timestamp": ANY_TIMESTAMP
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -530,7 +530,7 @@ async def test_network_should_not_block_queue_shared_workers_with_data_url(
         })
 
     response = await wait_for_event(websocket, 'network.beforeRequestSent')
-    assert response == {
+    assert response == AnyExtending({
         'type': 'event',
         "method": "network.beforeRequestSent",
         "params": {
@@ -553,4 +553,4 @@ async def test_network_should_not_block_queue_shared_workers_with_data_url(
             },
             "timestamp": ANY_TIMESTAMP
         }
-    }
+    })

--- a/tests/network/test_provide_response.py
+++ b/tests/network/test_provide_response.py
@@ -337,7 +337,7 @@ async def test_provide_response_twice(websocket, context_id, url_example):
         })
 
     event_response = await wait_for_event(websocket, "network.responseStarted")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.responseStarted",
         "params": {
             "context": context_id,
@@ -359,7 +359,7 @@ async def test_provide_response_twice(websocket, context_id, url_example):
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id = event_response["params"]["request"]["request"]
 
     await execute_command(

--- a/tests/network/test_remove_intercept.py
+++ b/tests/network/test_remove_intercept.py
@@ -144,7 +144,7 @@ async def test_remove_intercept_unblocks(websocket, context_id,
 
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -168,7 +168,7 @@ async def test_remove_intercept_unblocks(websocket, context_id,
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
 
     result = await execute_command(
         websocket, {
@@ -193,7 +193,7 @@ async def test_remove_intercept_unblocks(websocket, context_id,
     # Network events should complete.
     event_response = await wait_for_event(websocket,
                                           "network.responseCompleted")
-    assert event_response == {
+    assert event_response == AnyExtending({
         'type': 'event',
         "method": "network.responseCompleted",
         "params": {
@@ -214,7 +214,7 @@ async def test_remove_intercept_unblocks(websocket, context_id,
             "response": ANY_DICT,
             "timestamp": ANY_TIMESTAMP,
         }
-    }
+    })
 
 
 @pytest.mark.asyncio
@@ -263,7 +263,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
         })
     event_response = await wait_for_event(websocket,
                                           "network.beforeRequestSent")
-    assert event_response == {
+    assert event_response == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": context_id,
@@ -287,7 +287,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
 
     await send_JSON_command(
         websocket, {
@@ -300,7 +300,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
         })
     event_response_2 = await wait_for_event(websocket,
                                             "network.beforeRequestSent")
-    assert event_response_2 == {
+    assert event_response_2 == AnyExtending({
         "method": "network.beforeRequestSent",
         "params": {
             "context": another_context_id,
@@ -324,7 +324,7 @@ async def test_remove_intercept_does_not_affect_another_intercept(
             "timestamp": ANY_TIMESTAMP,
         },
         "type": "event",
-    }
+    })
     network_id_2 = event_response_2["params"]["request"]["request"]
 
     result = await execute_command(


### PR DESCRIPTION
- 'goog:postData'
- 'goog:hasPostData'
- 'goog:resourceType'

The testing is planned via Puppeteer.