### PR TITLE
fix: regression in serialization

### DIFF
--- a/src/bidiMapper/modules/script/Realm.ts
+++ b/src/bidiMapper/modules/script/Realm.ts
@@ -112,15 +112,18 @@ export abstract class Realm {
         internalIdMap.set(weakLocalObjectReference, uuidv4());
       }
 
-      (deepSerializedValue as any).internalId = internalIdMap.get(
-        weakLocalObjectReference,
-      );
+      (
+        deepSerializedValue as Protocol.Runtime.DeepSerializedValue & {
+          internalId?: string;
+        }
+      ).internalId = internalIdMap.get(weakLocalObjectReference);
       delete deepSerializedValue['weakLocalObjectReference'];
     }
 
     if (
-      (deepSerializedValue as any).type === 'node' &&
-      Object.hasOwn(deepSerializedValue?.value, 'frameId')
+      deepSerializedValue.type === 'node' &&
+      deepSerializedValue.value &&
+      Object.hasOwn(deepSerializedValue.value, 'frameId')
     ) {
       // `frameId` is not needed in BiDi as it is not yet specified.
       delete deepSerializedValue.value['frameId'];
@@ -128,7 +131,7 @@ export abstract class Realm {
 
     // Platform object is a special case. It should have only `{type: object}`
     // without `value` field.
-    if ((deepSerializedValue as any).type === 'platformobject') {
+    if ((deepSerializedValue.type as string) === 'platformobject') {
       return {type: 'object'};
     }
 


### PR DESCRIPTION
Deeply nested nodes do not include values in CDP, thus, Object.hasOwn throws an error because only objects are allowed as the first arg.

Drive-by: improve types
Caused by: https://github.com/GoogleChromeLabs/chromium-bidi/pull/2622
Addresses: https://github.com/puppeteer/puppeteer/issues/13433
WPT test: https://github.com/web-platform-tests/wpt/pull/49821/files