### PR TITLE
fix: allow setting `bluetooth.simulateAdapter` multiple times

### DIFF
--- a/src/bidiMapper/modules/bluetooth/BluetoothProcessor.ts
+++ b/src/bidiMapper/modules/bluetooth/BluetoothProcessor.ts
@@ -36,6 +36,12 @@ export class BluetoothProcessor {
     params: Bluetooth.SimulateAdapterParameters,
   ): Promise<EmptyResult> {
     const context = this.#browsingContextStorage.getContext(params.context);
+    // Bluetooth spec requires overriding the existing adapter (step 6). From the CDP
+    // perspective, we need to disable the emulation first.
+    // https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateAdapter-command
+    await context.cdpTarget.browserCdpClient.sendCommand(
+      'BluetoothEmulation.disable',
+    );
     await context.cdpTarget.browserCdpClient.sendCommand(
       'BluetoothEmulation.enable',
       {

--- a/tests/bluetooth/test_emulation.py
+++ b/tests/bluetooth/test_emulation.py
@@ -64,6 +64,39 @@ async def setup_device(websocket, context_id):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("state_1", ["absent", "powered-off", "powered-on"])
+@pytest.mark.parametrize("state_2", ["absent", "powered-off", "powered-on"])
+@pytest.mark.parametrize('capabilities', [{
+    'goog:chromeOptions': {
+        'args': ['--enable-features=WebBluetooth']
+    }
+}],
+                         indirect=True)
+async def test_simulate_adapter_twice(websocket, context_id, state_1, state_2,
+                                      test_headless_mode):
+    if test_headless_mode == "old":
+        pytest.xfail("Old headless mode does not support Bluetooth")
+
+    await execute_command(
+        websocket, {
+            'method': 'bluetooth.simulateAdapter',
+            'params': {
+                'context': context_id,
+                'state': state_1,
+            }
+        })
+
+    await execute_command(
+        websocket, {
+            'method': 'bluetooth.simulateAdapter',
+            'params': {
+                'context': context_id,
+                'state': state_2,
+            }
+        })
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('capabilities', [{
     'goog:chromeOptions': {
         'args': ['--enable-features=WebBluetooth']


### PR DESCRIPTION
Align with the spec (step 6) of [`bluetooth.simulateAdapter`](https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-simulateAdapter-command).