### PR TITLE
fix: `browser.getClientWindows` returns a unique per window value

### DIFF
--- a/src/bidiMapper/modules/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessor.ts
@@ -113,7 +113,7 @@ export class BrowserProcessor {
       {targetId},
     );
     return {
-      // `activate` is not supported in CDP yet.
+      // `active` is not supported in CDP yet.
       active: false,
       clientWindow: `${windowInfo.windowId}`,
       state: windowInfo.bounds.windowState ?? 'normal',

--- a/src/bidiMapper/modules/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessor.ts
@@ -113,7 +113,7 @@ export class BrowserProcessor {
       {targetId},
     );
     return {
-      // Is not supported in CDP yet.
+      // `activate` is not supported in CDP yet.
       active: false,
       clientWindow: `${windowInfo.windowId}`,
       state: windowInfo.bounds.windowState ?? 'normal',
@@ -134,6 +134,17 @@ export class BrowserProcessor {
         async (targetId) => await this.#getWindowInfo(targetId),
       ),
     );
-    return {clientWindows};
+
+    const uniqueClientWindowIds = new Set<string>();
+    const uniqueClientWindows = new Array<Browser.ClientWindowInfo>();
+
+    // Filter out duplicated client windows.
+    for (const window of clientWindows) {
+      if (!uniqueClientWindowIds.has(window.clientWindow)) {
+        uniqueClientWindowIds.add(window.clientWindow);
+        uniqueClientWindows.push(window);
+      }
+    }
+    return {clientWindows: uniqueClientWindows};
   }
 }

--- a/tests/browser/test_get_client_windows.py
+++ b/tests/browser/test_get_client_windows.py
@@ -19,7 +19,7 @@ from test_helpers import execute_command
 
 
 @pytest.mark.asyncio
-async def test_browser_get_client_windows(websocket, context_id):
+async def test_browser_get_client_windows_single_tab(websocket, context_id):
     resp = await execute_command(websocket, {
         "method": "browser.getClientWindows",
         "params": {}
@@ -27,7 +27,67 @@ async def test_browser_get_client_windows(websocket, context_id):
     assert resp == {
         'clientWindows': [
             {
-                # Not implemented yet
+                # `active` is not implemented yet
+                'active': False,
+                'clientWindow': ANY_STR,
+                'height': ANY_NUMBER,
+                'state': 'normal',
+                'width': ANY_NUMBER,
+                'x': ANY_NUMBER,
+                'y': ANY_NUMBER,
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_browser_get_client_windows_two_tabs(websocket, context_id,
+                                                   create_context):
+    await create_context(context_type='tab')
+
+    resp = await execute_command(websocket, {
+        "method": "browser.getClientWindows",
+        "params": {}
+    })
+    assert resp == {
+        'clientWindows': [
+            {
+                # `active` is not implemented yet
+                'active': False,
+                'clientWindow': ANY_STR,
+                'height': ANY_NUMBER,
+                'state': 'normal',
+                'width': ANY_NUMBER,
+                'x': ANY_NUMBER,
+                'y': ANY_NUMBER,
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_browser_get_client_windows_two_windows(websocket, context_id,
+                                                      create_context):
+    await create_context(context_type='window')
+
+    resp = await execute_command(websocket, {
+        "method": "browser.getClientWindows",
+        "params": {}
+    })
+    assert resp == {
+        'clientWindows': [
+            {
+                # `active` is not implemented yet
+                'active': False,
+                'clientWindow': ANY_STR,
+                'height': ANY_NUMBER,
+                'state': 'normal',
+                'width': ANY_NUMBER,
+                'x': ANY_NUMBER,
+                'y': ANY_NUMBER,
+            },
+            {
+                # `active` is not implemented yet
                 'active': False,
                 'clientWindow': ANY_STR,
                 'height': ANY_NUMBER,

--- a/tests/browser/test_get_client_windows.py
+++ b/tests/browser/test_get_client_windows.py
@@ -42,7 +42,11 @@ async def test_browser_get_client_windows_single_tab(websocket, context_id):
 
 @pytest.mark.asyncio
 async def test_browser_get_client_windows_two_tabs(websocket, context_id,
-                                                   create_context):
+                                                   create_context,
+                                                   test_headless_mode):
+    if test_headless_mode == "old":
+        pytest.xfail("In old headless mode, each tab is in a separate window")
+
     await create_context(context_type='tab')
 
     resp = await execute_command(websocket, {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,12 +174,12 @@ async def another_context_id(create_context):
 @pytest_asyncio.fixture
 def create_context(websocket):
     """Return a browsing context factory."""
-    async def create_context(user_context_id=None):
+    async def create_context(user_context_id=None, context_type='tab'):
         result = await execute_command(
             websocket, {
                 "method": "browsingContext.create",
                 "params": {
-                    "type": "tab"
+                    "type": context_type
                 } | ({
                     "userContext": user_context_id
                 } if user_context_id is not None else {})


### PR DESCRIPTION
Addressing issue pointed in https://github.com/GoogleChromeLabs/chromium-bidi/pull/2780#discussion_r1844312850