### PR TITLE
feat: throw a proper error if the browsing context was destroyed during action dispatching

### DIFF
--- a/src/bidiMapper/modules/input/ActionDispatcher.ts
+++ b/src/bidiMapper/modules/input/ActionDispatcher.ts
@@ -28,6 +28,7 @@ import {
   isSingleGrapheme,
 } from '../../../utils/GraphemeTools.js';
 import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
+import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
 
 import type {ActionOption} from './ActionOption.js';
 import {
@@ -90,19 +91,31 @@ export class ActionDispatcher {
     return result.result.value;
   };
 
+  readonly #browsingContextStorage: BrowsingContextStorage;
+
   #tickStart = 0;
   #tickDuration = 0;
   #inputState: InputState;
-  #context: BrowsingContextImpl;
+  #contextId: string;
   #isMacOS: boolean;
+
   constructor(
     inputState: InputState,
-    context: BrowsingContextImpl,
+    browsingContextStorage: BrowsingContextStorage,
+    contextId: string,
     isMacOS: boolean,
   ) {
+    this.#browsingContextStorage = browsingContextStorage;
     this.#inputState = inputState;
-    this.#context = context;
+    this.#contextId = contextId;
     this.#isMacOS = isMacOS;
+  }
+
+  /**
+   * The context can be disposed between action ticks, so need to get it each time.
+   */
+  get #context() {
+    return this.#browsingContextStorage.getContext(this.#contextId);
   }
 
   async dispatchActions(

--- a/src/bidiMapper/modules/input/InputProcessor.ts
+++ b/src/bidiMapper/modules/input/InputProcessor.ts
@@ -48,7 +48,8 @@ export class InputProcessor {
     const actionsByTick = this.#getActionsByTick(params, inputState);
     const dispatcher = new ActionDispatcher(
       inputState,
-      context,
+      this.#browsingContextStorage,
+      params.context,
       await ActionDispatcher.isMacOS(context).catch(() => false),
     );
     await dispatcher.dispatchActions(actionsByTick);
@@ -63,7 +64,8 @@ export class InputProcessor {
     const inputState = this.#inputStateManager.get(topContext);
     const dispatcher = new ActionDispatcher(
       inputState,
-      context,
+      this.#browsingContextStorage,
+      params.context,
       await ActionDispatcher.isMacOS(context).catch(() => false),
     );
     await dispatcher.dispatchTickActions(inputState.cancelList.reverse());


### PR DESCRIPTION
Get browsing context each time from the storage to guarantee it is not disposed.

+ e2e test