### PR TITLE
feat: implement capabilities handling in session.new

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -30,6 +30,7 @@ import type {Result} from '../utils/result.js';
 
 import {BidiNoOpParser} from './BidiNoOpParser.js';
 import type {BidiCommandParameterParser} from './BidiParser.js';
+import type {MapperOptions} from './BidiServer.js';
 import {BrowserProcessor} from './modules/browser/BrowserProcessor.js';
 import {CdpProcessor} from './modules/cdp/CdpProcessor.js';
 import {BrowsingContextProcessor} from './modules/context/BrowsingContextProcessor.js';
@@ -82,6 +83,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
     preloadScriptStorage: PreloadScriptStorage,
     networkStorage: NetworkStorage,
     parser: BidiCommandParameterParser = new BidiNoOpParser(),
+    initConnection: (options: MapperOptions) => Promise<void>,
     logger?: LoggerFn
   ) {
     super();
@@ -118,7 +120,8 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
     );
     this.#sessionProcessor = new SessionProcessor(
       eventManager,
-      browserCdpClient
+      browserCdpClient,
+      initConnection
     );
     this.#storageProcessor = new StorageProcessor(
       browserCdpClient,

--- a/src/bidiMapper/modules/session/SessionProcessor.ts
+++ b/src/bidiMapper/modules/session/SessionProcessor.ts
@@ -17,38 +17,97 @@
 
 import type {CdpClient} from '../../../cdp/CdpClient.js';
 import type {BidiPlusChannel} from '../../../protocol/chromium-bidi.js';
