### PR TITLE
chore: rely on Page.frameStartedNavigating CDP event

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -462,26 +462,15 @@ export class BrowsingContextImpl {
       this.#documentChanged(params.frame.loaderId);
     });
 
-    this.#cdpTarget.on(TargetEvents.FrameStartedNavigating, (params) => {
-      this.#logger?.(
-        LogType.debugInfo,
-        `Received ${TargetEvents.FrameStartedNavigating} event`,
-        params,
-      );
-
-      // The frame ID can be either a browsing context id, or not set in case of the frame
-      // is the top-level in the current CDP target.
-      const possibleFrameIds = [
-        this.id,
-        ...(this.cdpTarget.id === this.id ? [undefined] : []),
-      ];
-      if (!possibleFrameIds.includes(params.frameId)) {
+    this.#cdpTarget.cdpClient.on('Page.frameStartedNavigating', (params) => {
+      if (this.id !== params.frameId) {
         return;
       }
 
       this.#navigationTracker.frameStartedNavigating(
         params.url,
         params.loaderId,
+        params.navigationType,
       );
     });
 

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -36,7 +36,6 @@ import {type LoggerFn, LogType} from '../../../utils/log.js';
 import {getTimestamp} from '../../../utils/time.js';
 import {inchesFromCm} from '../../../utils/unitConversions.js';
 import type {CdpTarget} from '../cdp/CdpTarget.js';
-import {TargetEvents} from '../cdp/TargetEvents.js';
 import type {Realm} from '../script/Realm.js';
 import type {RealmStorage} from '../script/RealmStorage.js';
 import {getSharedId} from '../script/SharedId.js';
@@ -498,14 +497,6 @@ export class BrowsingContextImpl {
       }
     });
 
