### PR TITLE
fix: css and xPath selector start node is document

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1255,7 +1255,7 @@ export class BrowsingContextImpl {
                 return [...element.querySelectorAll(cssSelector)];
               };
 
-              startNodes = startNodes.length > 0 ? startNodes : [document.body];
+              startNodes = startNodes.length > 0 ? startNodes : [document];
               const returnedNodes = startNodes
                 .map((startNode) =>
                   // TODO: stop search early if `maxNodeCount` is reached.
@@ -1298,7 +1298,7 @@ export class BrowsingContextImpl {
                 }
                 return returnedNodes;
               };
-              startNodes = startNodes.length > 0 ? startNodes : [document.body];
+              startNodes = startNodes.length > 0 ? startNodes : [document];
               const returnedNodes = startNodes
                 .map((startNode) =>
                   // TODO: stop search early if `maxNodeCount` is reached.

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1530,7 +1530,12 @@ export class BrowsingContextImpl {
                 }
               }
 
-              startNodes = startNodes.length > 0 ? startNodes : [document.body];
+              startNodes =
+                startNodes.length > 0
+                  ? startNodes
+                  : Array.from(document.documentElement.children).filter(
+                      (c) => c instanceof HTMLElement
+                    );
               collect(startNodes, {
                 role,
                 name,

--- a/tests/browsing_context/test_locate_nodes.py
+++ b/tests/browsing_context/test_locate_nodes.py
@@ -15,7 +15,7 @@
 import re
 
 import pytest
-from test_helpers import ANY_SHARED_ID, execute_command, goto_url
+from test_helpers import ANY_SHARED_ID, AnyExtending, execute_command, goto_url
 
 
 @pytest.mark.parametrize('locator', [
@@ -143,3 +143,27 @@ async def test_locate_nodes_locator_invalid(websocket, context_id, html,
                     'locator': locator
                 }
             })
+
+
+# https://github.com/GoogleChromeLabs/chromium-bidi/issues/2539
+@pytest.mark.asyncio
+async def test_locate_nodes_css_wildcard_locator(websocket, context_id, html):
+    await goto_url(websocket, context_id, html('<div>foobarBARbaz</div>'))
+
+    resp = await execute_command(
+        websocket, {
+            'method': 'browsingContext.locateNodes',
+            'params': {
+                'context': context_id,
+                'locator': {
+                    'type': 'css',
+                    'value': '*'
+                }
+            }
+        })
+
+    assert resp == {
+        "nodes": [AnyExtending({
+            'type': 'node',
+        })]
+    }


### PR DESCRIPTION
Addressing https://github.com/GoogleChromeLabs/chromium-bidi/issues/2539

According to the spec, the default `startNodes` of the `browsingContext.locateNodes` is `document`, not `document.body`.