### PR TITLE
fix: allow pen to hover over

### DIFF
--- a/src/bidiMapper/modules/input/ActionDispatcher.ts
+++ b/src/bidiMapper/modules/input/ActionDispatcher.ts
@@ -410,6 +410,8 @@ export class ActionDispatcher {
             );
             break;
           case Input.PointerType.Pen:
+            // Even if the pressed size is 0, we still need to send the event, as pen can
+            // hover over.
             // TODO: Implement width and height when available.
             await this.#context.cdpTarget.cdpClient.sendCommand(
               'Input.dispatchMouseEvent',

--- a/src/bidiMapper/modules/input/ActionDispatcher.ts
+++ b/src/bidiMapper/modules/input/ActionDispatcher.ts
@@ -410,29 +410,25 @@ export class ActionDispatcher {
             );
             break;
           case Input.PointerType.Pen:
-            if (source.pressed.size !== 0) {
-              // TODO: Implement width and height when available.
-              await this.#context.cdpTarget.cdpClient.sendCommand(
-                'Input.dispatchMouseEvent',
-                {
-                  type: 'mouseMoved',
-                  x,
-                  y,
-                  modifiers,
-                  clickCount: 0,
-                  button: getCdpButton(
-                    source.pressed.values().next().value ?? 5
-                  ),
-                  buttons: source.buttons,
-                  pointerType,
-                  tangentialPressure,
-                  tiltX,
-                  tiltY,
-                  twist,
-                  force: pressure,
-                }
-              );
-            }
+            // TODO: Implement width and height when available.
+            await this.#context.cdpTarget.cdpClient.sendCommand(
+              'Input.dispatchMouseEvent',
+              {
+                type: 'mouseMoved',
+                x,
+                y,
+                modifiers,
+                clickCount: 0,
+                button: getCdpButton(source.pressed.values().next().value ?? 5),
+                buttons: source.buttons,
+                pointerType,
+                tangentialPressure,
+                tiltX,
+                tiltY,
+                twist,
+                force: pressure,
+              }
+            );
             break;
           case Input.PointerType.Touch:
             if (source.pressed.size !== 0) {


### PR DESCRIPTION
Even if the pen is not touching the surface, the move events should be dispatched.