### PR TITLE
feat: heuristic for request's `initiatorType` and `destination`

### DIFF
--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -911,9 +911,9 @@ export class NetworkRequest {
       headersSize: computeHeadersSize(headers),
       bodySize: this.#bodySize,
       // TODO: populate
-      destination: '',
+      destination: this.#getDestination(),
       // TODO: populate
-      initiatorType: null,
+      initiatorType: this.#getInitiatorType(),
       timings: this.#timings,
     };
 
@@ -922,7 +922,61 @@ export class NetworkRequest {
       'goog:postData': this.#request.info?.request?.postData,
       'goog:hasPostData': this.#request.info?.request?.hasPostData,
       'goog:resourceType': this.#request.info?.type,
+      'goog:resourceInitiator': this.#request.info?.initiator,
     } as Network.RequestData;
+  }
+
+  #getDestination(): string {
+    switch (this.#request.info?.type) {
+      case 'Script':
+        return 'script';
+      case 'Stylesheet':
+        return 'style';
+      case 'Image':
+        return 'image';
+      case 'Document':
+        // If request to document is initiated by parser| assume it is expected to
+        // arrive in an iframe. Otherwise, fallback to empty string.
+        return this.#request.info?.initiator.type === 'parser' ? 'iframe' : '';
+      default:
+        return '';
+    }
+  }
+
+  #getInitiatorType(): null | string {
+    if (this.#request.info?.initiator.type === 'parser') {
+      // Heuristic.
+      switch (this.#request.info?.type) {
+        case 'Document':
+          // The request to document is initiated by the parser. Assuming it's an iframe.
+          return 'iframe';
+        case 'Font':
+          // If the document's url is not the parser's url, assume the resource is loaded
+          // from css. Otherwise, it's a `font` element.
+          return this.#request.info?.initiator?.url ===
+            this.#request.info?.documentURL
+            ? 'font'
+            : 'css';
+        case 'Image':
+          // If the document's url is not the parser's url, assume the resource is loaded
+          // from css. Otherwise, it's a `img` element.
+          return this.#request.info?.initiator?.url ===
+            this.#request.info?.documentURL
+            ? 'img'
+            : 'css';
+        case 'Script':
+          return 'script';
+        case 'Stylesheet':
+          return 'link';
+        default:
+          return null;
+      }
+    }
+    if (this.#request?.info?.type === 'Fetch') {
+      return 'fetch';
+    }
+
+    return null;
   }
 
   #getBeforeRequestEvent(): Network.BeforeRequestSent {
