### PR TITLE
chore: extract navigation tracking

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -157,16 +157,21 @@ class NavigationTracker {
       return;
     });
 
-    // navigation.finished.then((eventName: NavigationEventName) => {
-    //   this.#eventManager.registerEvent(
-    //     {
-    //       type: 'event',
-    //       method: eventName,
-    //       params: navigation.navigationInfo(),
-    //     },
-    //     this.#browsingContextId,
-    //   )
-    // })
+    void navigation.finished.then((eventName: NavigationEventName) => {
+      if (
+        eventName === ChromiumBidi.BrowsingContext.EventNames.NavigationAborted
+      ) {
+        this.#eventManager.registerEvent(
+          {
+            type: 'event',
+            method: eventName,
+            params: navigation.navigationInfo(),
+          },
+          this.#browsingContextId,
+        );
+      }
+      return;
+    });
   }
 
   frameNavigated(url: string): void {
@@ -672,19 +677,6 @@ export class BrowsingContextImpl {
 
       if (this.#pendingCommandNavigation !== undefined) {
         // The pending navigation was aborted by the new one.
-        this.#eventManager.registerEvent(
-          {
-            type: 'event',
-            method: ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
-            params: {
-              context: this.id,
-              navigation: this.#navigationTracker.navigationId,
-              timestamp: BrowsingContextImpl.getTimestamp(),
-              url: this.#url,
-            },
-          },
-          this.id,
-        );
         this.#pendingCommandNavigation.reject(
           new UnknownErrorException('navigation aborted'),
         );

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1050,6 +1050,8 @@ export class BrowsingContextImpl {
       };
     }
 
