### PR TITLE
ci: explicitly mark it update expectations

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -234,7 +234,7 @@ jobs:
     name: Commit updated expectations
     runs-on: ubuntu-latest
     needs: [update_expectations]
-    if: ${{ needs.update_expectations.result == 'success' }}
+    if: ${{ !cancelled() && needs.update_expectations.result == 'success' }}
     steps:
       # Just checkout the repo. No need in setting up Node.js or Python.
       - name: Checkout


### PR DESCRIPTION
If I understand  correctly what is happening is - GitHub action implicitly add `success()` if non of the special cases are in the if.