### PR TITLE
build: mark roll of a new major browser version as breaking

### DIFF
--- a/tools/update_chrome_revision.mjs
+++ b/tools/update_chrome_revision.mjs
@@ -79,7 +79,7 @@ if (newSemVer.compare(oldSemVer) <= 0) {
 } else if (newSemVer.major === oldSemVer.major) {
   message = `build(chrome): ${message}`;
 } else {
-  message = `feat(chrome): ${message}`;
+  message = `feat(chrome)!: ${message}`;
 }
 
 actions.setOutput('commit', message);


### PR DESCRIPTION
Currently, the feat commits only generate a patch.