### PR TITLE
fix(network): url for interception

### DIFF
--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -153,9 +153,9 @@ export class NetworkRequest {
       this.#request.paused?.request.urlFragment ??
       '';
     const url =
-      this.#response.info?.url ??
       this.#response.paused?.request.url ??
       this.#requestOverrides?.url ??
+      this.#response.info?.url ??
       this.#request.auth?.request.url ??
       this.#request.info?.request.url ??
       this.#request.paused?.request.url ??

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/continue_request/url.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/network/continue_request/url.py.ini
@@ -1,3 +1,0 @@
-[url.py]
-  [test_navigation]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/continue_request/url.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/network/continue_request/url.py.ini
@@ -1,3 +1,0 @@
-[url.py]
-  [test_navigation]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/continue_request/url.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/continue_request/url.py.ini
@@ -1,3 +1,0 @@
-[url.py]
-  [test_navigation]
-    expected: FAIL


### PR DESCRIPTION
It seems that CDP does not report the correct URL on the response. Have to double check, but the other part of the WPT test pass so I am confident this is the case.