### PR TITLE
chore: reduce Mapper Tab size by not including Url Pattern polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@eslint/eslintrc": "3.1.0",
         "@eslint/js": "9.9.1",
         "@puppeteer/browsers": "2.3.1",
+        "@rollup/plugin-alias": "5.1.0",
         "@rollup/plugin-commonjs": "26.0.1",
         "@rollup/plugin-node-resolve": "15.2.3",
         "@rollup/wasm-node": "4.21.0",
@@ -610,6 +611,38 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/plugin-alias": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+      "integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
+      "dev": true,
+      "dependencies": {
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-alias/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -6080,12 +6113,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.9.1",
     "@puppeteer/browsers": "2.3.1",
+    "@rollup/plugin-alias": "5.1.0",
     "@rollup/plugin-commonjs": "26.0.1",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/wasm-node": "4.21.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,6 +16,7 @@
  */
 import path from 'path';
 
+import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import license from 'rollup-plugin-license';
@@ -64,6 +65,11 @@ export default {
           },
         },
       },
+    }),
+    alias({
+      entries: [
+        {find: /^(.*)UrlPattern\.js$/, replacement: '$1UrlPattern-browser.js'},
+      ],
     }),
     nodeResolve(),
     commonjs({

--- a/src/bidiMapper/modules/network/NetworkProcessor.ts
+++ b/src/bidiMapper/modules/network/NetworkProcessor.ts
@@ -21,6 +21,7 @@ import {
   NoSuchRequestException,
   InvalidArgumentException,
 } from '../../../protocol/protocol.js';
+import {URLPattern} from '../../../utils/UrlPattern.js';
 import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
 
 import type {NetworkRequest} from './NetworkRequest.js';

--- a/src/bidiServer/index.ts
+++ b/src/bidiServer/index.ts
@@ -42,6 +42,7 @@ export function parseCommandLineArgs() {
 (() => {
   try {
     const argv = parseCommandLineArgs();
+
     const {port, verbose} = argv;
 
     debugInfo('Launching BiDi server...');

--- a/src/utils/UrlPattern-browser.ts
+++ b/src/utils/UrlPattern-browser.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2024 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Used as an alias to `UrlPattern.ts` to reduce the
+ * size of Chromium-BiDi when used the tab.
+ * See rollup.config.mjs
+ */
+import type UrlPatternTypes from 'urlpattern-polyfill/dist/types.js';
+
+const URLPattern = (globalThis as any)
+  .URLPattern as typeof UrlPatternTypes.URLPattern;
+
+if (!URLPattern) {
+  throw new Error('Unable to find URLPattern');
+}
+
+export {URLPattern};


### PR DESCRIPTION
When we run Mapper Tab we can be sure that all Chrome APIs are there and we can use, so we can omit this.
The delta is around ~16K.

Note: we can't drop all together it as that will break Puppeteer.