### PR TITLE
fix: string `unhandledPromptBehavior` capability implies `beforeUnload: accept` behavior

### DIFF
--- a/src/bidiMapper/modules/session/SessionProcessor.ts
+++ b/src/bidiMapper/modules/session/SessionProcessor.ts
@@ -18,10 +18,10 @@
 import type {CdpClient} from '../../../cdp/CdpClient.js';
 import type {GoogChannel} from '../../../protocol/chromium-bidi.js';
 import {
-  InvalidArgumentException,
-  Session,
   type ChromiumBidi,
   type EmptyResult,
+  InvalidArgumentException,
+  Session,
 } from '../../../protocol/protocol.js';
 import type {MapperOptions} from '../../BidiServer.js';
 
@@ -99,14 +99,27 @@ export class SessionProcessor {
       );
     }
     switch (capabilityValue) {
+      // `beforeUnload: accept` has higher priority over string capability, as the latest
+      // one is set to "fallbackDefault".
+      // https://w3c.github.io/webdriver/#dfn-deserialize-as-an-unhandled-prompt-behavior
+      // https://w3c.github.io/webdriver/#dfn-get-the-prompt-handler
       case 'accept':
       case 'accept and notify':
-        return {default: Session.UserPromptHandlerType.Accept};
+        return {
+          default: Session.UserPromptHandlerType.Accept,
+          beforeUnload: Session.UserPromptHandlerType.Accept,
+        };
       case 'dismiss':
       case 'dismiss and notify':
-        return {default: Session.UserPromptHandlerType.Dismiss};
+        return {
+          default: Session.UserPromptHandlerType.Dismiss,
+          beforeUnload: Session.UserPromptHandlerType.Accept,
+        };
       case 'ignore':
-        return {default: Session.UserPromptHandlerType.Ignore};
+        return {
+          default: Session.UserPromptHandlerType.Ignore,
+          beforeUnload: Session.UserPromptHandlerType.Accept,
+        };
       default:
         throw new InvalidArgumentException(
           `Unexpected 'unhandledPromptBehavior' value: ${capabilityValue}`,

--- a/tests/browsing_context/test_user_prompt.py
+++ b/tests/browsing_context/test_user_prompt.py
@@ -253,12 +253,7 @@ async def test_browsingContext_beforeUnloadPromptOpened_capabilityRespected(
             expected_handler = capabilities['unhandledPromptBehavior'][
                 'default']
         if isinstance(capabilities['unhandledPromptBehavior'], str):
-            if capabilities[
-                    'unhandledPromptBehavior'] == 'dismiss' or capabilities[
-                        'unhandledPromptBehavior'] == 'dismiss and notify':
-                expected_handler = 'dismiss'
-            elif capabilities['unhandledPromptBehavior'] == 'ignore':
-                expected_handler = 'ignore'
+            expected_handler = 'accept'
 
     resp = await read_JSON_message(websocket)
     assert resp == {

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/interop/beforeunload_prompt.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/interop/beforeunload_prompt.py.ini
@@ -46,3 +46,9 @@
 
   [test_dismiss_and_notify[True\]]
     expected: FAIL
+
+  [test_ignore[False\]]
+    expected: FAIL
+
+  [test_ignore[True\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/user_prompt_opened/beforeunload.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/user_prompt_opened/beforeunload.py.ini
@@ -1,0 +1,2 @@
+[beforeunload.py]
+  expected: TIMEOUT

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/user_prompt_opened/beforeunload.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/user_prompt_opened/beforeunload.py.ini
@@ -1,2 +1,0 @@
-[beforeunload.py]
-  expected: TIMEOUT

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/interop/beforeunload_prompt.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/interop/beforeunload_prompt.py.ini
@@ -46,3 +46,9 @@
 
   [test_dismiss_and_notify[True\]]
     expected: FAIL
+
+  [test_ignore[False\]]
+    expected: FAIL
+
+  [test_ignore[True\]]
+    expected: FAIL


### PR DESCRIPTION
Align with the spec. If capability is set via string, the "beforeUnload" behavior should be "accept" regardless of the capability value.

WPT PR: https://github.com/web-platform-tests/wpt/pull/51998

#### [Html spec](https://html.spec.whatwg.org/#steps-to-fire-beforeunload)
> The steps to fire **beforeunload**
...
6.2. Let userPromptHandler be the result of [WebDriver BiDi user prompt opened](https://w3c.github.io/webdriver-bidi/#webdriver-bidi-user-prompt-opened) with document's [relevant global object](https://html.spec.whatwg.org/#concept-relevant-global), "beforeunload", and "".
...
6.4. If userPromptHandler is "none", then ...
...

#### [WebDriver BiDi user prompt opened](https://www.w3.org/TR/webdriver-bidi/#webdriver-bidi-user-prompt-opened)
> WebDriver BiDi user prompt opened
...
> 3. Let handler configuration be [get the prompt handler](https://w3c.github.io/webdriver/#dfn-get-the-prompt-handler) with type.
...
> 10. Return handler.

#### WebDriver Classic [get the prompt handler](https://w3c.github.io/webdriver/#dfn-get-the-prompt-handler):
> 4. If type is "beforeUnload", return a [prompt handler configuration](https://w3c.github.io/webdriver/#dfn-prompt-handler-configuration) with [handler](https://w3c.github.io/webdriver/#dfn-handler) "accept" and [notify](https://w3c.github.io/webdriver/#dfn-notify) false.
