### PR TITLE
ci: fix "Generate HTML test report"

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -305,7 +305,7 @@ jobs:
         run: npm ci
       - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          pattern: chromedriver-headful-*
+          pattern: cd-headful-*
           merge-multiple: true
       - name: Generate HTML test report
         run: >


### PR DESCRIPTION
Artifacts were renamed: https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/14449529084/job/40518988172