### PR TITLE
chore: run pre-commit hooks before push, not before commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@
 #
 # Apply all pre-commit hooks to all files:
 #   $ pre-commit run --all-files
+default_stages: [pre-push, manual]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
Required to ease iterative development process. Partly reverts https://github.com/GoogleChromeLabs/chromium-bidi/commit/0cde2e4def56db9cddc17feaa36c199731b14c2e