+
+
     await cdpNavigatePromise;
 
     // Wait for either the navigation is finished or canceled by another navigation.

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -33,9 +33,9 @@ import {
 import {assert} from '../../../utils/assert.js';
 import {Deferred} from '../../../utils/Deferred.js';
 import {type LoggerFn, LogType} from '../../../utils/log.js';
+import {getTimestamp} from '../../../utils/Time.js';
 import {inchesFromCm} from '../../../utils/unitConversions.js';
 import {urlMatchesAboutBlank} from '../../../utils/UrlHelpers.js';
-import {uuidv4} from '../../../utils/uuid.js';
 import type {CdpTarget} from '../cdp/CdpTarget.js';
 import type {Realm} from '../script/Realm.js';
 import type {RealmStorage} from '../script/RealmStorage.js';
@@ -43,193 +43,10 @@ import {WindowRealm} from '../script/WindowRealm.js';
 import type {EventManager} from '../session/EventManager.js';
 
 import type {BrowsingContextStorage} from './BrowsingContextStorage.js';
-
-type NavigationEventName =
-  // TODO: implement.
-  // ChromiumBidi.BrowsingContext.EventNames.DownloadWillBegin|
-  | ChromiumBidi.BrowsingContext.EventNames.FragmentNavigated
-  | ChromiumBidi.BrowsingContext.EventNames.NavigationAborted
-  | ChromiumBidi.BrowsingContext.EventNames.NavigationFailed;
-
-class NavigationState {
-  started = new Deferred<void>();
-  finished = new Deferred<NavigationEventName>();
-
-  // Tracks CDP events on the navigation. Used to distinguish new navigations from the
-  // initial one.
-  cdpStates = {
-    frameScheduledNavigation: false,
-    frameRequestedNavigation: false,
-    frameStartedLoading: false,
-  };
-
-  markFragmentNavigated() {
-    this.started.resolve();
-    this.finished.resolve(
-      ChromiumBidi.BrowsingContext.EventNames.FragmentNavigated,
-    );
-  }
-
-  markNavigationAborted() {
-    this.started.resolve();
-    this.finished.resolve(
-      ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
-    );
-  }
-
-  markNavigationFailed() {
-    this.started.resolve();
-    this.finished.resolve(
-      ChromiumBidi.BrowsingContext.EventNames.NavigationFailed,
-    );
-  }
-
-  readonly navigationId = uuidv4();
-  url: string;
-  readonly #browsingContextId: string;
-
-  constructor(browsingContextId: string, url: string) {
-    this.#browsingContextId = browsingContextId;
-    this.url = url;
-  }
-
-  navigationInfo(): BrowsingContext.NavigationInfo {
-    return {
-      context: this.#browsingContextId,
-      navigation: this.navigationId,
-      timestamp: BrowsingContextImpl.getTimestamp(),
-      url: this.url,
-    };
-  }
-
-  markStarted(): void {
-    this.started.resolve();
-  }
-}
-
-class NavigationTracker {
-  #initialNavigation = true;
-  #currentNavigation: NavigationState;
-  readonly #eventManager: EventManager;
-  readonly #browsingContextId: string;
-
-  constructor(eventManager: EventManager, browsingContextId: string) {
-    this.#eventManager = eventManager;
-    this.#browsingContextId = browsingContextId;
-    // Initial navigation.
-    this.#currentNavigation = new NavigationState(
-      this.#browsingContextId,
-      'about:blank',
-    );
-  }
-
-  get navigationId(): string {
-    return this.#currentNavigation.navigationId;
-  }
-
-  dispose() {
-    this.#currentNavigation.markNavigationAborted();
-  }
-
-  createNavigation(url: string): NavigationState {
-    this.#initialNavigation = false;
-    if (this.#currentNavigation !== undefined) {
-      this.#currentNavigation.markNavigationAborted();
-    }
-    const navigation = new NavigationState(this.#browsingContextId, url);
-    this.#setEventListeners(navigation);
-
-    this.#currentNavigation = navigation;
-    return navigation;
-  }
-
-  #setEventListeners(navigation: NavigationState) {
-    void navigation.started.then(() => {
-      this.#eventManager.registerEvent(
-        {
-          type: 'event',
-          method: ChromiumBidi.BrowsingContext.EventNames.NavigationStarted,
-          params: navigation.navigationInfo(),
-        },
-        this.#browsingContextId,
-      );
-      return;
-    });
-
-    void navigation.finished.then((eventName: NavigationEventName) => {
-      this.#eventManager.registerEvent(
-        {
-          type: 'event',
-          method: eventName,
-          params: navigation.navigationInfo(),
-        },
-        this.#browsingContextId,
-      );
-      return;
-    });
-  }
-
-  frameNavigated(url: string): void {
-    this.#currentNavigation.url = url;
-  }
-
-  navigatedWithinDocument(url: string, navigationType: string): void {
-    this.#currentNavigation.url = url;
-    if (navigationType === 'fragment') {
-      this.#currentNavigation.markFragmentNavigated();
-    }
-  }
-
-  frameStartedLoading(): void {
-    this.#currentNavigation.markStarted();
-    this.#currentNavigation.cdpStates.frameStartedLoading = true;
-  }
-
-  frameScheduledNavigation(url: string): void {
-    // Signals that it's a new navigation:
-    // 1. The `Page.frameStartedLoading` was already emitted.
-    // 2. The `Page.frameScheduledNavigation` was already emitted.
-    // 3. The `Page.frameRequestedNavigation` was already emitted, which cannot happen
-    //    before `Page.frameScheduledNavigation`.
-    // 4. The current navigation is the initial one, and the URL does not match
-    //    `about:blank`.
-    const isNewNavigation =
-      this.#currentNavigation.cdpStates.frameStartedLoading ||
-      this.#currentNavigation.cdpStates.frameRequestedNavigation ||
-      this.#currentNavigation.cdpStates.frameScheduledNavigation ||
-      (this.#initialNavigation && !urlMatchesAboutBlank(url));
-
-    if (isNewNavigation) {
-      this.createNavigation(url);
-    } else {
-      this.#currentNavigation.url = url;
-    }
-    this.#currentNavigation.markStarted();
-    this.#currentNavigation.cdpStates.frameScheduledNavigation = true;
-  }
-
-  frameRequestedNavigation = (url: string): void => {
-    // Signals that it's a new navigation:
-    // 1. The `Page.frameStartedLoading` was already emitted.
-    // 2. The `Page.frameRequestedNavigation` was already emitted. Note that having
-    //    `Page.frameScheduledNavigation` emitted at this point does not signal the new
-    //    navigation.
-    // 3. The current navigation is the initial one, and the URL does not match
-    //    `about:blank`.
-    const isNewNavigation =
-      this.#currentNavigation.cdpStates.frameStartedLoading ||
-      this.#currentNavigation.cdpStates.frameRequestedNavigation ||
-      (this.#initialNavigation && !urlMatchesAboutBlank(url));
-
-    if (isNewNavigation) {
-      this.createNavigation(url);
-    } else {
-      this.#currentNavigation.url = url;
-    }
-    this.#currentNavigation.markStarted();
-    this.#currentNavigation.cdpStates.frameRequestedNavigation = true;
-  };
-}
+import {
+  type NavigationEventName,
+  NavigationTracker,
+} from './NavigationTracker.js';
 
 export class BrowsingContextImpl {
   static readonly LOGGER_PREFIX = `${LogType.debug}:browsingContext` as const;
@@ -371,14 +188,6 @@ export class BrowsingContextImpl {
     );
 
     return context;
-  }
-
-  static getTimestamp(): number {
-    // `timestamp` from the event is MonotonicTime, not real time, so
-    // the best Mapper can do is to set the timestamp to the epoch time
-    // of the event arrived.
-    // https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-MonotonicTime
-    return new Date().getTime();
   }
 
   /**
@@ -676,7 +485,7 @@ export class BrowsingContextImpl {
         return;
       }
 
-      const timestamp = BrowsingContextImpl.getTimestamp();
+      const timestamp = getTimestamp();
 
       switch (params.name) {
         case 'DOMContentLoaded':

--- a/src/bidiMapper/modules/context/NavigationTracker.ts
+++ b/src/bidiMapper/modules/context/NavigationTracker.ts
@@ -1,0 +1,214 @@
+/*
+ *  Copyright 2024 Google LLC.
+ *  Copyright (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+import {
+  type BrowsingContext,
+  ChromiumBidi,
+} from '../../../protocol/protocol.js';
+import {Deferred} from '../../../utils/Deferred.js';
+import {getTimestamp} from '../../../utils/Time.js';
+import {urlMatchesAboutBlank} from '../../../utils/UrlHelpers.js';
+import {uuidv4} from '../../../utils/uuid.js';
+import type {EventManager} from '../session/EventManager.js';
+
+export type NavigationEventName =
+  // TODO: implement.
+  // ChromiumBidi.BrowsingContext.EventNames.DownloadWillBegin|
+  | ChromiumBidi.BrowsingContext.EventNames.FragmentNavigated
+  | ChromiumBidi.BrowsingContext.EventNames.NavigationAborted
+  | ChromiumBidi.BrowsingContext.EventNames.NavigationFailed;
+
+class NavigationState {
+  started = new Deferred<void>();
+  finished = new Deferred<NavigationEventName>();
+
+  // Tracks CDP events on the navigation. Used to distinguish new navigations from the
+  // initial one.
+  cdpStates = {
+    frameScheduledNavigation: false,
+    frameRequestedNavigation: false,
+    frameStartedLoading: false,
+  };
+
+  markFragmentNavigated() {
+    this.started.resolve();
+    this.finished.resolve(
+      ChromiumBidi.BrowsingContext.EventNames.FragmentNavigated,
+    );
+  }
+
+  markNavigationAborted() {
+    this.started.resolve();
+    this.finished.resolve(
+      ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
+    );
+  }
+
+  markNavigationFailed() {
+    this.started.resolve();
+    this.finished.resolve(
+      ChromiumBidi.BrowsingContext.EventNames.NavigationFailed,
+    );
+  }
+
+  readonly navigationId = uuidv4();
+  url: string;
+  readonly #browsingContextId: string;
+
+  constructor(browsingContextId: string, url: string) {
+    this.#browsingContextId = browsingContextId;
+    this.url = url;
+  }
+
+  navigationInfo(): BrowsingContext.NavigationInfo {
+    return {
+      context: this.#browsingContextId,
+      navigation: this.navigationId,
+      timestamp: getTimestamp(),
+      url: this.url,
+    };
+  }
+
+  markStarted(): void {
+    this.started.resolve();
+  }
+}
+
+export class NavigationTracker {
+  #initialNavigation = true;
+  #currentNavigation: NavigationState;
+  readonly #eventManager: EventManager;
+  readonly #browsingContextId: string;
+
+  constructor(eventManager: EventManager, browsingContextId: string) {
+    this.#eventManager = eventManager;
+    this.#browsingContextId = browsingContextId;
+    // Initial navigation. No need for event listeners.
+    this.#currentNavigation = new NavigationState(
+      this.#browsingContextId,
+      'about:blank',
+    );
+  }
+
+  get navigationId(): string {
+    return this.#currentNavigation.navigationId;
+  }
+
+  dispose() {
+    this.#currentNavigation.markNavigationAborted();
+  }
+
+  createNavigation(url: string): NavigationState {
+    this.#initialNavigation = false;
+    if (this.#currentNavigation !== undefined) {
+      this.#currentNavigation.markNavigationAborted();
+    }
+    const navigation = new NavigationState(this.#browsingContextId, url);
+    this.#setEventListeners(navigation);
+
+    this.#currentNavigation = navigation;
+    return navigation;
+  }
+
+  #setEventListeners(navigation: NavigationState) {
+    void navigation.started.then(() => {
+      this.#eventManager.registerEvent(
+        {
+          type: 'event',
+          method: ChromiumBidi.BrowsingContext.EventNames.NavigationStarted,
+          params: navigation.navigationInfo(),
+        },
+        this.#browsingContextId,
+      );
+      return;
+    });
+
+    void navigation.finished.then((eventName: NavigationEventName) => {
+      this.#eventManager.registerEvent(
+        {
+          type: 'event',
+          method: eventName,
+          params: navigation.navigationInfo(),
+        },
+        this.#browsingContextId,
+      );
+      return;
+    });
+  }
+
+  frameNavigated(url: string): void {
+    this.#currentNavigation.url = url;
+  }
+
+  navigatedWithinDocument(url: string, navigationType: string): void {
+    this.#currentNavigation.url = url;
+    if (navigationType === 'fragment') {
+      this.#currentNavigation.markFragmentNavigated();
+    }
+  }
+
+  frameStartedLoading(): void {
+    this.#currentNavigation.markStarted();
+    this.#currentNavigation.cdpStates.frameStartedLoading = true;
+  }
+
+  frameScheduledNavigation(url: string): void {
+    // Signals that it's a new navigation:
+    // 1. The `Page.frameStartedLoading` was already emitted.
+    // 2. The `Page.frameScheduledNavigation` was already emitted.
+    // 3. The `Page.frameRequestedNavigation` was already emitted, which cannot happen
+    //    before `Page.frameScheduledNavigation`.
+    // 4. The current navigation is the initial one, and the URL does not match
+    //    `about:blank`.
+    const isNewNavigation =
+      this.#currentNavigation.cdpStates.frameStartedLoading ||
+      this.#currentNavigation.cdpStates.frameRequestedNavigation ||
+      this.#currentNavigation.cdpStates.frameScheduledNavigation ||
+      (this.#initialNavigation && !urlMatchesAboutBlank(url));
+
+    if (isNewNavigation) {
+      this.createNavigation(url);
+    } else {
+      this.#currentNavigation.url = url;
+    }
+    this.#currentNavigation.markStarted();
+    this.#currentNavigation.cdpStates.frameScheduledNavigation = true;
+  }
+
+  frameRequestedNavigation = (url: string): void => {
+    // Signals that it's a new navigation:
+    // 1. The `Page.frameStartedLoading` was already emitted.
+    // 2. The `Page.frameRequestedNavigation` was already emitted. Note that having
+    //    `Page.frameScheduledNavigation` emitted at this point does not signal the new
+    //    navigation.
+    // 3. The current navigation is the initial one, and the URL does not match
+    //    `about:blank`.
+    const isNewNavigation =
+      this.#currentNavigation.cdpStates.frameStartedLoading ||
+      this.#currentNavigation.cdpStates.frameRequestedNavigation ||
+      (this.#initialNavigation && !urlMatchesAboutBlank(url));
+
+    if (isNewNavigation) {
+      this.createNavigation(url);
+    } else {
+      this.#currentNavigation.url = url;
+    }
+    this.#currentNavigation.markStarted();
+    this.#currentNavigation.cdpStates.frameRequestedNavigation = true;
+  };
+}

--- a/src/utils/Time.spec.ts
+++ b/src/utils/Time.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2024 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {expect} from 'chai';
+
+import {getTimestamp} from './Time.js';
+
+describe('getTimestamp', () => {
+  it('should return a number', () => {
+    const timestamp = getTimestamp();
+    expect(timestamp).to.be.a('number');
+  });
+
+  it(`should return a timestamp between '2020-01-01 00:00:00' and '2100-01-01 00:00:00'`, () => {
+    const timestamp = getTimestamp();
+    // Using a large delta to account for execution time and clock drift.
+    // In a real test, consider mocking the underlying time source.
+    expect(timestamp).to.be.within(1577833200000, 4102441200000);
+  });
+});

--- a/src/utils/Time.ts
+++ b/src/utils/Time.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function getTimestamp(): number {
+  // `timestamp` from the event is MonotonicTime, not real time, so
+  // the best Mapper can do is to set the timestamp to the epoch time
+  // of the event arrived.
+  // https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-MonotonicTime
+  return new Date().getTime();
+}

--- a/tests/browsing_context/test_close.py
+++ b/tests/browsing_context/test_close.py
@@ -257,7 +257,7 @@ async def test_browsingContext_navigate_prompt(websocket, context_id, html,
         assert resp == AnyExtending({
             'error': 'unknown error',
             'id': navigate_command_id,
-            'message': 'navigation aborted',
+            'message': 'navigation failed',
             'stacktrace': ANY_STR,
             'type': 'error',
         })

--- a/tests/browsing_context/test_close.py
+++ b/tests/browsing_context/test_close.py
@@ -257,7 +257,7 @@ async def test_browsingContext_navigate_prompt(websocket, context_id, html,
         assert resp == AnyExtending({
             'error': 'unknown error',
             'id': navigate_command_id,
-            'message': 'net::ERR_ABORTED',
+            'message': 'navigation aborted',
             'stacktrace': ANY_STR,
             'type': 'error',
         })

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -685,7 +685,7 @@ async def test_browsingContext_acceptInsecureCertsCapability_respected(
         with pytest.raises(Exception,
                            match=str({
                                'error': 'unknown error',
-                               'message': 'net::ERR_CERT_AUTHORITY_INVALID'
+                               'message': 'navigation failed'
                            })):
             await navigate()
 

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -20,7 +20,7 @@ from test_helpers import (ANY_TIMESTAMP, ANY_UUID, AnyExtending,
 
 
 @pytest.mark.asyncio
-async def test_browsingContext_navigateWaitInteractive_redirect(
+async def test_browsingContext_navigateWaitInteractive_redirect_navigaionFailed(
         websocket, context_id, html, url_example, read_sorted_messages):
     await subscribe(websocket, ["browsingContext.navigationAborted"])
 
@@ -39,17 +39,18 @@ async def test_browsingContext_navigateWaitInteractive_redirect(
     [navigation_result,
      navigation_aborted_event] = await read_sorted_messages(2)
     assert navigation_result == AnyExtending({
+        'error': 'unknown error',
         'id': command_id,
-        'type': 'success'
+        'message': 'navigation aborted',
+        'stacktrace': ANY_STR,
+        'type': 'error',
     })
-    initial_navigation_id = navigation_result['result']['navigation']
-
     assert navigation_aborted_event == AnyExtending({
         'method': 'browsingContext.navigationAborted',
         'type': 'event',
         'params': {
             'context': context_id,
-            'navigation': initial_navigation_id,
+            'navigation': ANY_UUID,
             'timestamp': ANY_TIMESTAMP,
             'url': initial_url
         }
@@ -566,7 +567,7 @@ async def test_browsingContext_navigationStarted_browsingContextClosedBeforeNavi
         'id': navigate_command_id,
         'type': 'error',
         'error': 'unknown error',
-        'message': 'navigation canceled by context disposal',
+        'message': 'navigation aborted',
     })
 
     assert close_command_result == AnyExtending({

--- a/tests/browsing_context/test_print.py
+++ b/tests/browsing_context/test_print.py
@@ -19,7 +19,11 @@ from test_helpers import execute_command, goto_url
 
 
 @pytest.mark.asyncio
-async def test_print_top_level_context(websocket, context_id, html):
+async def test_print_top_level_context(websocket, context_id, html,
+                                       test_headless_mode):
+    if test_headless_mode == "old":
+        pytest.xfail("PDF viewer not available in headless.")
+
     await goto_url(websocket, context_id, html())
 
     print_result = await execute_command(
@@ -38,15 +42,8 @@ async def test_print_top_level_context(websocket, context_id, html):
     # 'data' is not deterministic, ~a dozen characters differ between runs.
     assert print_result["data"] == ANY_STR
 
-    try:
-        await goto_url(websocket, context_id,
-                       f'data:application/pdf,base64;{print_result["data"]}')
-    except Exception as e:
-        assert e.args[0] == {
-            'error': 'unknown error',
-            'message': 'net::ERR_ABORTED'
-        }
-        pytest.xfail("PDF viewer not available in headless.")
+    await goto_url(websocket, context_id,
+                   f'data:application/pdf,base64;{print_result["data"]}')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Extract navigation tracking logic to a dedicated class. Simplify the logic. Required to be able to make further adjustments to the navigation logic.

Out of scope: document tracking.