### PR TITLE
fix: allow `bluetooth.requestDevicePromptUpdated` subscription

### DIFF
--- a/src/protocol/chromium-bidi.ts
+++ b/src/protocol/chromium-bidi.ts
@@ -142,6 +142,7 @@ export type Event = WebDriverBidi.Event | Cdp.Event | BluetoothEvent;
 export const EVENT_NAMES = new Set([
   // keep-sorted start
   ...Object.values(BiDiModule),
+  ...Object.values(Bluetooth.EventNames),
   ...Object.values(BrowsingContext.EventNames),
   ...Object.values(Log.EventNames),
   ...Object.values(Network.EventNames),

--- a/tests/bluetooth/test_handle_prompt.py
+++ b/tests/bluetooth/test_handle_prompt.py
@@ -74,7 +74,7 @@ async def test_bluetooth_requestDevicePromptUpdated(websocket, context_id,
     if test_headless_mode == "old":
         pytest.xfail("Old headless mode does not support Bluetooth")
 
-    await subscribe(websocket, ['bluetooth'])
+    await subscribe(websocket, ['bluetooth.requestDevicePromptUpdated'])
 
     url = html(HTML_SINGLE_PERIPHERAL)
     await goto_url(websocket, context_id, url)


### PR DESCRIPTION
The specific event name was missing in the `EVENT_NAMES`, which made it impossible to subscribe to a specific event.