-    this.#cdpTarget.cdpClient.on('Page.frameRequestedNavigation', (params) => {
-      if (this.id !== params.frameId) {
-        return;
-      }
-
-      this.#navigationTracker.frameRequestedNavigation(params.url);
-    });
-
     this.#cdpTarget.cdpClient.on('Page.lifecycleEvent', (params) => {
       if (this.id !== params.frameId) {
         return;
@@ -705,9 +696,6 @@ export class BrowsingContextImpl {
 
     this.#cdpTarget.cdpClient.on('Page.javascriptDialogOpening', (params) => {
       const promptType = BrowsingContextImpl.#getPromptType(params.type);
-      if (params.type === 'beforeunload') {
-        this.#navigationTracker.beforeunload();
-      }
       // Set the last prompt type to provide it in closing event.
       this.#lastUserPromptType = promptType;
       const promptHandler = this.#getPromptHandler(promptType);

--- a/src/bidiMapper/modules/context/NavigationTracker.spec.ts
+++ b/src/bidiMapper/modules/context/NavigationTracker.spec.ts
@@ -209,7 +209,7 @@ describe('NavigationTracker', () => {
         (await navigation.finished).eventName,
         NavigationEventName.NavigationFailed,
       );
-      // Current navigation is the not yet finished `YET_ANOTHER_URL` navigation.
+      // Current navigation is one to `YET_ANOTHER_URL`. It should be not the initial one.
       assert.notEqual(
         navigationTracker.currentNavigationId,
         initialNavigationId,

--- a/src/bidiMapper/modules/context/NavigationTracker.ts
+++ b/src/bidiMapper/modules/context/NavigationTracker.ts
@@ -352,12 +352,10 @@ export class NavigationTracker {
       return;
     }
 
-    // There is no way to guaranteed match pending navigation with finished fragment
-    // navigations. So assume any pending navigation without loader id is the fragment
-    // one.
+    // There is no way to map `navigatedWithinDocument` to a specific navigation. Consider
+    // it is the pending navigation, if it is a fragment one.
     const fragmentNavigation =
-      this.#pendingNavigation !== undefined &&
-      this.#pendingNavigation.isFragmentNavigation === true
+      this.#pendingNavigation?.isFragmentNavigation === true
         ? this.#pendingNavigation
         : new NavigationState(
             url,

--- a/src/bidiMapper/modules/context/NavigationTracker.ts
+++ b/src/bidiMapper/modules/context/NavigationTracker.ts
@@ -302,8 +302,7 @@ export class NavigationTracker {
     this.#logger?.(LogType.debug, `frameNavigated ${url}`);
 
     if (unreachableUrl !== undefined) {
-      // The navigation failed before started. Get or create pending navigation and fail
-      // it.
+      // The navigation failed.
       const navigation =
         this.#loaderIdToNavigationsMap.get(loaderId) ??
         this.#pendingNavigation ??

--- a/tests/browsing_context/__snapshots__/test_navigate_events.ambr
+++ b/tests/browsing_context/__snapshots__/test_navigate_events.ambr
@@ -2,6 +2,15 @@
 # name: test_navigate_aboutBlank_checkEvents[complete]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -12,15 +21,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -64,6 +64,15 @@
 # name: test_navigate_aboutBlank_checkEvents[interactive]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -74,15 +83,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -126,6 +126,15 @@
 # name: test_navigate_aboutBlank_checkEvents[none]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -136,15 +145,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -188,6 +188,15 @@
 # name: test_navigate_beforeunload_cancel[capabilities0]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -198,15 +207,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -249,6 +249,15 @@
 # name: test_navigate_checkEvents[complete]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -259,15 +268,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -322,6 +322,15 @@
 # name: test_navigate_checkEvents[interactive]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -332,15 +341,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -395,6 +395,15 @@
 # name: test_navigate_checkEvents[none]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -405,15 +414,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -468,6 +468,15 @@
 # name: test_navigate_dataUrl_checkEvents[complete]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -478,15 +487,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -541,6 +541,15 @@
 # name: test_navigate_dataUrl_checkEvents[interactive]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -551,15 +560,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -614,6 +614,15 @@
 # name: test_navigate_dataUrl_checkEvents[none]
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -624,15 +633,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -750,6 +750,15 @@
 # name: test_navigate_hang_navigate_again_checkEvents
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -760,15 +769,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -799,6 +799,15 @@
       'type': 'error',
     }),
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_6',
+        'url': 'stable_7',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -809,15 +818,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_6',
-        'url': 'stable_7',
       }),
       'type': 'event',
     }),
@@ -872,6 +872,15 @@
 # name: test_reload_aboutBlank_checkEvents
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -882,15 +891,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -934,6 +934,15 @@
 # name: test_reload_checkEvents
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -944,15 +953,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -1007,6 +1007,15 @@
 # name: test_reload_dataUrl_checkEvents
   list([
     dict({
+      'method': 'browsingContext.navigationStarted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
+      }),
+      'type': 'event',
+    }),
+    dict({
       'method': 'script.message',
       'params': dict({
         'channel': 'beforeunload_channel',
@@ -1017,15 +1026,6 @@
         'source': dict({
           'context': 'stable_0',
         }),
-      }),
-      'type': 'event',
-    }),
-    dict({
-      'method': 'browsingContext.navigationStarted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -1089,20 +1089,20 @@
       'type': 'event',
     }),
     dict({
-      'method': 'browsingContext.navigationAborted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationStarted',
       'params': dict({
         'context': 'stable_0',
         'navigation': 'stable_3',
         'url': 'stable_4',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationAborted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -1120,20 +1120,20 @@
       'type': 'event',
     }),
     dict({
-      'method': 'browsingContext.navigationAborted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationStarted',
       'params': dict({
         'context': 'stable_0',
         'navigation': 'stable_3',
         'url': 'stable_4',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationAborted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
       }),
       'type': 'event',
     }),
@@ -1151,20 +1151,20 @@
       'type': 'event',
     }),
     dict({
-      'method': 'browsingContext.navigationAborted',
-      'params': dict({
-        'context': 'stable_0',
-        'navigation': 'stable_1',
-        'url': 'stable_2',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationStarted',
       'params': dict({
         'context': 'stable_0',
         'navigation': 'stable_3',
         'url': 'stable_4',
+      }),
+      'type': 'event',
+    }),
+    dict({
+      'method': 'browsingContext.navigationAborted',
+      'params': dict({
+        'context': 'stable_0',
+        'navigation': 'stable_1',
+        'url': 'stable_2',
       }),
       'type': 'event',
     }),

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/navigate_beforeunload.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/navigate_beforeunload.py.ini
@@ -1,2 +1,0 @@
-[navigate_beforeunload.py]
-  expected: TIMEOUT

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/navigate_beforeunload.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/navigate_beforeunload.py.ini
@@ -1,0 +1,2 @@
+[navigate_beforeunload.py]
+  expected: TIMEOUT

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/integration/navigation.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/integration/navigation.py.ini
@@ -1,3 +1,0 @@
-[navigation.py]
-  [test_navigate_history_replacestate_beforeunload]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/integration/navigation.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/integration/navigation.py.ini
@@ -1,3 +1,0 @@
-[navigation.py]
-  [test_navigate_history_replacestate_beforeunload]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/integration/navigation.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/integration/navigation.py.ini
@@ -1,3 +1,0 @@
-[navigation.py]
-  [test_navigate_history_replacestate_beforeunload]
-    expected: FAIL


### PR DESCRIPTION
`Page.frameStartedNavigating` is emitted for new navigations, so we can rely on it.

Disabling Network domain is out of scope to reduce risks of the PR.
Cleaning up TargetEvents and CdpTarget is out of scope.

Addressing http://b/401500518