### PR TITLE
build: switch to pre-release versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromium-bidi",
-  "version": "0.6.4",
+  "version": "0.6.4-alpha001",
   "description": "An implementation of the WebDriver BiDi protocol for Chromium implemented as a JavaScript layer translating between BiDi and CDP, running inside a Chrome tab.",
   "scripts": {
     "build": "wireit",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
   "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
   "packages": {
-    ".": {}
+    ".": {
+      "prerelease-type": "alpha"
+    }
   }
 }


### PR DESCRIPTION
This PR switches versioning on the main branch to use alpha suffix indicating compatibility with canary browser builds.

chromium-bidi was already using a prerelease flag for release-please and so the appropriate versioning strategy should be in place.

I have already created two release branches `releases/m127` and `releases/m128` off the main branch. Currently, the main branch is using M129. As soon as we switch to M130, we need a new branch.

Related semver spec: https://semver.org/#spec-item-9
Related release-please versioning strategy: https://github.com/googleapis/release-please/blob/main/src/versioning-strategies/prerelease.ts#L175