### PR TITLE
ci: try adding the puppeteer label last

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - run: gh pr edit "$NUMBER" --add-label "puppeteer" --add-label "puppeteer-required"
+      - run: gh pr edit "$NUMBER" --add-label "puppeteer-required" --add-label "puppeteer"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
Some race condition in GitHub Actions seems to prevent the Puppeteer workflow from detecting the Puppeteer label after the Puppeteer-Required label was added. Let us try to change the order