### PR TITLE
build: remove comments from esm script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "prettier": "3.5.1",
         "rimraf": "6.0.1",
         "rollup": "4.34.7",
+        "rollup-plugin-cleanup": "3.2.1",
         "rollup-plugin-license": "3.5.3",
         "selenium-webdriver": "4.28.1",
         "semver": "7.7.1",
@@ -6042,6 +6043,31 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-cleanup": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/js-cleanup/-/js-cleanup-1.2.0.tgz",
+      "integrity": "sha512-JeDD0yiiSt80fXzAVa/crrS0JDPQljyBG/RpOtaSbyDq03VHa9szJWMaWOYU/bcTn412uMN2MxApXq8v79cUiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.25.7",
+        "perf-regexes": "^1.0.1",
+        "skip-regex": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10.14.2 || >=12.0.0"
+      }
+    },
+    "node_modules/js-cleanup/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7126,6 +7152,16 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
+    "node_modules/perf-regexes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/perf-regexes/-/perf-regexes-1.0.1.tgz",
+      "integrity": "sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.14"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -7825,6 +7861,23 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-cleanup": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-cleanup/-/rollup-plugin-cleanup-3.2.1.tgz",
+      "integrity": "sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-cleanup": "^1.2.0",
+        "rollup-pluginutils": "^2.8.2"
+      },
+      "engines": {
+        "node": "^10.14.2 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "rollup": ">=2.0"
+      }
+    },
     "node_modules/rollup-plugin-license": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/rollup-plugin-license/-/rollup-plugin-license-3.5.3.tgz",
@@ -7874,6 +7927,23 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -8195,6 +8265,16 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/skip-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/skip-regex/-/skip-regex-1.0.2.tgz",
+      "integrity": "sha512-pEjMUbwJ5Pl/6Vn6FsamXHXItJXSRftcibixDmNCWbWhic0hzHrwkMZo0IZ7fMRH9KxcWDFSkzhccB4285PutA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.2"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8260,6 +8340,14 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/spacetrim": {
       "version": "0.11.59",

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "prettier": "3.5.1",
     "rimraf": "6.0.1",
     "rollup": "4.34.7",
+    "rollup-plugin-cleanup": "3.2.1",
     "rollup-plugin-license": "3.5.3",
     "selenium-webdriver": "4.28.1",
     "semver": "7.7.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -17,6 +17,7 @@
 import path from 'path';
 
 import {nodeResolve} from '@rollup/plugin-node-resolve';
+import cleanup from 'rollup-plugin-cleanup';
 import license from 'rollup-plugin-license';
 
 // Generate Mapper Tab from ESM as we can run that in the browser
@@ -29,6 +30,12 @@ const mapperTabConfig = {
     format: 'iife',
   },
   plugins: [
+    cleanup({
+      // Keep license comments. Other comments are removed due to
+      // http://b/390559299 and
+      // https://github.com/microsoft/TypeScript/issues/60811.
+      comments: [/Copyright/i],
+    }),
     license({
       thirdParty: {
         allow: {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
+    "removeComments": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,6 @@
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "removeComments": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
Required as a work-around for `keep-sorted` artifacts. [Example](https://crrev.com/c/6105891/1).

Keep license headers.