### PR TITLE
chore: remove support of legacy `cdp.` commands

### DIFF
--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -262,34 +262,6 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
           this.#parser.parseSendCommandParams(command.params),
         );
       // keep-sorted end
-      // CDP deprecated domain.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/2844
-      // keep-sorted start block=yes
-      case 'cdp.getSession':
-        this.#logger?.(
-          LogType.debugWarn,
-          `Legacy '${command.method}' command is deprecated and will not supported soon. Use 'goog:${command.method}' instead.`,
-        );
-        return this.#cdpProcessor.getSession(
-          this.#parser.parseGetSessionParams(command.params),
-        );
-      case 'cdp.resolveRealm':
-        this.#logger?.(
-          LogType.debugWarn,
-          `Legacy '${command.method}' command is deprecated and will not supported soon. Use 'goog:${command.method}' instead.`,
-        );
-        return this.#cdpProcessor.resolveRealm(
-          this.#parser.parseResolveRealmParams(command.params),
-        );
-      case 'cdp.sendCommand':
-        this.#logger?.(
-          LogType.debugWarn,
-          `Legacy '${command.method}' command is deprecated and will not supported soon. Use 'goog:${command.method}' instead.`,
-        );
-        return await this.#cdpProcessor.sendCommand(
-          this.#parser.parseSendCommandParams(command.params),
-        );
-      // keep-sorted end
 
       // Emulation module
       // keep-sorted start block=yes

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -462,20 +462,6 @@ export class CdpTarget {
         },
         this.id,
       );
-      // Duplicate the event to the deprecated event name.
-      // https://github.com/GoogleChromeLabs/chromium-bidi/issues/2844
-      this.#eventManager.registerEvent(
-        {
-          type: 'event',
-          method: `cdp.${event}`,
-          params: {
-            event,
-            params,
-            session: this.cdpSessionId,
-          },
-        },
-        this.id,
-      );
     });
   }
 

