### PR TITLE
!fix: emit `browsingContext.contextDestroyed` once

### DIFF
--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -113,6 +113,10 @@ export class CdpTargetManager {
       'Page.frameDetached',
       this.#handleFrameDetachedEvent.bind(this)
     );
+    cdpClient.on(
+      'Page.frameSubtreeWillBeDetached',
+      this.#handleFrameSubtreeWillBeDetached.bind(this)
+    );
   }
 
   #handleFrameAttachedEvent(params: Protocol.Page.FrameAttachedEvent) {
@@ -143,7 +147,13 @@ export class CdpTargetManager {
     if (params.reason === 'swap') {
       return;
     }
-    this.#browsingContextStorage.findContext(params.frameId)?.dispose();
+    this.#browsingContextStorage.findContext(params.frameId)?.dispose(false);
+  }
+
+  #handleFrameSubtreeWillBeDetached(
+    params: Protocol.Page.FrameSubtreeWillBeDetachedEvent
+  ) {
+    this.#browsingContextStorage.findContext(params.frameId)?.dispose(true);
   }
 
   #handleAttachedToTargetEvent(
@@ -327,7 +337,7 @@ export class CdpTargetManager {
     const context =
       this.#browsingContextStorage.findContextBySession(sessionId);
     if (context) {
-      context.dispose();
+      context.dispose(true);
       return;
     }
 

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -211,7 +211,7 @@ export class BrowsingContextImpl {
     return this.#navigationId;
   }
 
-  dispose() {
+  dispose(emitContextDestroyed: boolean) {
     this.#deleteAllChildren();
 
     this.#realmStorage.deleteRealms({
@@ -226,14 +226,16 @@ export class BrowsingContextImpl {
     // Fail all ongoing navigations.
     this.#failLifecycleIfNotFinished();
 
-    this.#eventManager.registerEvent(
-      {
-        type: 'event',
-        method: ChromiumBidi.BrowsingContext.EventNames.ContextDestroyed,
-        params: this.serializeToBidiValue(),
-      },
-      this.id
-    );
+    if (emitContextDestroyed) {
+      this.#eventManager.registerEvent(
+        {
+          type: 'event',
+          method: ChromiumBidi.BrowsingContext.EventNames.ContextDestroyed,
+          params: this.serializeToBidiValue(),
+        },
+        this.id
+      );
+    }
     this.#browsingContextStorage.deleteContextById(this.id);
   }
 
@@ -308,7 +310,7 @@ export class BrowsingContextImpl {
   }
 
   #deleteAllChildren() {
-    this.directChildren.map((child) => child.dispose());
+    this.directChildren.map((child) => child.dispose(false));
   }
 
   get cdpTarget(): CdpTarget {


### PR DESCRIPTION
Rely on the new CDP event `Page.frameSubtreeWillBeDetached`, do not emit extra `browsingContext.contextDestroyed`, only for the top-level frame to be destroyed.