### PR TITLE
chore: don't allow PDF printing of iframes

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1109,6 +1109,12 @@ export class BrowsingContextImpl {
   async print(
     params: BrowsingContext.PrintParameters,
   ): Promise<BrowsingContext.PrintResult> {
+    if (!this.isTopLevelContext()) {
+      throw new UnsupportedOperationException(
+        'Printing of non-top level contexts is not supported',
+      );
+    }
+
     const cdpParams: Protocol.Page.PrintToPDFRequest = {};
 
     if (params.background !== undefined) {

--- a/tests/browsing_context/test_print.py
+++ b/tests/browsing_context/test_print.py
@@ -19,7 +19,7 @@ from test_helpers import execute_command, goto_url
 
 
 @pytest.mark.asyncio
-async def test_print(websocket, context_id, html):
+async def test_print_top_level_context(websocket, context_id, html):
     await goto_url(websocket, context_id, html())
 
     print_result = await execute_command(
@@ -47,3 +47,19 @@ async def test_print(websocket, context_id, html):
             'message': 'net::ERR_ABORTED'
         }
         pytest.xfail("PDF viewer not available in headless.")
+
+
+@pytest.mark.asyncio
+async def test_print_iframe(websocket, iframe_id, html):
+    with pytest.raises(
+            Exception,
+            match=str({
+                'error': 'unsupported operation',
+                'message': 'Printing of non-top level contexts is not supported'
+            })):
+        await execute_command(websocket, {
+            "method": "browsingContext.print",
+            "params": {
+                "context": iframe_id,
+            }
+        })

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/print/context.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/print/context.py.ini
@@ -4,3 +4,6 @@
 
   [test_context_origin[cross_origin\]]
     expected: FAIL
+
+  [test_context_origin[same_origin\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/queue.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/queue.py.ini
@@ -1,3 +1,6 @@
 [queue.py]
   [test_parallel_pointer]
     expected: FAIL
+
+  [test_parallel_key]
+    expected: [FAIL, PASS]

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/print/context.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/print/context.py.ini
@@ -4,3 +4,6 @@
 
   [test_context_origin[cross_origin\]]
     expected: FAIL
+
+  [test_context_origin[same_origin\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/queue.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/input/perform_actions/queue.py.ini
@@ -1,3 +1,6 @@
 [queue.py]
   [test_parallel_pointer]
     expected: FAIL
+
+  [test_parallel_key]
+    expected: [FAIL, PASS]

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/print/context.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/print/context.py.ini
@@ -1,3 +1,9 @@
 [context.py]
   [test_page_with_iframe]
     expected: FAIL
+
+  [test_context_origin[same_origin\]]
+    expected: FAIL
+
+  [test_context_origin[cross_origin\]]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/queue.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/input/perform_actions/queue.py.ini
@@ -1,3 +1,6 @@
 [queue.py]
   [test_parallel_pointer]
     expected: FAIL
+
+  [test_parallel_key]
+    expected: [FAIL, PASS]


### PR DESCRIPTION
Restrict pdf printing only to top level browsing contexts. Required, as CDP method `Page.printToPDF` works only on the top-level targets, and don't allow printing not same-proccess nor OOPiF.