### PR TITLE
test: make puppeteer tests required on releases

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - run: gh pr edit "$NUMBER" --add-label "puppeteer"
+      - run: gh pr edit "$NUMBER" --add-label "puppeteer" --add-label "puppeteer-required"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -90,3 +90,13 @@ jobs:
         env:
           PUPPETEER_EXECUTABLE_PATH: ${{ steps.browser.outputs.executablePath }}
         run: xvfb-run --auto-servernum npm run test:chrome:bidi -- --shard '${{ matrix.shard }}'
+
+  puppeteer-test-required:
+    name: '[Required] Puppeteer tests'
+    needs: [puppeteer-test]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - if: ${{ needs.puppeteer-test.result != 'success' && contains(github.event.pull_request.labels.*.name, 'puppeteer-required') }}
+        run: 'exit 1'
+      - run: 'exit 0'


### PR DESCRIPTION
This PR adds an automation label `puppeteer-required` that would make Puppeteer test failures to block the release PRs requiring suppressing the test failure in Puppeteer's main branch if a change with regressions needs to be released.