### PR TITLE
chore: mark as timeout as well

### DIFF
--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/add_intercept/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/network/add_intercept/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  expected: [OK, TIMEOUT]

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/call_function/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/script/call_function/invalid.py.ini
@@ -1,0 +1,2 @@
+[invalid.py]
+  expected: [OK, TIMEOUT]


### PR DESCRIPTION
We are seeing a lot of flake in Pure Mapper, and we should ignore them so that to make sure that every run on main succeeds.