### PR TITLE
chore: heuristic in console log serialization

### DIFF
--- a/src/bidiMapper/modules/script/Realm.ts
+++ b/src/bidiMapper/modules/script/Realm.ts
@@ -250,6 +250,7 @@ export abstract class Realm {
     cdpRemoteObject: Protocol.Runtime.RemoteObject,
     resultOwnership: Script.ResultOwnership
   ): Promise<Script.RemoteValue> {
+    // TODO: if the object is a primitive, return it directly without CDP roundtrip.
     const argument = Realm.#cdpRemoteObjectToCallArgument(cdpRemoteObject);
 
     const cdpValue: Protocol.Runtime.CallFunctionOnResponse =

--- a/tests/script/test_add_preload_script.py
+++ b/tests/script/test_add_preload_script.py
@@ -699,13 +699,29 @@ async def test_preloadScript_add_withUserGesture_blankTargetLink(
             }
         })
 
-    [command_result, log_entry_added] = await read_sorted_messages(2)
+    # There preloaded script should be executed on the initial about:blank page
+    # and after navigation to `url_example`.
+    [command_result, first_log_entry_added,
+     second_log_entry_added] = await read_sorted_messages(3)
     assert command_result == AnyExtending({
         "id": command_id,
         "type": "success",
         "result": ANY_DICT
     })
-    assert log_entry_added == AnyExtending({
+    assert first_log_entry_added == AnyExtending({
+        "type": "event",
+        "method": "log.entryAdded",
+        "params": {
+            "args": [{
+                "type": "string",
+                "value": "my preload script"
+            }, {
+                'type': 'string',
+                'value': 'about:blank',
+            }]
+        }
+    })
+    assert second_log_entry_added == AnyExtending({
         "type": "event",
         "method": "log.entryAdded",
         "params": {


### PR DESCRIPTION
This change saves some CDP round trips on console log events, which improves Mapper performance in case of tons of console log events are written. This seems to be a bottleneck for testdriverJS BiDi.