### PR TITLE
feat: abort navigation only after frame navigated

### DIFF
--- a/src/bidiMapper/modules/context/NavigationTracker.spec.ts
+++ b/src/bidiMapper/modules/context/NavigationTracker.spec.ts
@@ -160,7 +160,7 @@ describe('NavigationTracker', () => {
       });
     });
 
-    it('aborted by script-initiated navigation', async () => {
+    it('canceled by script-initiated navigation', async () => {
       const navigation = navigationTracker.createPendingNavigation(SOME_URL);
       navigationTracker.frameStartedNavigating(ANOTHER_URL, LOADER_ID);
 
@@ -173,6 +173,30 @@ describe('NavigationTracker', () => {
       navigationTracker.frameRequestedNavigation(YET_ANOTHER_URL);
 
       assertNavigationEvent(
+        ChromiumBidi.BrowsingContext.EventNames.NavigationFailed,
+        navigation.navigationId,
+        ANOTHER_URL,
+      );
+
+      assert.equal(
+        (await navigation.finished).eventName,
+        NavigationEventName.NavigationFailed,
+      );
+      assert.equal(navigationTracker.currentNavigationId, initialNavigationId);
+      assert.equal(navigationTracker.url, INITIAL_URL);
+    });
+
+    it('aborted by script-initiated navigation', async () => {
+      const navigation = navigationTracker.createPendingNavigation(SOME_URL);
+      navigationTracker.frameStartedNavigating(ANOTHER_URL, LOADER_ID);
+      navigationTracker.frameNavigated(ANOTHER_URL, LOADER_ID);
+
+      eventManager.registerEvent.reset();
+
+      navigationTracker.frameRequestedNavigation(YET_ANOTHER_URL);
+      navigationTracker.frameNavigated(YET_ANOTHER_URL, ANOTHER_LOADER_ID);
+
+      assertNavigationEvent(
         ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
         navigation.navigationId,
         ANOTHER_URL,
@@ -182,8 +206,6 @@ describe('NavigationTracker', () => {
         (await navigation.finished).eventName,
         NavigationEventName.NavigationAborted,
       );
-      assert.equal(navigationTracker.currentNavigationId, initialNavigationId);
-      assert.equal(navigationTracker.url, INITIAL_URL);
     });
 
     it('failed command', async () => {
@@ -296,7 +318,7 @@ describe('NavigationTracker', () => {
         assertNoNavigationEvents();
       });
 
-      it('aborted by script-initiated navigation', () => {
+      it('canceled by script-initiated navigation', async () => {
         navigationTracker.frameRequestedNavigation(SOME_URL);
 
         assertNoNavigationEvents();
@@ -317,7 +339,7 @@ describe('NavigationTracker', () => {
         navigationTracker.frameRequestedNavigation(YET_ANOTHER_URL);
 
         assertNavigationEvent(
-          ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
+          ChromiumBidi.BrowsingContext.EventNames.NavigationFailed,
           sinon.match.any,
           ANOTHER_URL,
         );
@@ -328,7 +350,7 @@ describe('NavigationTracker', () => {
         assert.equal(navigationTracker.url, INITIAL_URL);
       });
 
-      it('aborted by command navigation', () => {
+      it('canceled by command navigation', async () => {
         navigationTracker.frameRequestedNavigation(SOME_URL);
         navigationTracker.frameStartedNavigating(ANOTHER_URL, LOADER_ID);
 
@@ -341,7 +363,7 @@ describe('NavigationTracker', () => {
         navigationTracker.createPendingNavigation(YET_ANOTHER_URL);
 
         assertNavigationEvent(
-          ChromiumBidi.BrowsingContext.EventNames.NavigationAborted,
+          ChromiumBidi.BrowsingContext.EventNames.NavigationFailed,
           sinon.match.any,
           ANOTHER_URL,
         );

--- a/tests/browsing_context/__snapshots__/test_navigate_events.ambr
+++ b/tests/browsing_context/__snapshots__/test_navigate_events.ambr
@@ -180,6 +180,96 @@
     }),
   ])
 # ---
+# name: test_navigate_hang_navigate_again_checkEvents
+  list([
+    dict({
+      'method': 'network.beforeRequestSent',
+      'params': dict({
+        'context': 'stable_0',
+        'isBlocked': False,
+        'navigation': 'stable_1',
+        'redirectCount': 0,
+        'request': 'stable_4',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationFailed',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_3',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'error': 'unknown error',
+      'id': 'stable_5',
+      'message': 'navigation canceled by concurrent navigation',
+      'type': 'error',
+    }),
+    dict({
+      'method': 'script.message',
+      'params': dict({
+        'channel': 'beforeunload_channel',
+        'data': dict({
+          'type': 'string',
+          'value': 'beforeunload',
+        }),
+        'source': dict({
+          'context': 'stable_0',
+        }),
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_6',
+        'url': 'stable_7',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'network.beforeRequestSent',
+      'params': dict({
+        'context': 'stable_0',
+        'isBlocked': False,
+        'navigation': 'stable_6',
+        'redirectCount': 0,
+        'request': 'stable_9',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.domContentLoaded',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_6',
+        'url': 'stable_7',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.load',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_6',
+        'url': 'stable_7',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'id': 'stable_10',
+      'result': dict({
+        'navigation': 'stable_6',
+        'url': 'stable_7',
+      }),
+      'type': 'success',
+    }),
+  ])
+# ---
 # name: test_reload_aboutBlank_checkEvents
   list([
     dict({

--- a/tests/browsing_context/test_navigate_events.py
+++ b/tests/browsing_context/test_navigate_events.py
@@ -16,10 +16,10 @@
 import pytest
 from syrupy.filters import props
 from test_helpers import (execute_command, goto_url, send_JSON_command,
-                          subscribe)
+                          subscribe, wait_for_event)
 
-SNAPSHOT_EXCLUDE = props("timestamp", "message", "timings", "headers",
-                         "stacktrace", "response", "initiator", "realm")
+SNAPSHOT_EXCLUDE = props("timestamp", "timings", "headers", "stacktrace",
+                         "response", "initiator", "realm")
 KEYS_TO_STABILIZE = ['context', 'navigation', 'id', 'url', 'request']
 
 
@@ -126,6 +126,48 @@ async def test_navigate_dataUrl_checkEvents(websocket, context_id, url_base,
         })
 
     messages = await read_messages(6,
+                                   keys_to_stabilize=KEYS_TO_STABILIZE,
+                                   check_no_other_messages=True,
+                                   sort=False)
+    assert messages == snapshot(exclude=SNAPSHOT_EXCLUDE)
+
+
+@pytest.mark.asyncio
+async def test_navigate_hang_navigate_again_checkEvents(
+        websocket, context_id, url_base, url_hang_forever,
+        url_example_another_origin, read_messages, snapshot,
+        assert_no_more_messages):
+    # Use `url_example_another_origin`, as `url_example` will hang because of
+    # `url_hang_forever`.
+    await goto_url(websocket, context_id, url_base)
+    await set_beforeunload_handler(websocket, context_id)
+    await subscribe(
+        websocket,
+        ["browsingContext", "script.message", "network.beforeRequestSent"])
+
+    await send_JSON_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "url": url_hang_forever,
+                "wait": "complete",
+                "context": context_id
+            }
+        })
+
+    await wait_for_event(websocket, "browsingContext.navigationStarted")
+
+    await send_JSON_command(
+        websocket, {
+            "method": "browsingContext.navigate",
+            "params": {
+                "url": url_example_another_origin,
+                "wait": "complete",
+                "context": context_id
+            }
+        })
+
+    messages = await read_messages(9,
                                    keys_to_stabilize=KEYS_TO_STABILIZE,
                                    check_no_other_messages=True,
                                    sort=False)

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -4,3 +4,6 @@
 
   [test_with_new_navigation]
     expected: [PASS, FAIL]
+
+  [test_close_iframe]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -4,3 +4,6 @@
 
   [test_with_new_navigation]
     expected: [PASS, FAIL]
+
+  [test_close_iframe]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigation_failed/navigation_failed.py.ini
@@ -4,3 +4,6 @@
 
   [test_with_new_navigation]
     expected: [PASS, FAIL]
+
+  [test_close_iframe]
+    expected: FAIL


### PR DESCRIPTION
WPT failures are due to the fact Chrome emits `frameNavigated` after receiving headers.
https://github.com/web-platform-tests/wpt/pull/49718