### PR TITLE
chore: print an error for e2e launch failures

### DIFF
--- a/tools/run-e2e.mjs
+++ b/tools/run-e2e.mjs
@@ -206,7 +206,8 @@ if (e2eProcess.stdout) {
   e2eProcess.stdout.pipe(addPrefix()).pipe(syncFileStreams);
 }
 
-e2eProcess.on('error', () => {
+e2eProcess.on('error', (error) => {
+  console.log('starting e2e tests failed', error);
   serverProcess.kill();
   process.exit(1);
 });


### PR DESCRIPTION
This can happen if your pipenv is missing dependencies, for example.