### PR TITLE
fix: stop calling bringToFront before taking screenshots

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1128,10 +1128,6 @@ export class BrowsingContextImpl {
     }
     const formatParameters = getImageFormatParameters(params);
 
-    // XXX: Focus the original tab after the screenshot is taken.
-    // This is needed because the screenshot gets blocked until the active tab gets focus.
-    await this.#cdpTarget.cdpClient.sendCommand('Page.bringToFront');
-
     let captureBeyondViewport = false;
     let script: string;
     params.origin ??= 'viewport';


### PR DESCRIPTION
With https://crrev.com/5899683 (M131) it should not be longer needer to make sure background tabs are brought to front before taking a screenshot.