### PR TITLE
fix: wait for context should respect already existing contexts

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextStorage.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextStorage.ts
@@ -79,6 +79,10 @@ export class BrowsingContextStorage {
   waitForContext(
     browsingContextId: BrowsingContext.BrowsingContext,
   ): Promise<BrowsingContextImpl> {
+    if (this.#contexts.has(browsingContextId)) {
+      return Promise.resolve(this.getContext(browsingContextId));
+    }
+
     return new Promise((resolve) => {
       const listener = (event: {browsingContext: BrowsingContextImpl}) => {
         if (event.browsingContext.id === browsingContextId) {


### PR DESCRIPTION
This should address Puppeteer test failures: https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/12827546451/job/35769733285?pr=2993

Tested manually. 1000 times run Puppeteer test "[locator.spec] Locator Locator.prototype.filter should resolve as soon as the predicate matches" with and without the change. Problem is gone.