--- a/src/bidiMapper/modules/session/SubscriptionManager.ts
+++ b/src/bidiMapper/modules/session/SubscriptionManager.ts
@@ -133,7 +133,7 @@ export class SubscriptionManager {
   ): boolean {
     let includesEvent = false;
     for (const eventName of subscription.eventNames) {
-      // This also covers the `cdp` case where
+      // This also covers the `goog:cdp` case where
       // we don't unroll the event names
       if (
         // Event explicitly subscribed

--- a/src/bidiMapper/modules/session/events.spec.ts
+++ b/src/bidiMapper/modules/session/events.spec.ts
@@ -18,21 +18,12 @@ import {expect} from 'chai';
 
 import {ChromiumBidi} from '../../../protocol/protocol.js';
 
-import {
-  assertSupportedEvent,
-  isCdpEvent,
-  isDeprecatedCdpEvent,
-} from './events.js';
+import {assertSupportedEvent, isCdpEvent} from './events.js';
 
 const CDP_EVENTS = [
   'goog:cdp',
   'goog:cdp.event',
   'goog:cdp.Debugger.breakpointResolved',
-];
-const DEPRECATED_CDP_EVENTS = [
-  'cdp',
-  'cdp.event',
-  'cdp.Debugger.breakpointResolved',
 ];
 const NON_CDP_EVENTS = ['log', 'log.entryAdded'];
 
@@ -42,10 +33,6 @@ describe('event', () => {
       it(`should return true for CDP event '${cdpEvent}'`, () => {
         expect(isCdpEvent(cdpEvent)).to.be.true;
       });
-    for (const deprecatedCdpEvent of DEPRECATED_CDP_EVENTS)
-      it(`should return false for deprecated CDP event '${deprecatedCdpEvent}'`, () => {
-        expect(isCdpEvent(deprecatedCdpEvent)).to.be.false;
-      });
 
     for (const nonCdpEvent of NON_CDP_EVENTS)
       it(`should return false for non-CDP event '${nonCdpEvent}'`, () => {
@@ -53,35 +40,13 @@ describe('event', () => {
       });
   });
 
-  describe('isDeprecatedCdpEvent', () => {
-    for (const cdpEvent of CDP_EVENTS)
-      it(`should return false for CDP event '${cdpEvent}'`, () => {
-        expect(isDeprecatedCdpEvent(cdpEvent)).to.be.false;
-      });
-
-    for (const deprecatedCdpEvent of DEPRECATED_CDP_EVENTS)
-      it(`should return true for deprecated CDP event '${deprecatedCdpEvent}'`, () => {
-        expect(isDeprecatedCdpEvent(deprecatedCdpEvent)).to.be.true;
-      });
-
-    for (const nonCdpEvent of NON_CDP_EVENTS)
-      it(`should return false for non-CDP event '${nonCdpEvent}'`, () => {
-        expect(isDeprecatedCdpEvent(nonCdpEvent)).to.be.false;
-      });
-  });
-
   describe('assertSupportedEvent', () => {
     it('should throw for unknown events', () => {
       expect(() => {
         assertSupportedEvent('unknown');
-      }).to.throw('Unknown event: unknown');
-    });
-
-    it('should not throw for known deprecated CDP events', () => {
-      expect(() => {
         assertSupportedEvent('cdp.Debugger.breakpointResolved');
         assertSupportedEvent(ChromiumBidi.Log.EventNames.LogEntryAdded);
-      }).to.not.throw();
+      }).to.throw('Unknown event: unknown');
     });
 
     it('should not throw for known CDP events', () => {

--- a/src/bidiMapper/modules/session/events.ts
+++ b/src/bidiMapper/modules/session/events.ts
@@ -28,16 +28,6 @@ export function isCdpEvent(name: string): boolean {
     name.split('.').at(0)?.startsWith(ChromiumBidi.BiDiModule.Cdp) ?? false
   );
 }
-/**
- * Returns true if the given event is a deprecated CDP event.
- * @see https://chromedevtools.github.io/devtools-protocol/
- */
-export function isDeprecatedCdpEvent(name: string): boolean {
-  return (
-    name.split('.').at(0)?.startsWith(ChromiumBidi.BiDiModule.DeprecatedCdp) ??
-    false
-  );
-}
 
 /**
  * Asserts that the given event is known to BiDi or BiDi+, or throws otherwise.
@@ -45,11 +35,7 @@ export function isDeprecatedCdpEvent(name: string): boolean {
 export function assertSupportedEvent(
   name: string,
 ): asserts name is ChromiumBidi.EventNames {
-  if (
-    !ChromiumBidi.EVENT_NAMES.has(name as never) &&
-    !isCdpEvent(name) &&
-    !isDeprecatedCdpEvent(name)
-  ) {
+  if (!ChromiumBidi.EVENT_NAMES.has(name as never) && !isCdpEvent(name)) {
     throw new InvalidArgumentException(`Unknown event: ${name}`);
   }
 }

--- a/src/protocol/cdp.ts
+++ b/src/protocol/cdp.ts
@@ -33,11 +33,7 @@ export type Command = {
 export type CommandData =
   | SendCommandCommand
   | GetSessionCommand
-  | ResolveRealmCommand
-  // https://github.com/GoogleChromeLabs/chromium-bidi/issues/2844
-  | DeprecatedSendCommandCommand
-  | DeprecatedGetSessionCommand
-  | DeprecatedResolveRealmCommand;
+  | ResolveRealmCommand;
 
 export interface CommandResponse {
   type: 'success';
@@ -48,11 +44,6 @@ export type ResultData =
   | SendCommandResult
   | GetSessionResult
   | ResolveRealmResult;
-
-export interface DeprecatedSendCommandCommand {
-  method: 'cdp.sendCommand';
-  params: SendCommandParameters;
-}
 
 export interface SendCommandCommand {
   method: 'goog:cdp.sendCommand';
@@ -73,11 +64,6 @@ export interface SendCommandResult {
   session?: Protocol.Target.SessionID;
 }
 
-export interface DeprecatedGetSessionCommand {
-  method: 'cdp.getSession';
-  params: GetSessionParameters;
-}
-
 export interface GetSessionCommand {
   method: 'goog:cdp.getSession';
   params: GetSessionParameters;
@@ -89,11 +75,6 @@ export interface GetSessionParameters {
 
 export interface GetSessionResult {
   session?: Protocol.Target.SessionID;
-}
-
-export interface DeprecatedResolveRealmCommand {
-  method: 'cdp.resolveRealm';
-  params: ResolveRealmParameters;
 }
 
 export interface ResolveRealmCommand {
@@ -113,16 +94,7 @@ export type Event = {
   type: 'event';
 } & EventData;
 
-export type EventData =
-  | EventDataFor<keyof ProtocolMapping.Events>
-  | DeprecatedEventDataFor<keyof ProtocolMapping.Events>;
-
-export interface DeprecatedEventDataFor<
-  EventName extends keyof ProtocolMapping.Events,
-> {
-  method: `cdp.${EventName}`;
-  params: EventParametersFor<EventName>;
-}
+export type EventData = EventDataFor<keyof ProtocolMapping.Events>;
 
 export interface EventDataFor<EventName extends keyof ProtocolMapping.Events> {
   method: `goog:cdp.${EventName}`;

--- a/src/protocol/chromium-bidi.ts
+++ b/src/protocol/chromium-bidi.ts
@@ -38,7 +38,6 @@ export enum BiDiModule {
   Browser = 'browser',
   BrowsingContext = 'browsingContext',
   Cdp = 'goog:cdp',
-  DeprecatedCdp = 'cdp',
   Input = 'input',
   Log = 'log',
   Network = 'network',

--- a/tests/session/test_subscription.py
+++ b/tests/session/test_subscription.py
@@ -606,7 +606,7 @@ async def test_unsubscribeIsAtomic(websocket, context_id, iframe_id):
 async def test_unsubscribe_from_detached_target(websocket, context_id,
                                                 read_messages):
     events = [
-        'bluetooth', 'browser', 'browsingContext', 'cdp', 'input', 'log',
+        'bluetooth', 'browser', 'browsingContext', 'goog:cdp', 'input', 'log',
         'network', 'script', 'session'
     ]
 


### PR DESCRIPTION
Addressing https://github.com/GoogleChromeLabs/chromium-bidi/issues/2844