### PR TITLE
fix: group clicks in action

### DIFF
--- a/src/bidiMapper/modules/input/InputProcessor.ts
+++ b/src/bidiMapper/modules/input/InputProcessor.ts
@@ -263,6 +263,8 @@ export class InputProcessor {
               `Expected input source ${action.id} to be ${source.subtype}; got ${action.parameters.pointerType}.`,
             );
           }
+          // https://github.com/GoogleChromeLabs/chromium-bidi/issues/3043
+          source.resetClickCount();
           break;
         }
         default:

--- a/src/bidiMapper/modules/input/InputSource.ts
+++ b/src/bidiMapper/modules/input/InputSource.ts
@@ -158,18 +158,24 @@ export class PointerSource {
       storedContext = context;
     }
     ++storedContext.count;
-    if (storedContext.count > 2) {
-      // There is no API for triple clicks, so a series of clicks should be grouped in
-      // pairs.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/3043
-      storedContext.count = 1;
-    }
     this.#clickContexts.set(button, storedContext);
     return storedContext.count;
   }
 
   getClickCount(button: number) {
     return this.#clickContexts.get(button)?.count ?? 0;
+  }
+
+  /**
+   * Resets click count. Resets consequent click counter. Prevents grouping clicks in
+   * different `performActions` calls, so that they are not grouped as double, triple etc
+   * clicks. Required for https://github.com/GoogleChromeLabs/chromium-bidi/issues/3043.
+   */
+  resetClickCount(): void {
+    this.#clickContexts = new Map<
+      number,
+      InstanceType<typeof PointerSource.ClickContext>
+    >();
   }
   // --- Platform-specific state ends here ---
 }

--- a/src/bidiMapper/modules/input/InputSource.ts
+++ b/src/bidiMapper/modules/input/InputSource.ts
@@ -158,6 +158,12 @@ export class PointerSource {
       storedContext = context;
     }
     ++storedContext.count;
+    if (storedContext.count > 2) {
+      // There is no API for triple clicks, so a series of clicks should be grouped in
+      // pairs.
+      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/3043
+      storedContext.count = 1;
+    }
     this.#clickContexts.set(button, storedContext);
     return storedContext.count;
   }

--- a/tests/input/__snapshots__/test_input.ambr
+++ b/tests/input/__snapshots__/test_input.ambr
@@ -951,6 +951,82 @@
     'type': 'success',
   })
 # ---
