### PR TITLE
chore: warn if legacy BiDi+ is used

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -254,14 +254,26 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       // https://github.com/GoogleChromeLabs/chromium-bidi/issues/2844
       // keep-sorted start block=yes
       case 'cdp.getSession':
+        this.#logger?.(
+          LogType.debugWarn,
+          `Legacy '${command.method}' command is deprecated and will not supported soon. Use 'goog:${command.method}' instead.`,
+        );
         return this.#cdpProcessor.getSession(
           this.#parser.parseGetSessionParams(command.params),
         );
       case 'cdp.resolveRealm':
+        this.#logger?.(
+          LogType.debugWarn,
+          `Legacy '${command.method}' command is deprecated and will not supported soon. Use 'goog:${command.method}' instead.`,
+        );
         return this.#cdpProcessor.resolveRealm(
           this.#parser.parseResolveRealmParams(command.params),
         );
       case 'cdp.sendCommand':
+        this.#logger?.(
+          LogType.debugWarn,
+          `Legacy '${command.method}' command is deprecated and will not supported soon. Use 'goog:${command.method}' instead.`,
+        );
         return await this.#cdpProcessor.sendCommand(
           this.#parser.parseSendCommandParams(command.params),
         );

--- a/src/bidiTab/Transport.ts
+++ b/src/bidiTab/Transport.ts
@@ -29,6 +29,7 @@ import {log} from './mapperTabPage.js';
 export class WindowBidiTransport implements BidiTransport {
   static readonly LOGGER_PREFIX_RECV = `${LogType.bidi}:RECV ◂` as const;
   static readonly LOGGER_PREFIX_SEND = `${LogType.bidi}:SEND ▸` as const;
+  static readonly LOGGER_PREFIX_WARN = LogType.debugWarn as const;
 
   #onMessage: ((message: ChromiumBidi.Command) => void) | null = null;
 
@@ -168,6 +169,10 @@ export class WindowBidiTransport implements BidiTransport {
         channel = {'goog:channel': command['goog:channel'] as string};
       }
     } else if (command.channel !== undefined) {
+      log(
+        WindowBidiTransport.LOGGER_PREFIX_WARN,
+        'Legacy `channel` parameter is deprecated and will not supported soon. Use `goog:channel` instead.',
+      );
       const channelType = WindowBidiTransport.#getJsonType(command.channel);
       if (channelType !== 'string') {
         throw new Error(`Expected string 'channel' but got ${channelType}`);

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -22,6 +22,7 @@ export enum LogType {
   debug = 'debug',
   debugError = 'debug:error',
   debugInfo = 'debug:info',
+  debugWarn = 'debug:warn',
   // keep-sorted end
 }
 


### PR DESCRIPTION
Addressing https://github.com/GoogleChromeLabs/chromium-bidi/issues/2843.

Tested manually.