### PR TITLE
fix: hide cdp.send after the mapper receives it

### DIFF
--- a/src/bidiTab/Transport.ts
+++ b/src/bidiTab/Transport.ts
@@ -188,8 +188,12 @@ export class WindowBidiTransport implements BidiTransport {
 
 export class WindowCdpTransport implements Transport {
   #onMessage: ((message: string) => void) | null = null;
+  #cdpSend: typeof window.cdp.send;
 
   constructor() {
+    this.#cdpSend = window.cdp.send;
+    // @ts-expect-error removing cdp
+    window.cdp.send = undefined;
     window.cdp.onmessage = (message: string) => {
       this.#onMessage?.call(null, message);
     };
@@ -200,7 +204,7 @@ export class WindowCdpTransport implements Transport {
   }
 
   sendMessage(message: string) {
-    window.cdp.send(message);
+    this.#cdpSend(message);
   }
 
   close() {


### PR DESCRIPTION
Currently, the CDP connection is exposed on the global object. With this change, the CDP connection's send method would be only internally available.