### PR TITLE
test: extend navigation tests

### DIFF
--- a/tests/browsing_context/__snapshots__/test_navigate_events.ambr
+++ b/tests/browsing_context/__snapshots__/test_navigate_events.ambr
@@ -185,6 +185,67 @@
     }),
   ])
 # ---
+# name: test_navigate_beforeunload_cancel[capabilities0]
+  list([
+    dict({
+      'method': 'script.message',
+      'params': dict({
+        'channel': 'beforeunload_channel',
+        'data': dict({
+          'type': 'string',
+          'value': 'beforeunload',
+        }),
+        'source': dict({
+          'context': 'stable_0',
+        }),
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.userPromptOpened',
+      'params': dict({
+        'context': 'stable_0',
+        'handler': 'dismiss',
+        'message': '',
+        'type': 'beforeunload',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationFailed',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'error': 'unknown error',
+      'id': 'stable_3',
+      'message': 'net::ERR_ABORTED',
+      'type': 'error',
+    }),
+    dict({
+      'method': 'browsingContext.userPromptClosed',
+      'params': dict({
+        'accepted': False,
+        'context': 'stable_0',
+        'type': 'beforeunload',
+      }),
+      'type': 'event',
+    }),
+  ])
+# ---
 # name: test_navigate_checkEvents[complete]
   list([
     dict({
@@ -689,6 +750,29 @@
 # name: test_navigate_hang_navigate_again_checkEvents
   list([
     dict({
+      'method': 'script.message',
+      'params': dict({
+        'channel': 'beforeunload_channel',
+        'data': dict({
+          'type': 'string',
+          'value': 'beforeunload',
+        }),
+        'source': dict({
+          'context': 'stable_0',
+        }),
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'network.beforeRequestSent',
       'params': dict({
         'context': 'stable_0',
@@ -704,7 +788,7 @@
       'params': dict({
         'context': 'stable_0',
         'navigation': 'stable_1',
-        'url': 'stable_3',
+        'url': 'stable_2',
       }),
       'type': 'event',
     }),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -334,6 +334,7 @@ def read_messages(websocket, read_all_messages):
                                                     bool] = lambda _: True,
                             keys_to_stabilize: list[str] = [],
                             check_no_other_messages: bool = False,
+                            known_values: dict[str, str] | None = None,
                             sort=True):
         messages = []
         for _ in range(message_count):
@@ -352,7 +353,7 @@ def read_messages(websocket, read_all_messages):
             messages.sort(key=lambda x: x["method"] if "method" in x else str(
                 x["id"]) if "id" in x else "")
         # Stabilize some values through the messages.
-        stabilize_key_values(messages, keys_to_stabilize)
+        stabilize_key_values(messages, keys_to_stabilize, known_values)
 
         if len(messages) > message_count:
             # "Assert equals" to produce a readable overview of all received


### PR DESCRIPTION
Extend test coverage for navigation. Extracted from https://github.com/GoogleChromeLabs/chromium-bidi/pull/3104.