### PR TITLE
test: remove `network.beforeRequestSent` from snapshot tests

### DIFF
--- a/tests/browsing_context/__snapshots__/test_navigate_events.ambr
+++ b/tests/browsing_context/__snapshots__/test_navigate_events.ambr
@@ -272,17 +272,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -310,7 +299,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -345,17 +334,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -374,7 +352,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -418,17 +396,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -438,7 +405,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -491,17 +458,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -529,7 +485,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -564,17 +520,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -593,7 +538,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -637,17 +582,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -657,7 +591,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -773,17 +707,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationFailed',
       'params': dict({
         'context': 'stable_0',
@@ -794,7 +717,7 @@
     }),
     dict({
       'error': 'unknown error',
-      'id': 'stable_5',
+      'id': 'stable_3',
       'message': 'navigation canceled by concurrent navigation',
       'type': 'error',
     }),
@@ -802,8 +725,8 @@
       'method': 'browsingContext.navigationStarted',
       'params': dict({
         'context': 'stable_0',
-        'navigation': 'stable_6',
-        'url': 'stable_7',
+        'navigation': 'stable_4',
+        'url': 'stable_5',
       }),
       'type': 'event',
     }),
@@ -822,22 +745,11 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_6',
-        'redirectCount': 0,
-        'request': 'stable_9',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
-        'navigation': 'stable_6',
-        'url': 'stable_7',
+        'navigation': 'stable_4',
+        'url': 'stable_5',
       }),
       'type': 'event',
     }),
@@ -845,8 +757,8 @@
       'method': 'browsingContext.domContentLoaded',
       'params': dict({
         'context': 'stable_0',
-        'navigation': 'stable_6',
-        'url': 'stable_7',
+        'navigation': 'stable_4',
+        'url': 'stable_5',
       }),
       'type': 'event',
     }),
@@ -854,16 +766,16 @@
       'method': 'browsingContext.load',
       'params': dict({
         'context': 'stable_0',
-        'navigation': 'stable_6',
-        'url': 'stable_7',
+        'navigation': 'stable_4',
+        'url': 'stable_5',
       }),
       'type': 'event',
     }),
     dict({
-      'id': 'stable_10',
+      'id': 'stable_6',
       'result': dict({
-        'navigation': 'stable_6',
-        'url': 'stable_7',
+        'navigation': 'stable_4',
+        'url': 'stable_5',
       }),
       'type': 'success',
     }),
