### PR TITLE
Revert "build: switch to pre-release versioning"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromium-bidi",
-  "version": "0.6.4-alpha001",
+  "version": "0.6.4",
   "description": "An implementation of the WebDriver BiDi protocol for Chromium implemented as a JavaScript layer translating between BiDi and CDP, running inside a Chrome tab.",
   "scripts": {
     "build": "wireit",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,6 @@
   "bump-patch-for-minor-pre-major": true,
   "prerelease": true,
   "packages": {
-    ".": {
-      "prerelease-type": "alpha"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
Reverts GoogleChromeLabs/chromium-bidi#2512

it didn't work with release-please. See https://github.com/GoogleChromeLabs/chromium-bidi/pull/2514