### PR TITLE
test: use sleep to mitigate a race condition

### DIFF
--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -111,7 +111,7 @@ export class BrowserInstance {
 
     let cdpConnection;
     if (pipe) {
-      cdpConnection = await this.#establishPipeConnection(browserProcess);
+      cdpConnection = this.#establishPipeConnection(browserProcess);
     } else {
       const cdpEndpoint = await browserProcess.waitForLineOutput(
         CDP_WEBSOCKET_ENDPOINT_REGEX,
@@ -176,9 +176,9 @@ export class BrowserInstance {
 
   static #establishPipeConnection(
     browserProcess: Process,
-  ): Promise<MapperCdpConnection> {
+  ): MapperCdpConnection {
     debugInternal(
-      'Establishing pipe connection to browser process with cdpUrl: ',
+      'Establishing pipe connection to browser process with pid: ',
       browserProcess.nodeProcess.pid,
     );
     const {3: pipeWrite, 4: pipeRead} = browserProcess.nodeProcess.stdio;
@@ -186,7 +186,6 @@ export class BrowserInstance {
       pipeWrite as NodeJS.WritableStream,
       pipeRead as NodeJS.ReadableStream,
     );
-    const connection = new MapperCdpConnection(transport);
-    return Promise.resolve(connection);
+    return new MapperCdpConnection(transport);
   }
 }

--- a/tests/webExtension/test_web_extension.py
+++ b/tests/webExtension/test_web_extension.py
@@ -13,6 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import time
+
 import pytest
 from test_helpers import execute_command
 
@@ -67,6 +69,7 @@ async def uninstall(websocket, extension_id):
                          indirect=True)
 async def test_extensions_invalid_path(websocket, test_headless_mode):
     if test_headless_mode == "old":
+        time.sleep(0.1)
         pytest.xfail("Old headless mode does not support extensions")
         return
     with pytest.raises(Exception,
@@ -88,6 +91,7 @@ async def test_extensions_invalid_path(websocket, test_headless_mode):
 async def test_extensions_can_install(websocket, unpacked_extension_location,
                                       test_headless_mode):
     if test_headless_mode == "old":
+        time.sleep(0.1)
         pytest.xfail("Old headless mode does not support extensions")
         return
     path = unpacked_extension_location(SIMPLE_EXTENSION_FILES)
@@ -106,6 +110,7 @@ async def test_extensions_cannot_install(websocket,
                                          unpacked_extension_location,
                                          test_headless_mode):
     if test_headless_mode == "old":
+        time.sleep(0.1)
         pytest.xfail("Old headless mode does not support extensions")
         return
     path = unpacked_extension_location(SIMPLE_EXTENSION_FILES)
@@ -128,6 +133,7 @@ async def test_extensions_cannot_install(websocket,
 async def test_extensions_can_uninstall(websocket, unpacked_extension_location,
                                         test_headless_mode):
     if test_headless_mode == "old":
+        time.sleep(0.1)
         pytest.xfail("Old headless mode does not support extensions")
         return
     path = unpacked_extension_location(SIMPLE_EXTENSION_FILES)
@@ -146,6 +152,7 @@ async def test_extensions_can_uninstall(websocket, unpacked_extension_location,
                          indirect=True)
 async def test_extensions_no_such_exension(websocket, test_headless_mode):
     if test_headless_mode == "old":
+        time.sleep(0.1)
         pytest.xfail("Old headless mode does not support extensions")
         return
     with pytest.raises(Exception,


### PR DESCRIPTION
Somehow if the test fails too fast the websocket connection to WebDriver server fails.