-import type {
-  ChromiumBidi,
-  EmptyResult,
+import {
+  InvalidArgumentException,
   Session,
+  type ChromiumBidi,
+  type EmptyResult,
 } from '../../../protocol/protocol.js';
+import type {MapperOptions} from '../../BidiServer.js';
 
 import type {EventManager} from './EventManager.js';
 
 export class SessionProcessor {
   #eventManager: EventManager;
   #browserCdpClient: CdpClient;
+  #initConnection: (opts: MapperOptions) => Promise<void>;
+  #created = false;
 
-  constructor(eventManager: EventManager, browserCdpClient: CdpClient) {
+  constructor(
+    eventManager: EventManager,
+    browserCdpClient: CdpClient,
+    initConnection: (opts: MapperOptions) => Promise<void>
+  ) {
     this.#eventManager = eventManager;
     this.#browserCdpClient = browserCdpClient;
+    this.#initConnection = initConnection;
   }
 
   status(): Session.StatusResult {
     return {ready: false, message: 'already connected'};
   }
 
-  async new(_params: Session.NewParameters): Promise<Session.NewResult> {
+  #getMapperOptions(capabilities: any): MapperOptions {
+    const acceptInsecureCerts =
+      capabilities?.alwaysMatch?.acceptInsecureCerts ?? false;
+    const unhandledPromptBehavior = this.#getUnhandledPromptBehavior(
+      capabilities?.alwaysMatch?.unhandledPromptBehavior
+    );
+
+    return {acceptInsecureCerts, unhandledPromptBehavior};
+  }
+
+  #getUnhandledPromptBehavior(
+    capabilityValue: unknown
+  ): Session.UserPromptHandler | undefined {
+    if (capabilityValue === undefined) {
+      return undefined;
+    }
+    if (typeof capabilityValue === 'object') {
+      // Do not validate capabilities. Incorrect ones will be ignored by Mapper.
+      return capabilityValue as Session.UserPromptHandler;
+    }
+    if (typeof capabilityValue !== 'string') {
+      throw new InvalidArgumentException(
+        `Unexpected 'unhandledPromptBehavior' type: ${typeof capabilityValue}`
+      );
+    }
+    switch (capabilityValue) {
+      case 'accept':
+      case 'accept and notify':
+        return {default: Session.UserPromptHandlerType.Accept};
+      case 'dismiss':
+      case 'dismiss and notify':
+        return {default: Session.UserPromptHandlerType.Dismiss};
+      case 'ignore':
+        return {default: Session.UserPromptHandlerType.Ignore};
+      default:
+        throw new InvalidArgumentException(
+          `Unexpected 'unhandledPromptBehavior' value: ${capabilityValue}`
+        );
+    }
+  }
+
+  async new(params: Session.NewParameters): Promise<Session.NewResult> {
+    if (this.#created) {
+      throw new Error('Session has been already created.');
+    }
+    this.#created = true;
     // Since mapper exists, there is a session already.
     // Still the mapper can handle capabilities for us.
     // Currently, only Puppeteer calls here but, eventually, every client
     // should delegrate capability processing here.
+    await this.#initConnection(this.#getMapperOptions(params.capabilities));
+
     const version =
       await this.#browserCdpClient.sendCommand('Browser.getVersion');
+
     return {
       sessionId: 'unknown',
       capabilities: {
-        acceptInsecureCerts: false,
+        acceptInsecureCerts: Boolean(
+          params.capabilities.alwaysMatch?.acceptInsecureCerts
+        ),
         browserName: version.product,
         browserVersion: version.revision,
         platformName: '',

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -28,7 +28,6 @@ import {
 import debug from 'debug';
 import WebSocket from 'ws';
 
-import type {MapperOptions} from '../bidiMapper/BidiServer.js';
 import {MapperCdpConnection} from '../cdp/CdpConnection.js';
 import {WebSocketTransport} from '../utils/WebsocketTransport.js';
 
@@ -58,7 +57,6 @@ export class BrowserInstance {
 
   static async run(
     chromeOptions: ChromeOptions,
-    mapperOptions: MapperOptions,
     verbose: boolean
   ): Promise<BrowserInstance> {
     const profileDir = await mkdtemp(
@@ -121,8 +119,7 @@ export class BrowserInstance {
     const mapperCdpConnection = await MapperServerCdpConnection.create(
       cdpConnection,
       mapperTabSource,
-      verbose,
-      mapperOptions
+      verbose
     );
 
     return new BrowserInstance(mapperCdpConnection, browserProcess);

--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -18,7 +18,6 @@
 import debug, {type Debugger} from 'debug';
 import type {Protocol} from 'devtools-protocol';
 
-import type {MapperOptions} from '../bidiMapper/BidiServer.js';
 import type {MapperCdpClient} from '../cdp/CdpClient.js';
 import type {MapperCdpConnection} from '../cdp/CdpConnection.js';
 import type {LogPrefix, LogType} from '../utils/log.js';
@@ -47,15 +46,13 @@ export class MapperServerCdpConnection {
   static async create(
     cdpConnection: MapperCdpConnection,
     mapperTabSource: string,
-    verbose: boolean,
-    mapperOptions: MapperOptions
+    verbose: boolean
   ): Promise<MapperServerCdpConnection> {
     try {
       const bidiSession = await this.#initMapper(
         cdpConnection,
         mapperTabSource,
-        verbose,
-        mapperOptions
+        verbose
       );
       return new MapperServerCdpConnection(cdpConnection, bidiSession);
     } catch (e) {
@@ -140,10 +137,9 @@ export class MapperServerCdpConnection {
   static async #initMapper(
     cdpConnection: MapperCdpConnection,
     mapperTabSource: string,
-    verbose: boolean,
-    mapperOptions: MapperOptions
+    verbose: boolean
   ): Promise<SimpleTransport> {
-    debugInternal('Initializing Mapper.', mapperOptions);
+    debugInternal('Initializing Mapper.');
 
     const browserClient = await cdpConnection.createBrowserSession();
 
@@ -214,10 +210,9 @@ export class MapperServerCdpConnection {
       expression: mapperTabSource,
     });
 
+    // TODO: handle errors in all these evaluate calls!
     await mapperCdpClient.sendCommand('Runtime.evaluate', {
-      expression: `window.runMapperInstance('${mapperTabTargetId}', ${JSON.stringify(
-        mapperOptions
-      )})`,
+      expression: `window.runMapperInstance('${mapperTabTargetId}')`,
       awaitPromise: true,
     });
 

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -18,7 +18,6 @@
  */
 
 import {BidiServer} from '../bidiMapper/BidiMapper.js';
-import type {MapperOptions} from '../bidiMapper/BidiServer';
 import {MapperCdpConnection} from '../cdp/CdpConnection.js';
 import {LogType} from '../utils/log.js';
 
@@ -70,10 +69,7 @@ const cdpConnection = new MapperCdpConnection(cdpTransport, log);
  * @param {string} selfTargetId
  * @param options Mapper options. E.g. `acceptInsecureCerts`.
  */
-async function runMapperInstance(
-  selfTargetId: string,
-  options?: MapperOptions
-) {
+async function runMapperInstance(selfTargetId: string) {
   // eslint-disable-next-line no-console
   console.log('Launching Mapper instance with selfTargetId:', selfTargetId);
 
@@ -85,7 +81,6 @@ async function runMapperInstance(
      */
     await cdpConnection.createBrowserSession(),
     selfTargetId,
-    options,
     new BidiParser(),
     log
   );
@@ -98,7 +93,7 @@ async function runMapperInstance(
 /**
  * Set `window.runMapper` to a function which launches the BiDi mapper instance.
  * @param selfTargetId Needed to filter out info related to BiDi target.
- * @param options Mapper options. E.g. `acceptInsecureCerts`. */
-window.runMapperInstance = async (selfTargetId, options?: MapperOptions) => {
-  await runMapperInstance(selfTargetId, options);
+ */
+window.runMapperInstance = async (selfTargetId) => {
+  await runMapperInstance(selfTargetId);
 };

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/interop/beforeunload_prompt.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/interop/beforeunload_prompt.py.ini
@@ -22,9 +22,3 @@
 
   [test_dismiss_and_notify[capabilities0-True\]]
     expected: FAIL
-
-  [test_ignore[capabilities0-False\]]
-    expected: FAIL
-
-  [test_ignore[capabilities0-True\]]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/interop/beforeunload_prompt.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/interop/beforeunload_prompt.py.ini
@@ -22,9 +22,3 @@
 
   [test_dismiss_and_notify[capabilities0-True\]]
     expected: FAIL
-
-  [test_ignore[capabilities0-False\]]
-    expected: FAIL
-
-  [test_ignore[capabilities0-True\]]
-    expected: FAIL


### PR DESCRIPTION
This PR moves Mapper options to be processed inside session.new so that there is a single place on how these options have to be provided and that allows using the mapper in the same way as other protocol implementations.

ChromeDriver issue: https://crbug.com/356371297