@@ -957,17 +869,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -995,7 +896,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',
@@ -1030,17 +931,6 @@
       'type': 'event',
     }),
     dict({
-      'method': 'network.beforeRequestSent',
-      'params': dict({
-        'context': 'stable_0',
-        'isBlocked': False,
-        'navigation': 'stable_1',
-        'redirectCount': 0,
-        'request': 'stable_4',
-      }),
-      'type': 'event',
-    }),
-    dict({
       'method': 'browsingContext.navigationCommitted',
       'params': dict({
         'context': 'stable_0',
@@ -1068,7 +958,7 @@
       'type': 'event',
     }),
     dict({
-      'id': 'stable_5',
+      'id': 'stable_3',
       'result': dict({
         'navigation': 'stable_1',
         'url': 'stable_2',

--- a/tests/browsing_context/test_navigate_events.py
+++ b/tests/browsing_context/test_navigate_events.py
@@ -68,9 +68,7 @@ async def test_navigate_checkEvents(websocket, context_id, url_base,
                                     wait):
     await goto_url(websocket, context_id, url_base)
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     await send_JSON_command(
         websocket, {
@@ -82,7 +80,7 @@ async def test_navigate_checkEvents(websocket, context_id, url_base,
             }
         })
 
-    messages = await read_messages(7,
+    messages = await read_messages(6,
                                    keys_to_stabilize=KEYS_TO_STABILIZE,
                                    check_no_other_messages=True,
                                    sort=False)
@@ -96,9 +94,7 @@ async def test_navigate_fragment_checkEvents(websocket, context_id,
                                              snapshot, wait):
     await goto_url(websocket, context_id, url_example)
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     await send_JSON_command(
         websocket, {
@@ -174,9 +170,7 @@ async def test_navigate_aboutBlank_checkEvents(websocket, context_id, url_base,
                                                read_messages, snapshot, wait):
     await goto_url(websocket, context_id, url_base)
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     about_blank_url = 'about:blank'
 
@@ -203,9 +197,7 @@ async def test_navigate_dataUrl_checkEvents(websocket, context_id, url_base,
                                             read_messages, snapshot, wait):
     await goto_url(websocket, context_id, url_base)
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     data_url = "data:text/html;,<h2>header</h2>"
 
@@ -219,7 +211,7 @@ async def test_navigate_dataUrl_checkEvents(websocket, context_id, url_base,
             }
         })
 
-    messages = await read_messages(7,
+    messages = await read_messages(6,
                                    keys_to_stabilize=KEYS_TO_STABILIZE,
                                    check_no_other_messages=True,
                                    sort=False)
@@ -234,9 +226,7 @@ async def test_navigate_hang_navigate_again_checkEvents(
     # `url_hang_forever`.
     await goto_url(websocket, context_id, url_base)
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     messages_log = []
     known_values = {}
@@ -251,7 +241,7 @@ async def test_navigate_hang_navigate_again_checkEvents(
             }
         })
 
-    messages_log += await read_messages(3,
+    messages_log += await read_messages(2,
                                         keys_to_stabilize=KEYS_TO_STABILIZE,
                                         known_values=known_values,
                                         sort=False)
@@ -266,7 +256,7 @@ async def test_navigate_hang_navigate_again_checkEvents(
             }
         })
 
-    messages_log += await read_messages(9,
+    messages_log += await read_messages(8,
                                         keys_to_stabilize=KEYS_TO_STABILIZE,
                                         known_values=known_values,
                                         check_no_other_messages=True,
@@ -290,9 +280,7 @@ async def test_navigate_beforeunload_cancel(websocket, context_id, url_base,
     # `url_hang_forever`.
     await goto_url(websocket, context_id, url_base)
     await set_beforeunload_handler(websocket, context_id, True)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     known_values = {}
 
@@ -479,9 +467,7 @@ async def test_reload_checkEvents(websocket, context_id, url_example, html,
     await goto_url(websocket, context_id, url_example)
 
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     await send_JSON_command(
         websocket, {
@@ -492,7 +478,7 @@ async def test_reload_checkEvents(websocket, context_id, url_example, html,
             }
         })
 
-    messages = await read_messages(7,
+    messages = await read_messages(6,
                                    keys_to_stabilize=KEYS_TO_STABILIZE,
                                    check_no_other_messages=True,
                                    sort=False)
@@ -507,9 +493,7 @@ async def test_reload_aboutBlank_checkEvents(websocket, context_id, html,
     await goto_url(websocket, context_id, url)
 
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     await send_JSON_command(
         websocket, {
@@ -534,9 +518,7 @@ async def test_reload_dataUrl_checkEvents(websocket, context_id, html,
     await goto_url(websocket, context_id, data_url)
 
     await set_beforeunload_handler(websocket, context_id)
-    await subscribe(
-        websocket,
-        ["browsingContext", "script.message", "network.beforeRequestSent"])
+    await subscribe(websocket, ["browsingContext", "script.message"])
 
     await send_JSON_command(
         websocket, {
@@ -547,7 +529,7 @@ async def test_reload_dataUrl_checkEvents(websocket, context_id, html,
             }
         })
 
-    messages = await read_messages(7,
+    messages = await read_messages(6,
                                    keys_to_stabilize=KEYS_TO_STABILIZE,
                                    check_no_other_messages=True,
                                    sort=False)


### PR DESCRIPTION
As long as the `browsingContext.navigationStarted` is now rely on the proper CDP event, there is no need in adding network event in the assertion. This should increase tests stability.