### PR TITLE
feat: align abort navigation with the spec

### DIFF
--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -19,6 +19,25 @@ from test_helpers import (ANY_TIMESTAMP, ANY_UUID, AnyExtending,
                           read_JSON_message, send_JSON_command, subscribe)
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/GoogleChromeLabs/chromium-bidi/issues/2709")
+@pytest.mark.asyncio
+async def test_browsingContext_navigateWaitInteractive_redirect(
+        websocket, context_id, html, url_example):
+
+    url = html(f"<script>window.location='{url_example}';</script>")
+
+    await execute_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "url": url,
+                "wait": "interactive",
+                "context": context_id
+            }
+        })
+
+
 @pytest.mark.asyncio
 async def test_browsingContext_navigateWaitNone_navigated(
         websocket, context_id, html):

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,3 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,3 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,3 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL


### PR DESCRIPTION
Related issue: https://github.com/GoogleChromeLabs/chromium-bidi/issues/2709

Should be reverted if https://github.com/w3c/webdriver-bidi/issues/799 is fixed