### PR TITLE
fix: fix unsubscribe by id parser

### DIFF
--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -282,6 +282,12 @@ export namespace Session {
   export function parseUnsubscribeParams(
     params: unknown,
   ): Protocol.Session.UnsubscribeParameters {
+    if (params && typeof params === 'object' && 'subscriptions' in params) {
+      return parseObject(
+        params,
+        WebDriverBidi.Session.UnsubscribeByIdRequestSchema,
+      ) as Protocol.Session.UnsubscribeParameters;
+    }
     return parseObject(
       params,
       WebDriverBidi.Session.UnsubscribeParametersSchema,


### PR DESCRIPTION
in the spec, we prefer matching the subscription ID over the attributes. Our parser is removing the extra attributes so if the order is wrong, we will strip subscription ids. This PR enforces the specified order.