### PR TITLE
test: disable HttpsFirstBalancedModeAutoEnable

### DIFF
--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -68,7 +68,8 @@ export class BrowserInstance {
       '--allow-browser-signin=false',
       '--disable-component-update',
       '--disable-default-apps',
-      '--disable-features=DialMediaRouteProvider,TrackingProtection3pcd',
+      // For HttpsFirstBalancedModeAutoEnable, crbug.com/378022921.
+      '--disable-features=DialMediaRouteProvider,TrackingProtection3pcd,HttpsFirstBalancedModeAutoEnable',
       '--disable-infobars',
       '--disable-notifications',
       '--disable-popup-blocking',


### PR DESCRIPTION
To fix https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/11796904094/job/32864869059?pr=2758 short-term. Long-term the e2e server needs to support custom hosts.