### PR TITLE
ci: update expectations for WPT bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     labels:
       - 'dependencies'
       - 'submodules'
+      - 'update-expectations'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
When WPT module is updated, add `update-expectations` label to the PR so that the update WPT expectations PR is created.