### PR TITLE
chore: reject pending cdp commands when the cdp session is destroyed

### DIFF
--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -349,7 +349,7 @@ export class CdpTarget {
     return (
       error.code === -32001 &&
       error.message === 'Session with given id not found.'
-    );
+    ) || this.#cdpClient.isCloseError(err);
   }
 
   #setEventListeners() {

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -347,9 +347,10 @@ export class CdpTarget {
   #isExpectedError(err: unknown): boolean {
     const error = err as {code?: unknown; message?: unknown};
     return (
-      error.code === -32001 &&
-      error.message === 'Session with given id not found.'
-    ) || this.#cdpClient.isCloseError(err);
+      (error.code === -32001 &&
+        error.message === 'Session with given id not found.') ||
+      this.#cdpClient.isCloseError(err)
+    );
   }
 
   #setEventListeners() {

--- a/src/cdp/CdpConnection.ts
+++ b/src/cdp/CdpConnection.ts
@@ -167,7 +167,7 @@ export class MapperCdpConnection implements CdpConnection {
         }
         // Reject all the pending commands for the detached session.
         for (const callback of this.#commandCallbacks.values()) {
-          if (callback.sessionId === message.sessionId) {
+          if (callback.sessionId === sessionId) {
             callback.reject(callback.error);
           }
         }


### PR DESCRIPTION
If there are some pending commands at the moment a CDP session is ended, those commands will never end. This PR makes sure we don't have those hanging commands.

Motivation: this becomes critical for switching to tab targets, as the tab target can be closed when the page is closed.