### PR TITLE
chore(deps): Bump wpt from e06138a to 41e905e

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -148,6 +148,7 @@ jobs:
         kind: [cd, node]
         head: [headless, headful]
         exclude:
+          # Don't run headful node, as it takes too long.
           - kind: node
             head: headful
     runs-on: ubuntu-latest
@@ -201,9 +202,9 @@ jobs:
           -name "wptreport.${{ matrix.kind }}-${{ matrix.head }}*.json"
           -exec npm run wpt -- --wpt-report {} \;
       - name: Update interop expectations
-        if: ${{ matrix.kind == 'chromedriver' }}
+        if: ${{ matrix.kind == 'cd' }}
         env:
-          CHROMEDRIVER: ${{ matrix.kind == 'chromedriver' }}
+          CHROMEDRIVER: ${{ matrix.kind == 'cd' }}
           HEADLESS: ${{ matrix.head!='headful' }}
           # Do not run tests, only update expectations.
           RUN_TESTS: false
@@ -223,7 +224,10 @@ jobs:
           else
             echo "src_dir_name=mapper/${{ matrix.head }}" >> $GITHUB_OUTPUT
           fi
-      - name: Move updated expectations
+      - name:
+          Move updated expectations
+          # Move the expectations from the current config to a separate directory to
+          # upload them to artifacts.
         run: |
           mkdir -p ./artifacts/updated-wpt-metadata/${{ steps.paths.outputs.src_dir_name }}
           mv ./wpt-metadata/${{ steps.paths.outputs.src_dir_name }}/* ./artifacts/updated-wpt-metadata/${{ steps.paths.outputs.src_dir_name }}/

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -145,10 +145,10 @@ jobs:
     strategy:
       matrix:
         # Should be in sync with `wpt` job.
-        kind: [chromedriver, mapper]
+        kind: [cd, node]
         head: [headless, headful]
         exclude:
-          - kind: mapper
+          - kind: node
             head: headful
     runs-on: ubuntu-latest
     needs: [wpt-required]
@@ -188,7 +188,7 @@ jobs:
       - name: Update expectations
         timeout-minutes: 60
         env:
-          CHROMEDRIVER: ${{ matrix.kind == 'chromedriver' }}
+          CHROMEDRIVER: ${{ matrix.kind == 'cd' }}
           HEADLESS: ${{ matrix.head!='headful' }}
           # Do not run tests, only update expectations.
           RUN_TESTS: false
@@ -220,7 +220,7 @@ jobs:
         # upload them to artifacts.
         run: |
           mkdir -p ./artifacts/updated-wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}
-          mv ./wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}/* ./artifacts/updated-wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}/
+          mv ./wpt-metadata/${{ matrix.kind == 'cd' ? 'chromedriver' : 'mapper' }}/${{ matrix.head }}/* ./artifacts/updated-wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}/
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -145,11 +145,10 @@ jobs:
     strategy:
       matrix:
         # Should be in sync with `wpt` job.
-        kind: [cd, node]
+        kind: [chromedriver, mapper]
         head: [headless, headful]
         exclude:
-          # Don't run headful node, as it takes too long.
-          - kind: node
+          - kind: mapper
             head: headful
     runs-on: ubuntu-latest
     needs: [wpt-required]
@@ -189,7 +188,7 @@ jobs:
       - name: Update expectations
         timeout-minutes: 60
         env:
-          CHROMEDRIVER: ${{ matrix.kind == 'cd' }}
+          CHROMEDRIVER: ${{ matrix.kind == 'chromedriver' }}
           HEADLESS: ${{ matrix.head!='headful' }}
           # Do not run tests, only update expectations.
           RUN_TESTS: false
@@ -202,9 +201,9 @@ jobs:
           -name "wptreport.${{ matrix.kind }}-${{ matrix.head }}*.json"
           -exec npm run wpt -- --wpt-report {} \;
       - name: Update interop expectations
-        if: ${{ matrix.kind == 'cd' }}
+        if: ${{ matrix.kind == 'chromedriver' }}
         env:
-          CHROMEDRIVER: ${{ matrix.kind == 'cd' }}
+          CHROMEDRIVER: ${{ matrix.kind == 'chromedriver' }}
           HEADLESS: ${{ matrix.head!='headful' }}
           # Do not run tests, only update expectations.
           RUN_TESTS: false

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -215,12 +215,18 @@ jobs:
           find ./wpt_artifacts/
           -name "wptreport-interop.${{ matrix.kind }}-${{ matrix.head }}*.json"
           -exec npm run wpt -- --wpt-report {} \;
-      - name: Move updated expectations
-        # Move the expectations from the current config to a separate directory to
-        # upload them to artifacts.
+      - name: Determine source metadata directory name
+        id: paths
         run: |
-          mkdir -p ./artifacts/updated-wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}
-          mv ./wpt-metadata/${{ matrix.kind == 'cd' ? 'chromedriver' : 'mapper' }}/${{ matrix.head }}/* ./artifacts/updated-wpt-metadata/${{ matrix.kind }}/${{ matrix.head }}/
+          if [[ "${{ matrix.kind }}" == "cd" ]]; then
+            echo "src_dir_name=chromedriver/${{ matrix.head }}" >> $GITHUB_OUTPUT
+          else
+            echo "src_dir_name=mapper/${{ matrix.head }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Move updated expectations
+        run: |
+          mkdir -p ./artifacts/updated-wpt-metadata/${{ steps.paths.outputs.src_dir_name }}
+          mv ./wpt-metadata/${{ steps.paths.outputs.src_dir_name }}/* ./artifacts/updated-wpt-metadata/${{ steps.paths.outputs.src_dir_name }}/
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/tests/network/test_network.py
+++ b/tests/network/test_network.py
@@ -89,7 +89,7 @@ async def test_network_before_request_sent_event_emitted_with_url_fragment(
             }
         })
 
-    resp = await read_JSON_message(websocket)
+    resp = await wait_for_event(websocket, "network.beforeRequestSent")
 
     assert resp == AnyExtending({
         'type': 'event',

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py.ini
@@ -1,0 +1,6 @@
+[contexts.py]
+  [test_contexts]
+    expected: ERROR
+
+  [test_multiple_contexts]
+    expected: ERROR

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/coordinates.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/coordinates.py.ini
@@ -1,0 +1,27 @@
+[coordinates.py]
+  [test_get_current_position[test_coordinates0\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates1\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates2\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates3\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates4\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates5\]]
+    expected: ERROR
+
+  [test_watch_position]
+    expected: ERROR
+
+  [test_persists_on_reload]
+    expected: ERROR
+
+  [test_persists_on_navigation]
+    expected: ERROR

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/invalid.py.ini
@@ -1,0 +1,189 @@
+[invalid.py]
+  [test_params_contexts_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_contexts_empty_list]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_contexts_entry_invalid_value]
+    expected: FAIL
+
+  [test_params_contexts_iframe]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[value0\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_empty_object]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_missing]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_missing]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_without_altitude]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[True\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_empty_list]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_value[\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_value[somestring\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/user_contexts.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/emulation/set_geolocation_override/user_contexts.py.ini
@@ -1,0 +1,12 @@
+[user_contexts.py]
+  [test_user_contexts]
+    expected: ERROR
+
+  [test_set_to_default_user_context]
+    expected: ERROR
+
+  [test_set_to_multiple_user_contexts]
+    expected: FAIL
+
+  [test_set_to_user_context_and_then_to_context]
+    expected: ERROR

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py.ini
@@ -1,0 +1,6 @@
+[contexts.py]
+  [test_contexts]
+    expected: ERROR
+
+  [test_multiple_contexts]
+    expected: ERROR

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/coordinates.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/coordinates.py.ini
@@ -1,0 +1,27 @@
+[coordinates.py]
+  [test_get_current_position[test_coordinates0\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates1\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates2\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates3\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates4\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates5\]]
+    expected: ERROR
+
+  [test_watch_position]
+    expected: ERROR
+
+  [test_persists_on_reload]
+    expected: ERROR
+
+  [test_persists_on_navigation]
+    expected: ERROR

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/invalid.py.ini
@@ -1,0 +1,189 @@
+[invalid.py]
+  [test_params_contexts_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_contexts_empty_list]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_contexts_entry_invalid_value]
+    expected: FAIL
+
+  [test_params_contexts_iframe]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[value0\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_empty_object]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_missing]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_missing]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_without_altitude]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[True\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_empty_list]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_value[\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_value[somestring\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/user_contexts.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/emulation/set_geolocation_override/user_contexts.py.ini
@@ -1,0 +1,12 @@
+[user_contexts.py]
+  [test_user_contexts]
+    expected: ERROR
+
+  [test_set_to_default_user_context]
+    expected: ERROR
+
+  [test_set_to_multiple_user_contexts]
+    expected: FAIL
+
+  [test_set_to_user_context_and_then_to_context]
+    expected: ERROR

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/contexts.py.ini
@@ -1,0 +1,6 @@
+[contexts.py]
+  [test_contexts]
+    expected: ERROR
+
+  [test_multiple_contexts]
+    expected: ERROR

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/coordinates.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/coordinates.py.ini
@@ -1,0 +1,27 @@
+[coordinates.py]
+  [test_get_current_position[test_coordinates0\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates1\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates2\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates3\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates4\]]
+    expected: ERROR
+
+  [test_get_current_position[test_coordinates5\]]
+    expected: ERROR
+
+  [test_watch_position]
+    expected: ERROR
+
+  [test_persists_on_reload]
+    expected: ERROR
+
+  [test_persists_on_navigation]
+    expected: ERROR

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/invalid.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/invalid.py.ini
@@ -1,0 +1,189 @@
+[invalid.py]
+  [test_params_contexts_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_contexts_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_contexts_empty_list]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_contexts_context_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_contexts_entry_invalid_value]
+    expected: FAIL
+
+  [test_params_contexts_iframe]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[value0\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_empty_object]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_missing]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_latitude_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_missing]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_longitude_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_accuracy_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_altitude_accuracy_without_altitude]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_heading_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[value2\]]
+    expected: FAIL
+
+  [test_params_coordinates_speed_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[True\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[foo\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_user_contexts_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_empty_list]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[None\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[False\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[42\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[value3\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_type[value4\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_value[\]]
+    expected: FAIL
+
+  [test_params_user_contexts_entry_invalid_value[somestring\]]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/user_contexts.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/emulation/set_geolocation_override/user_contexts.py.ini
@@ -1,0 +1,12 @@
+[user_contexts.py]
+  [test_user_contexts]
+    expected: ERROR
+
+  [test_set_to_default_user_context]
+    expected: ERROR
+
+  [test_set_to_multiple_user_contexts]
+    expected: FAIL
+
+  [test_set_to_user_context_and_then_to_context]
+    expected: ERROR


### PR DESCRIPTION
#3305 + some fixes

Bumps [wpt](https://github.com/web-platform-tests/wpt) from `e06138a` to `41e905e`.
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/web-platform-tests/wpt/commit/41e905e5f5dacf58b1233b04b5959652d9165fa5"><code>41e905e</code></a> corner-shape: remove curvature adjustment</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/b8db5ed3913f91dfa7e3c95467eaf532bc347884"><code>b8db5ed</code></a> [animation-trigger] Restrict ActionAnimation to PhaseAndTime changes</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/84814093a84aca33105b57257e0d240d5c9b1398"><code>8481409</code></a> [gap-decorations] Making <code>PaintGaps</code> conform to collapsing border model</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/998347fd4325f3f2dab506997cfec12f91dff5ea"><code>998347f</code></a> <a href="https://redirect.github.com/web-platform-tests/wpt/issues/0">#0</a> PrerenderNoHttp: Run prerender related wpts over https</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/b0c1561b1e82004c4b3a9b5299c6a0fd91803f72"><code>b0c1561</code></a> Add WPT expectations for pointerevents click/auxclick button(s)</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/075fc8a083a00c49ef4b24e86df988f665f413e5"><code>075fc8a</code></a> Sync interfaces/ with <code>@​webref/idl</code> 3.61.4 (<a href="https://redirect.github.com/web-platform-tests/wpt/issues/51936">#51936</a>)</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/08082705a2e0adda1cc82ca1ff324d414e527482"><code>0808270</code></a> wpt: Set timeout to long for multisession wpt clearkey test</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/47530f755429ba1fd60eade5fa6f0ce0e5807939"><code>47530f7</code></a> Skip loading persistent license if persistent licenses are not supported</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/164426ace287247bd99e6d1cee31035875ad57a0"><code>164426a</code></a> WebCryptoAPI: Add the 'y' component of ECC keys in JWK import key tests (<a href="https://redirect.github.com/web-platform-tests/wpt/issues/51915">#51915</a>)</li>
<li><a href="https://github.com/web-platform-tests/wpt/commit/52e0ae0806075e44ec4054aee273f74c8a59515b"><code>52e0ae0</code></a> bust cache</li>
<li>Additional commits viewable in <a href="https://github.com/web-platform-tests/wpt/compare/e06138aa4f21003846859847ad5f409a69dba370...41e905e5f5dacf58b1233b04b5959652d9165fa5">compare view</a></li>
</ul>
</details>
<br />