### PR TITLE
fix: handle max depth property

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -221,7 +221,7 @@ export class BrowsingContextImpl {
         {
           type: 'event',
           method: ChromiumBidi.BrowsingContext.EventNames.ContextDestroyed,
-          params: this.serializeToBidiValue(),
+          params: this.serializeToBidiValue(null),
         },
         this.id,
       );
@@ -361,8 +361,11 @@ export class BrowsingContextImpl {
     return maybeSandboxes[0]!;
   }
 
+  /**
+   * Implements https://w3c.github.io/webdriver-bidi/#get-the-navigable-info.
+   */
   serializeToBidiValue(
-    maxDepth = 0,
+    maxDepth: number | null = 0,
     addParentField = true,
   ): BrowsingContext.Info {
     return {
@@ -373,9 +376,12 @@ export class BrowsingContextImpl {
       // TODO(#2646): Implement Client Window correctly
       clientWindow: '',
       children:
-        maxDepth > 0
+        maxDepth === null || maxDepth > 0
           ? this.directChildren.map((c) =>
-              c.serializeToBidiValue(maxDepth - 1, false),
+              c.serializeToBidiValue(
+                maxDepth === null ? maxDepth : maxDepth - 1,
+                false,
+              ),
             )
           : null,
       ...(addParentField ? {parent: this.#parentId} : {}),

--- a/tests/browsing_context/test_close.py
+++ b/tests/browsing_context/test_close.py
@@ -38,7 +38,7 @@ async def test_browsingContext_close(websocket, context_id):
             "context": context_id,
             "parent": None,
             "url": "about:blank",
-            "children": None,
+            "children": [],
             "userContext": "default"
         }
     })
@@ -139,7 +139,7 @@ async def test_browsingContext_close_prompt(websocket, context_id, html,
             'method': 'browsingContext.contextDestroyed',
             'params': {
                 'context': context_id,
-                'children': None,
+                'children': [],
                 'originalOpener': None,
                 'clientWindow': ANY_STR,
                 'parent': None,

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py.ini
@@ -1,30 +1,6 @@
 [context_destroyed.py]
-  [test_new_context[tab\]]
-    expected: FAIL
-
-  [test_new_context[window\]]
-    expected: FAIL
-
-  [test_navigate_iframe[same_origin\]]
-    expected: FAIL
-
-  [test_navigate_iframe[cross_origin\]]
-    expected: FAIL
-
-  [test_delete_iframe]
-    expected: FAIL
-
   [test_nested_iframes_delete_top_iframe]
     expected: FAIL
 
-  [test_nested_iframes_delete_deepest_iframe]
-    expected: FAIL
-
   [test_iframe_destroy_parent]
-    expected: FAIL
-
-  [test_new_user_context[tab\]]
-    expected: FAIL
-
-  [test_new_user_context[window\]]
     expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py.ini
@@ -1,30 +1,6 @@
 [context_destroyed.py]
-  [test_new_context[tab\]]
-    expected: FAIL
-
-  [test_new_context[window\]]
-    expected: FAIL
-
-  [test_navigate_iframe[same_origin\]]
-    expected: FAIL
-
-  [test_navigate_iframe[cross_origin\]]
-    expected: FAIL
-
-  [test_delete_iframe]
-    expected: FAIL
-
   [test_nested_iframes_delete_top_iframe]
     expected: FAIL
 
-  [test_nested_iframes_delete_deepest_iframe]
-    expected: FAIL
-
   [test_iframe_destroy_parent]
-    expected: FAIL
-
-  [test_new_user_context[tab\]]
-    expected: FAIL
-
-  [test_new_user_context[window\]]
     expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/context_destroyed/context_destroyed.py.ini
@@ -1,30 +1,6 @@
 [context_destroyed.py]
-  [test_new_context[tab\]]
-    expected: FAIL
-
-  [test_new_context[window\]]
-    expected: FAIL
-
-  [test_navigate_iframe[same_origin\]]
-    expected: FAIL
-
-  [test_navigate_iframe[cross_origin\]]
-    expected: FAIL
-
-  [test_delete_iframe]
-    expected: FAIL
-
   [test_nested_iframes_delete_top_iframe]
     expected: FAIL
 
-  [test_nested_iframes_delete_deepest_iframe]
-    expected: FAIL
-
   [test_iframe_destroy_parent]
-    expected: FAIL
-
-  [test_new_user_context[tab\]]
-    expected: FAIL
-
-  [test_new_user_context[window\]]
     expected: FAIL


### PR DESCRIPTION
According to the spec, max depth in browsingContext.contextDestroyed event should always be null.