### PR TITLE
chore: remove support of legacy `channel` field

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -69,8 +69,11 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
   };
 
   #processOutgoingMessage = async (messageEntry: OutgoingMessage) => {
-    // Enrich message with channel data.
-    const message = {...messageEntry.message, ...messageEntry.channel};
+    const message = messageEntry.message;
+
+    if (messageEntry.googChannel !== null) {
+      message['goog:channel'] = messageEntry.googChannel;
+    }
 
     await this.#transport.sendMessage(message);
   };

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -406,12 +406,12 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       case 'session.subscribe':
         return await this.#sessionProcessor.subscribe(
           this.#parser.parseSubscribeParams(command.params),
-          command.channel,
+          command['goog:channel'],
         );
       case 'session.unsubscribe':
         return await this.#sessionProcessor.unsubscribe(
           this.#parser.parseUnsubscribeParams(command.params),
-          command.channel,
+          command['goog:channel'],
         );
       // keep-sorted end
 
@@ -479,7 +479,10 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
       } satisfies ChromiumBidi.CommandResponse;
 
       this.emit(CommandProcessorEvents.Response, {
-        message: OutgoingMessage.createResolved(response, command.channel),
+        message: OutgoingMessage.createResolved(
+          response,
+          command['goog:channel'],
+        ),
         event: command.method,
       });
     } catch (e) {
@@ -487,7 +490,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
         this.emit(CommandProcessorEvents.Response, {
           message: OutgoingMessage.createResolved(
             e.toErrorResponse(command.id),
-            command.channel,
+            command['goog:channel'],
           ),
           event: command.method,
         });
@@ -500,7 +503,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
               error.message,
               error.stack,
             ).toErrorResponse(command.id),
-            command.channel,
+            command['goog:channel'],
           ),
           event: command.method,
         });

--- a/src/bidiMapper/OutgoingMessage.ts
+++ b/src/bidiMapper/OutgoingMessage.ts
@@ -15,28 +15,31 @@
  * limitations under the License.
  */
 
