### PR TITLE
feat: create the main entrypoint module

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,18 @@
     "wpt:all": "wireit",
     "yapf": "yapf -i --parallel --recursive --exclude=wpt examples/ tests/"
   },
+  "type": "commonjs",
+  "main": "./lib/cjs/index.js",
   "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
     "./*": {
       "import": "./lib/esm/*",
       "require": "./lib/cjs/*"
     },
     "./lib/cjs/*": {
-      "types": "./lib/cjs/*",
       "import": "./lib/cjs/*",
       "require": "./lib/cjs/*"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2025 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * as BidiMapper from './bidiMapper/BidiMapper.js';
+export * as Protocol from './protocol/protocol.js';


### PR DESCRIPTION
The main entry and the type commonjs would allow older runtimes to import the CJS version. For ESM imports, the exports field is used.

This allows clients to import data using the module name.