### PR TITLE
ci: run browser update every 12 hours

### DIFF
--- a/.github/workflows/update-browser-version.yml
+++ b/.github/workflows/update-browser-version.yml
@@ -7,8 +7,8 @@ permissions: read-all
 
 on:
   schedule:
-    # Run hourly at xx:30.
-    - cron: '30 * * * *'
+    # Run every 12 hours
+    - cron: '0 */12 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
With the move to pushing to fork we need to reaccept the runs, which means every other the PR resets.
We also don't merge it every time.