### PR TITLE
ci: fix artifacts path

### DIFF
--- a/.github/workflows/wpt-quick.yml
+++ b/.github/workflows/wpt-quick.yml
@@ -304,7 +304,6 @@ jobs:
       - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           pattern: chromedriver-headful-*
-          path: out
           merge-multiple: true
       - name: Generate HTML test report
         run: >


### PR DESCRIPTION
The WPT reports artifacts already include the `out`  folder to the path as `out/out/<report>`.