### PR TITLE
Revert "test: unmark flaky from `test_non_printable_key_sends_events`"

### DIFF
--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/key_events.py.ini
@@ -1,0 +1,3 @@
+[key_events.py]
+  [test_non_printable_key_sends_events[\\ue00c-ESCAPE\]]
+    expected: [FAIL, PASS]


### PR DESCRIPTION
Reverts GoogleChromeLabs/chromium-bidi#2545