### PR TITLE
chore: hide Mapper tab in nodejs runner

### DIFF
--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -147,7 +147,8 @@ export class MapperServerCdpConnection {
       'Target.createTarget',
       {
         url: 'about:blank#MAPPER_TARGET',
-        hidden: true,
+        hidden: !verbose,
+        background: true,
       } as any,
     );
 


### PR DESCRIPTION
Run Mapper in a hidden target, unless `verbose` flag is set.