### PR TITLE
fix: improve capabilities matching

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -42,7 +42,7 @@ type BidiServerEvent = {
 };
 
 export type MapperOptions = {
-  acceptInsecureCerts: boolean;
+  acceptInsecureCerts?: boolean;
   unhandledPromptBehavior?: Session.UserPromptHandler;
 };
 


### PR DESCRIPTION
This PR improves capabilities matching to support capabilities that could be cross-browser for Puppeteer. It is not fully aligned with the spec though as we expect most of things to be handled by ChromeDriver.