### PR TITLE
test: speed up `assert_no_more_messages`

### DIFF
--- a/tests/browsing_context/test_nested_browsing_context.py
+++ b/tests/browsing_context/test_nested_browsing_context.py
@@ -107,7 +107,7 @@ async def test_nestedBrowsingContext_navigateWaitInteractive_navigated(
         'type': 'event',
     }
 
-    await assert_no_more_messages(timeout=1.0)
+    await assert_no_more_messages()
 
 
 @pytest.mark.asyncio
@@ -156,7 +156,7 @@ async def test_nestedBrowsingContext_navigateWaitComplete_navigated(
     response = await read_JSON_message(websocket)
     assert response['result'] == {"navigation": navigation_id, "url": url}
 
-    await assert_no_more_messages(timeout=1.0)
+    await assert_no_more_messages()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Apply heuristic. Run a script on each exising browsing context instead of waiting. If there are events, most likely they will be enqueued before the script is finished.