### PR TITLE
test: mark as flaky

### DIFF
--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/key.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/input/perform_actions/key.py.ini
@@ -1,0 +1,3 @@
+[key.py]
+  [test_key_down_closes_browsing_context]
+    expected: [FAIL,PASS]


### PR DESCRIPTION
This is flaky on `headful` as well.