+# name: test_input_performActionsEmitsDblClicks
+  dict({
+    'result': dict({
+      'type': 'array',
+      'value': list([
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'dblclick',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 2,
+              }),
+            ]),
+          ]),
+        }),
+        dict({
+          'type': 'object',
+          'value': list([
+            list([
+              'event',
+              dict({
+                'type': 'string',
+                'value': 'dblclick',
+              }),
+            ]),
+            list([
+              'button',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'buttons',
+              dict({
+                'type': 'number',
+                'value': 0,
+              }),
+            ]),
+            list([
+              'clickCount',
+              dict({
+                'type': 'number',
+                'value': 2,
+              }),
+            ]),
+          ]),
+        }),
+      ]),
+    }),
+    'type': 'success',
+  })
+# ---
 # name: test_input_performActionsEmitsDragging
   dict({
     'result': dict({

--- a/tests/input/test_input.py
+++ b/tests/input/test_input.py
@@ -226,10 +226,9 @@ async def test_input_performActionsEmitsKeyboardEvents(websocket, context_id,
 
 
 @pytest.mark.asyncio
-async def test_input_performActionsEmitsDblClicks(websocket, context_id,
-                                                       html, activate_main_tab,
-                                                       query_selector,
-                                                       snapshot):
+async def test_input_performActionsEmitsDblClicks(websocket, context_id, html,
+                                                  activate_main_tab,
+                                                  query_selector, snapshot):
     await goto_url(websocket, context_id, html(DBL_CLICK_SCRIPT))
     await activate_main_tab()
     await reset_mouse(websocket, context_id)
@@ -241,22 +240,31 @@ async def test_input_performActionsEmitsDblClicks(websocket, context_id,
             "method": "input.performActions",
             "params": {
                 "context": context_id,
-                "actions": [
-                    {"type":"pointer",
-                     "id":"__puppeteer_mouse",
-                     "actions":[
-                         {"type":"pointerMove",
-                          "x": 0,
-                          "y": 0,
-                          "origin": {
-                              "type": "element",
-                              "element": target_element
-                          }},
-                         {"type":"pointerDown","button":0},
-                         {"type":"pointerUp","button":0},
-                         {"type":"pointerDown","button":0},
-                         {"type":"pointerUp","button":0}
-                ]}]
+                "actions": [{
+                    "type": "pointer",
+                    "id": "__puppeteer_mouse",
+                    "actions": [{
+                        "type": "pointerMove",
+                        "x": 0,
+                        "y": 0,
+                        "origin": {
+                            "type": "element",
+                            "element": target_element
+                        }
+                    }, {
+                        "type": "pointerDown",
+                        "button": 0
+                    }, {
+                        "type": "pointerUp",
+                        "button": 0
+                    }, {
+                        "type": "pointerDown",
+                        "button": 0
+                    }, {
+                        "type": "pointerUp",
+                        "button": 0
+                    }]
+                }]
             }
         })
 
@@ -265,29 +273,37 @@ async def test_input_performActionsEmitsDblClicks(websocket, context_id,
             "method": "input.performActions",
             "params": {
                 "context": context_id,
-                "actions": [
-                    {"type":"pointer",
-                     "id":"__puppeteer_mouse",
-                     "actions":[
-                         {"type":"pointerMove",
-                          "x": 0,
-                          "y": 0,
-                          "origin": {
-                              "type": "element",
-                              "element": target_element
-                          }},
-                         {"type":"pointerDown","button":0},
-                         {"type":"pointerUp","button":0},
-                         {"type":"pointerDown","button":0},
-                         {"type":"pointerUp","button":0}
-                ]}]
+                "actions": [{
+                    "type": "pointer",
+                    "id": "__puppeteer_mouse",
+                    "actions": [{
+                        "type": "pointerMove",
+                        "x": 0,
+                        "y": 0,
+                        "origin": {
+                            "type": "element",
+                            "element": target_element
+                        }
+                    }, {
+                        "type": "pointerDown",
+                        "button": 0
+                    }, {
+                        "type": "pointerUp",
+                        "button": 0
+                    }, {
+                        "type": "pointerDown",
+                        "button": 0
+                    }, {
+                        "type": "pointerUp",
+                        "button": 0
+                    }]
+                }]
             }
         })
 
     result = await get_events(websocket, context_id)
 
     assert result == snapshot(exclude=props("realm"))
-
 
 
 @pytest.mark.asyncio

--- a/tests/input/test_input.py
+++ b/tests/input/test_input.py
@@ -91,6 +91,21 @@ SCRIPT = """
 </script>
 """
 
+DBL_CLICK_SCRIPT = """
+<div style="height: 2000px; width: 10px"></div>
+<script>
+    var allEvents = [];
+    window.addEventListener("dblclick", (event) => {
+        allEvents.push({
+          event: "dblclick",
+          button: event.button,
+          buttons: event.buttons,
+          clickCount: event.detail,
+      });
+    });
+</script>
+"""
+
 DRAG_SCRIPT = """
 <div
   style="height: 100px; width: 100px; background-color: red"
@@ -208,6 +223,71 @@ async def test_input_performActionsEmitsKeyboardEvents(websocket, context_id,
     result = await get_events(websocket, context_id)
 
     assert result == snapshot(exclude=props("realm"))
+
+
+@pytest.mark.asyncio
+async def test_input_performActionsEmitsDblClicks(websocket, context_id,
+                                                       html, activate_main_tab,
+                                                       query_selector,
+                                                       snapshot):
+    await goto_url(websocket, context_id, html(DBL_CLICK_SCRIPT))
+    await activate_main_tab()
+    await reset_mouse(websocket, context_id)
+
+    target_element = await query_selector('div')
+
+    await execute_command(
+        websocket, {
+            "method": "input.performActions",
+            "params": {
+                "context": context_id,
+                "actions": [
+                    {"type":"pointer",
+                     "id":"__puppeteer_mouse",
+                     "actions":[
+                         {"type":"pointerMove",
+                          "x": 0,
+                          "y": 0,
+                          "origin": {
+                              "type": "element",
+                              "element": target_element
+                          }},
+                         {"type":"pointerDown","button":0},
+                         {"type":"pointerUp","button":0},
+                         {"type":"pointerDown","button":0},
+                         {"type":"pointerUp","button":0}
+                ]}]
+            }
+        })
+
+    await execute_command(
+        websocket, {
+            "method": "input.performActions",
+            "params": {
+                "context": context_id,
+                "actions": [
+                    {"type":"pointer",
+                     "id":"__puppeteer_mouse",
+                     "actions":[
+                         {"type":"pointerMove",
+                          "x": 0,
+                          "y": 0,
+                          "origin": {
+                              "type": "element",
+                              "element": target_element
+                          }},
+                         {"type":"pointerDown","button":0},
+                         {"type":"pointerUp","button":0},
+                         {"type":"pointerDown","button":0},
+                         {"type":"pointerUp","button":0}
+                ]}]
+            }
+        })
+
+    result = await get_events(websocket, context_id)
+
+    assert result == snapshot(exclude=props("realm"))
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Attempt to address https://github.com/GoogleChromeLabs/chromium-bidi/issues/3043.

Group clicks only in a single `input.performActions`. 