@@ -933,9 +987,7 @@ export class NetworkRequest {
       params: {
         ...this.#getBaseEventParams(Network.InterceptPhase.BeforeRequestSent),
         initiator: {
-          type: NetworkRequest.#getInitiatorType(
-            this.#request.info.initiator.type,
-          ),
+          type: NetworkRequest.#getInitiator(this.#request.info.initiator.type),
           columnNumber: this.#request.info.initiator.columnNumber,
           lineNumber: this.#request.info.initiator.lineNumber,
           stackTrace: this.#request.info.initiator.stack,
@@ -999,7 +1051,7 @@ export class NetworkRequest {
     return overrideHeaders;
   }
 
-  static #getInitiatorType(
+  static #getInitiator(
     initiatorType: Protocol.Network.Initiator['type'],
   ): Network.Initiator['type'] {
     switch (initiatorType) {

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -926,6 +926,14 @@ export class NetworkRequest {
     } as Network.RequestData;
   }
 
+  /**
+   * Heuristic trying to guess the destination.
+   * Specification: https://fetch.spec.whatwg.org/#concept-request-destination.
+   * Specified values: "audio", "audioworklet", "document", "embed", "font", "frame",
+   * "iframe", "image", "json", "manifest", "object", "paintworklet", "report", "script",
+   * "serviceworker", "sharedworker", "style", "track", "video", "webidentity", "worker",
+   * "xslt".
+   */
   #getDestination(): string {
     switch (this.#request.info?.type) {
       case 'Script':
@@ -943,9 +951,15 @@ export class NetworkRequest {
     }
   }
 
+  /**
+   * Heuristic trying to guess the initiator type.
+   * Specification: https://fetch.spec.whatwg.org/#request-initiator-type.
+   * Specified values: "audio", "beacon", "body", "css", "early-hints", "embed", "fetch",
+   * "font", "frame", "iframe", "image", "img", "input", "link", "object", "ping",
+   * "script", "track", "video", "xmlhttprequest", "other".
+   */
   #getInitiatorType(): null | string {
     if (this.#request.info?.initiator.type === 'parser') {
-      // Heuristic.
       switch (this.#request.info?.type) {
         case 'Document':
           // The request to document is initiated by the parser. Assuming it's an iframe.

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -943,7 +943,7 @@ export class NetworkRequest {
       case 'Image':
         return 'image';
       case 'Document':
-        // If request to document is initiated by parser| assume it is expected to
+        // If request to document is initiated by parser, assume it is expected to
         // arrive in an iframe. Otherwise, fallback to empty string.
         return this.#request.info?.initiator.type === 'parser' ? 'iframe' : '';
       default:

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -59,7 +59,9 @@ async def test_network_before_request_sent_event_emitted(
                 "cookies": [],
                 "headersSize": ANY_NUMBER,
                 "bodySize": 0,
-                "timings": ANY_DICT
+                "timings": ANY_DICT,
+                "initiatorType": None,
+                "destination": "",
             },
             "initiator": {
                 "type": "other"
@@ -116,7 +118,9 @@ async def test_network_before_request_sent_event_emitted_with_url_fragment(
                 "cookies": [],
                 "headersSize": ANY_NUMBER,
                 "bodySize": 0,
-                "timings": ANY_DICT
+                "timings": ANY_DICT,
+                "initiatorType": None,
+                "destination": "",
             },
             "initiator": {
                 "type": "other"
@@ -217,7 +221,9 @@ async def test_network_before_request_sent_event_with_cookies_emitted(
                 ], []),
                 "headersSize": ANY_NUMBER,
                 "bodySize": 0,
-                "timings": ANY_DICT
+                "timings": ANY_DICT,
+                "initiatorType": None,
+                "destination": "",
             },
             "initiator": {
                 "type": "other"
@@ -411,7 +417,9 @@ async def test_network_before_request_sent_event_with_data_url_emitted(
                 "cookies": ANY_LIST,
                 "headersSize": 0,
                 "bodySize": 0,
-                "timings": ANY_DICT
+                "timings": ANY_DICT,
+                "initiatorType": None,
+                "destination": "",
             },
             "initiator": {
                 "type": "other"
@@ -474,7 +482,9 @@ async def test_network_sends_only_included_cookies(websocket, context_id,
                 "cookies": [],
                 "headersSize": ANY_NUMBER,
                 "bodySize": 0,
-                "timings": ANY_DICT
+                "timings": ANY_DICT,
+                "initiatorType": None,
+                "destination": "",
             },
             "initiator": {
                 "type": "other"
@@ -521,7 +531,9 @@ async def test_network_should_not_block_queue_shared_workers_with_data_url(
                 "cookies": [],
                 "headersSize": ANY_NUMBER,
                 "bodySize": 0,
-                "timings": ANY_DICT
+                "timings": ANY_DICT,
+                "initiatorType": None,
+                "destination": "script",
             },
             "initiator": {
                 "type": "other"

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py.ini
@@ -1,3 +1,0 @@
-[before_request_sent.py]
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/response_completed/response_completed.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/response_completed/response_completed.py.ini
@@ -13,6 +13,3 @@
 
   [test_response_status[407-Proxy Authentication Required\]]
     expected: FAIL
-
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/response_started/response_started.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/response_started/response_started.py.ini
@@ -7,6 +7,3 @@
 
   [test_www_authenticate]
     expected: FAIL
-
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py.ini
@@ -1,3 +1,0 @@
-[before_request_sent.py]
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/response_completed/response_completed.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/response_completed/response_completed.py.ini
@@ -13,6 +13,3 @@
 
   [test_response_status[407-Proxy Authentication Required\]]
     expected: FAIL
-
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/response_started/response_started.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/response_started/response_started.py.ini
@@ -7,6 +7,3 @@
 
   [test_www_authenticate]
     expected: FAIL
-
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/before_request_sent/before_request_sent.py.ini
@@ -1,3 +1,0 @@
-[before_request_sent.py]
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/response_completed/response_completed.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/response_completed/response_completed.py.ini
@@ -13,6 +13,3 @@
 
   [test_response_status[407-Proxy Authentication Required\]]
     expected: FAIL
-
-  [test_destination_initiator]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/response_started/response_started.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/response_started/response_started.py.ini
@@ -4,6 +4,3 @@
 
   [test_response_status[407-Proxy Authentication Required\]]
     expected: FAIL
-
-  [test_destination_initiator]
-    expected: FAIL


### PR DESCRIPTION
Add heuristic to support some of `initiatorType` and `destination` in network requests.