### PR TITLE
feat: emit `browsingContext.navigationFailed` event

### DIFF
--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,3 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -17,11 +17,5 @@
   [test_with_new_navigation_inside_page]
     expected: FAIL
 
-  [test_close_context[tab\]]
-    expected: FAIL
-
-  [test_close_context[window\]]
-    expected: FAIL
-
   [test_close_iframe]
     expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,6 @@
+[error.py]
+  [test_with_new_navigation]
+    expected: FAIL
+
+  [test_with_new_navigation_inside_page]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,3 +1,6 @@
 [error.py]
   [test_with_new_navigation_inside_page]
     expected: FAIL
+
+  [test_with_new_navigation]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,6 +1,3 @@
 [error.py]
-  [test_with_new_navigation]
-    expected: FAIL
-
   [test_with_new_navigation_inside_page]
     expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -16,12 +16,3 @@
 
   [test_with_new_navigation_inside_page]
     expected: FAIL
-
-  [test_close_context[tab\]]
-    expected: FAIL
-
-  [test_close_context[window\]]
-    expected: FAIL
-
-  [test_close_iframe]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -16,3 +16,6 @@
 
   [test_with_new_navigation_inside_page]
     expected: FAIL
+
+  [test_close_iframe]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,3 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -16,12 +16,3 @@
 
   [test_with_new_navigation_inside_page]
     expected: FAIL
-
-  [test_close_context[tab\]]
-    expected: FAIL
-
-  [test_close_context[window\]]
-    expected: FAIL
-
-  [test_close_iframe]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -16,3 +16,6 @@
 
   [test_with_new_navigation_inside_page]
     expected: FAIL
+
+  [test_close_iframe]
+    expected: FAIL


### PR DESCRIPTION
Introduce `#currentNavigation` deferred, which represents the ongoing navigation.