### PR TITLE
test: wait for the browser to be launched

### DIFF
--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -247,6 +247,10 @@ export class WebSocketServer {
     }
 
     connection.on('message', async (message) => {
+      // If session exists, wait for the browser instance to be launched before processing
+      // BiDi commands.
+      await session?.browserInstancePromise;
+
       // If type is not text, return error.
       if (message.type !== 'utf8') {
         this.#respondWithError(


### PR DESCRIPTION
When websocket connection is established to NodeJS Mapper Runner, wait for the browser instance to be launched before processing commands. This is required, as WPT uses same session, but Mapper re-runs browser instance for each connection. This can cause artifact events from the browser or mapper initiation to be sent to BiDi client. E.g. unexpected `browsingContext.domContentLoaded` of the initial page.