-import type {BidiPlusChannel} from '../protocol/chromium-bidi.js';
+import type {GoogChannel} from '../protocol/chromium-bidi.js';
 import type {ChromiumBidi} from '../protocol/protocol.js';
 import type {Result} from '../utils/result.js';
 
 export class OutgoingMessage {
   readonly #message: ChromiumBidi.Message;
-  readonly #channel: BidiPlusChannel;
+  readonly #googChannel: GoogChannel;
 
-  private constructor(message: ChromiumBidi.Message, channel: BidiPlusChannel) {
+  private constructor(
+    message: ChromiumBidi.Message,
+    googChannel: GoogChannel = null,
+  ) {
     this.#message = message;
-    this.#channel = channel;
+    this.#googChannel = googChannel;
   }
 
   static createFromPromise(
     messagePromise: Promise<Result<ChromiumBidi.Message>>,
-    channel: BidiPlusChannel,
+    googChannel: GoogChannel,
   ): Promise<Result<OutgoingMessage>> {
     return messagePromise.then((message) => {
       if (message.kind === 'success') {
         return {
           kind: 'success',
-          value: new OutgoingMessage(message.value, channel),
+          value: new OutgoingMessage(message.value, googChannel),
         };
       }
       return message;
@@ -45,11 +48,11 @@ export class OutgoingMessage {
 
   static createResolved(
     message: ChromiumBidi.Message,
-    channel: BidiPlusChannel,
+    googChannel: GoogChannel = null,
   ): Promise<Result<OutgoingMessage>> {
     return Promise.resolve({
       kind: 'success',
-      value: new OutgoingMessage(message, channel),
+      value: new OutgoingMessage(message, googChannel),
     });
   }
 
@@ -57,7 +60,7 @@ export class OutgoingMessage {
     return this.#message;
   }
 
-  get channel(): BidiPlusChannel {
-    return this.#channel;
+  get googChannel(): GoogChannel {
+    return this.#googChannel;
   }
 }

--- a/src/bidiMapper/modules/network/NetworkStorage.spec.ts
+++ b/src/bidiMapper/modules/network/NetworkStorage.spec.ts
@@ -96,7 +96,7 @@ describe('NetworkStorage', () => {
       // To the correct context
       [MockCdpNetworkEvents.defaultFrameId],
       [],
-      {},
+      null,
     );
     eventManager.on(EventManagerEvents.Event, ({message, event}) => {
       processingQueue.add(message, event);

--- a/src/bidiMapper/modules/session/SessionProcessor.ts
+++ b/src/bidiMapper/modules/session/SessionProcessor.ts
@@ -16,7 +16,7 @@
  */
 
 import type {CdpClient} from '../../../cdp/CdpClient.js';
-import type {BidiPlusChannel} from '../../../protocol/chromium-bidi.js';
+import type {GoogChannel} from '../../../protocol/chromium-bidi.js';
 import {
   InvalidArgumentException,
   Session,
@@ -144,13 +144,13 @@ export class SessionProcessor {
 
   async subscribe(
     params: Session.SubscriptionRequest,
-    channel: BidiPlusChannel = {},
+    googChannel: GoogChannel = null,
   ): Promise<Session.SubscribeResult> {
     const subscription = await this.#eventManager.subscribe(
       params.events as ChromiumBidi.EventNames[],
       params.contexts ?? [],
       params.userContexts ?? [],
-      channel,
+      googChannel,
     );
     return {
       subscription,
@@ -159,7 +159,7 @@ export class SessionProcessor {
 
   async unsubscribe(
     params: Session.UnsubscribeParameters,
-    channel: BidiPlusChannel = {},
+    googChannel: GoogChannel = null,
   ): Promise<EmptyResult> {
     if ('subscriptions' in params) {
       await this.#eventManager.unsubscribeByIds(params.subscriptions);
@@ -168,7 +168,7 @@ export class SessionProcessor {
     await this.#eventManager.unsubscribe(
       params.events as ChromiumBidi.EventNames[],
       params.contexts ?? [],
-      channel,
+      googChannel,
     );
     return {};
   }

--- a/src/bidiMapper/modules/session/SubscriptionManager.spec.ts
+++ b/src/bidiMapper/modules/session/SubscriptionManager.spec.ts
@@ -43,8 +43,8 @@ const ANOTHER_CONTEXT = 'ANOTHER_CONTEXT';
 const ANOTHER_USER_CONTEXT = 'ANOTHER_USER_CONTEXT';
 const ANOTHER_NESTED_CONTEXT = 'ANOTHER_NESTED_CONTEXT';
 
-const SOME_CHANNEL = {'goog:channel': 'SOME_CHANNEL'};
-const ANOTHER_CHANNEL = {'goog:channel': 'ANOTHER_CHANNEL'};
+const SOME_CHANNEL = 'SOME_CHANNEL';
+const ANOTHER_CHANNEL = 'ANOTHER_CHANNEL';
 
 describe('SubscriptionManager', () => {
   let subscriptionManager: SubscriptionManager;
@@ -98,8 +98,8 @@ describe('SubscriptionManager', () => {
     subscriptionManager = new SubscriptionManager(browsingContextStorage);
   });
 
-  describe('getChannelsSubscribedToEvent', () => {
-    it('should maintain channel subscription order', () => {
+  describe('getGoogChannelsSubscribedToEvent', () => {
+    it('should maintain goog:channel subscription order', () => {
       subscriptionManager.subscribe([SOME_EVENT], [], [], SOME_CHANNEL);
       subscriptionManager.subscribe([SOME_EVENT], [], [], ANOTHER_CHANNEL);
       subscriptionManager.subscribe([ANOTHER_EVENT], [], [], ANOTHER_CHANNEL);
@@ -112,9 +112,9 @@ describe('SubscriptionManager', () => {
         ANOTHER_CHANNEL,
       );
 
-      // `SOME_EVENT` was fist subscribed in `SOME_CHANNEL`.
+      // `SOME_EVENT` was fist subscribed in `SOME_GOOG_CHANNEL`.
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           SOME_EVENT,
           SOME_CONTEXT,
         ),
@@ -122,7 +122,7 @@ describe('SubscriptionManager', () => {
 
       // `ANOTHER_EVENT` was fist subscribed in `ANOTHER_CHANNEL`.
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           ANOTHER_EVENT,
           SOME_CONTEXT,
         ),
@@ -131,7 +131,7 @@ describe('SubscriptionManager', () => {
       // `YET_ANOTHER_EVENT` was first subscribed in `SOME_CHANNEL` via
       // `ALL_EVENTS`.
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           YET_ANOTHER_EVENT,
           SOME_CONTEXT,
         ),
@@ -144,7 +144,7 @@ describe('SubscriptionManager', () => {
       subscriptionManager.unsubscribe([SOME_EVENT], [], SOME_CHANNEL);
       subscriptionManager.subscribe([SOME_EVENT], [], [], SOME_CHANNEL);
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           SOME_EVENT,
           SOME_CONTEXT,
         ),
@@ -161,7 +161,7 @@ describe('SubscriptionManager', () => {
         SOME_CHANNEL,
       );
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           SOME_EVENT,
           SOME_CONTEXT,
         ),
@@ -178,7 +178,7 @@ describe('SubscriptionManager', () => {
       subscriptionManager.subscribe([SOME_EVENT], [], [], ANOTHER_CHANNEL);
       subscriptionManager.subscribe([SOME_EVENT], [], [], SOME_CHANNEL);
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           SOME_EVENT,
           SOME_CONTEXT,
         ),
@@ -199,7 +199,7 @@ describe('SubscriptionManager', () => {
         ANOTHER_CHANNEL,
       );
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           SOME_EVENT,
           SOME_CONTEXT,
         ),
@@ -231,7 +231,7 @@ describe('SubscriptionManager', () => {
         SOME_CHANNEL,
       );
       expect(
-        subscriptionManager.getChannelsSubscribedToEvent(
+        subscriptionManager.getGoogChannelsSubscribedToEvent(
           SOME_EVENT,
           SOME_CONTEXT,
         ),

--- a/src/protocol/chromium-bidi.ts
+++ b/src/protocol/chromium-bidi.ts
@@ -120,7 +120,7 @@ export type Command = (
   | Cdp.Command
   | ExternalSpecCommand<WebDriverBidiPermissions.PermissionsCommand>
   | ExternalSpecCommand<WebDriverBidiBluetooth.BluetoothCommand>
-) & {channel: BidiPlusChannel};
+) & {'goog:channel'?: GoogChannel};
 
 export type CommandResponse =
   | WebDriverBidi.CommandResponse
@@ -146,22 +146,8 @@ export const EVENT_NAMES = new Set([
 
 export type ResultData = WebDriverBidi.ResultData | Cdp.ResultData;
 
-// TODO: replace with optional string once legacy `channel` is removed.
-export type BidiPlusChannel =
-  | {
-      'goog:channel': string;
-      channel?: never;
-    }
-  | {
-      'goog:channel'?: never;
-      channel: string;
-    }
-  | {
-      'goog:channel'?: never;
-      channel?: never;
-    };
+export type GoogChannel = string | null;
 
 export type Message = (WebDriverBidi.Message | Cdp.Message | BluetoothEvent) & {
-  channel?: string;
-  'goog:channel'?: string;
+  'goog:channel'?: GoogChannel;
 };

--- a/tests/session/test_protocol_basics.py
+++ b/tests/session/test_protocol_basics.py
@@ -97,12 +97,12 @@ async def test_channel_non_empty(websocket):
             "id": 6000,
             "method": "session.status",
             "params": {},
-            "channel": "SOME_CHANNEL"
+            "goog:channel": "SOME_CHANNEL"
         })
     resp = await read_JSON_message(websocket)
     assert resp == {
         "id": 6000,
-        "channel": "SOME_CHANNEL",
+        "goog:channel": "SOME_CHANNEL",
         "type": "success",
         "result": {
             "ready": False,
@@ -117,7 +117,7 @@ async def test_channel_empty(websocket):
         "id": 7000,
         "method": "session.status",
         "params": {},
-        "channel": ""
+        "goog:channel": ""
     })
     resp = await read_JSON_message(websocket)
     assert resp == {

--- a/tests/session/test_subscription.py
+++ b/tests/session/test_subscription.py
@@ -337,14 +337,13 @@ async def test_subscribeWithContext_doesNotSubscribeToEventsInAnotherContexts(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("channel_name", ["channel", "goog:channel"])
 async def test_subscribeToOneChannel_eventReceivedWithProperChannel(
-        websocket, context_id, channel_name):
+        websocket, context_id):
     # Subscribe and unsubscribe in `CHANNEL_1`.
     await execute_command(
         websocket, {
             "method": "session.subscribe",
-            channel_name: "CHANNEL_1",
+            "goog:channel": "CHANNEL_1",
             "params": {
                 "events": ["log.entryAdded"]
             }
@@ -352,7 +351,7 @@ async def test_subscribeToOneChannel_eventReceivedWithProperChannel(
     await execute_command(
         websocket, {
             "method": "session.unsubscribe",
-            channel_name: "CHANNEL_1",
+            "goog:channel": "CHANNEL_1",
             "params": {
                 "events": ["log.entryAdded"]
             }
@@ -362,7 +361,7 @@ async def test_subscribeToOneChannel_eventReceivedWithProperChannel(
     await execute_command(
         websocket, {
             "method": "session.subscribe",
-            channel_name: "CHANNEL_2",
+            "goog:channel": "CHANNEL_2",
             "params": {
                 "events": ["log.entryAdded"]
             }
@@ -386,38 +385,31 @@ async def test_subscribeToOneChannel_eventReceivedWithProperChannel(
         "type": "event",
         "method": "log.entryAdded",
         "params": ANY_DICT,
-        channel_name: "CHANNEL_2"
+        "goog:channel": "CHANNEL_2"
     } == resp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("channel_name", ["channel", "goog:channel"])
 async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
-        websocket, context_id, channel_name):
+        websocket, context_id):
     empty_channel = ""
     channel_2 = "999_SECOND_SUBSCRIBED_CHANNEL"
     channel_3 = "000_THIRD_SUBSCRIBED_CHANNEL"
     channel_4 = "555_FOURTH_SUBSCRIBED_CHANNEL"
 
-    await subscribe(websocket, ["log.entryAdded"], None, empty_channel,
-                    channel_name)
-    await subscribe(websocket, ["log.entryAdded"], None, channel_2,
-                    channel_name)
-    await subscribe(websocket, ["log.entryAdded"], [context_id], channel_3,
-                    channel_name)
-    await subscribe(websocket, ["log.entryAdded"], [context_id], channel_4,
-                    channel_name)
+    await subscribe(websocket, ["log.entryAdded"], None, empty_channel)
+    await subscribe(websocket, ["log.entryAdded"], None, channel_2)
+    await subscribe(websocket, ["log.entryAdded"], [context_id], channel_3)
+    await subscribe(websocket, ["log.entryAdded"], [context_id], channel_4)
     # Re-subscribe with specific BrowsingContext.
-    await subscribe(websocket, ["log.entryAdded"], [context_id], channel_3,
-                    channel_name)
+    await subscribe(websocket, ["log.entryAdded"], [context_id], channel_3)
     # Re-subscribe.
-    await subscribe(websocket, ["log.entryAdded"], None, channel_2,
-                    channel_name)
+    await subscribe(websocket, ["log.entryAdded"], None, channel_2)
 
     await execute_command(
         websocket, {
             "method": "session.subscribe",
-            channel_name: channel_3,
+            "goog:channel": channel_3,
             "params": {
                 "events": ["log.entryAdded"]
             }
@@ -427,7 +419,7 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
     await execute_command(
         websocket, {
             "method": "session.subscribe",
-            channel_name: channel_2,
+            "goog:channel": channel_2,
             "params": {
                 "events": ["log.entryAdded"],
                 "context": context_id
@@ -437,7 +429,7 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
     await send_JSON_command(
         websocket, {
             "method": "script.evaluate",
-            channel_name: "SOME_OTHER_CHANNEL",
+            "goog:channel": "SOME_OTHER_CHANNEL",
             "params": {
                 "expression": "console.log('SOME_MESSAGE')",
                 "target": {
@@ -459,7 +451,7 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
     assert {
         "type": "event",
         "method": "log.entryAdded",
-        channel_name: channel_2,
+        "goog:channel": channel_2,
         "params": ANY_DICT
     } == resp
 
@@ -467,7 +459,7 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
     assert {
         "type": "event",
         "method": "log.entryAdded",
-        channel_name: channel_3,
+        "goog:channel": channel_3,
         "params": ANY_DICT
     } == resp
 
@@ -475,19 +467,18 @@ async def test_subscribeToMultipleChannels_eventsReceivedInProperOrder(
     assert {
         "type": "event",
         "method": "log.entryAdded",
-        channel_name: channel_4,
+        "goog:channel": channel_4,
         "params": ANY_DICT
     } == resp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("channel_name", ["channel", "goog:channel"])
 async def test_subscribeWithoutContext_bufferedEventsFromNotClosedContextsAreReturned(
-        websocket, context_id, another_context_id, channel_name):
+        websocket, context_id, another_context_id):
     await execute_command(
         websocket, {
             "method": "script.evaluate",
-            channel_name: "SOME_OTHER_CHANNEL",
+            "goog:channel": "SOME_OTHER_CHANNEL",
             "params": {
                 "expression": "console.log('SOME_MESSAGE')",
                 "target": {
@@ -500,7 +491,7 @@ async def test_subscribeWithoutContext_bufferedEventsFromNotClosedContextsAreRet
     await execute_command(
         websocket, {
             "method": "script.evaluate",
-            channel_name: "SOME_OTHER_CHANNEL",
+            "goog:channel": "SOME_OTHER_CHANNEL",
             "params": {
                 "expression": "console.log('ANOTHER_MESSAGE')",
                 "target": {
@@ -567,9 +558,7 @@ async def test_unsubscribe_by_id(websocket):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("channel_name", ["channel", "goog:channel"])
-async def test_unsubscribeIsAtomic(websocket, context_id, iframe_id,
-                                   channel_name):
+async def test_unsubscribeIsAtomic(websocket, context_id, iframe_id):
     await subscribe(websocket, ["log.entryAdded"], [iframe_id])
 
     with pytest.raises(Exception,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -45,8 +45,7 @@ def get_next_command_id() -> int:
 async def subscribe(websocket,
                     events: list[str] | str,
                     context_ids: list[str] | str | None = None,
-                    channel: str | None = None,
-                    channel_name: str | None = None):
+                    goog_channel: str | None = None):
     if type(events) is str:
         events = [events]
 
@@ -62,9 +61,8 @@ async def subscribe(websocket,
 
     if context_ids is not None:
         command["params"]["contexts"] = context_ids
-    if channel is not None:
-        command[channel_name
-                if channel_name is not None else "goog:channel"] = channel
+    if goog_channel is not None:
+        command["goog:channel"] = goog_channel
 
     return await execute_command(websocket, command)
 


### PR DESCRIPTION
Addressing `channel` part of #2844.