### PR TITLE
chore: do not allow for `socksVersion` without `socksProxy`

### DIFF
--- a/src/bidiMapper/modules/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessor.ts
@@ -24,6 +24,7 @@ import {
   NoSuchUserContextException,
   type Session,
   UnknownErrorException,
+  UnsupportedOperationException,
 } from '../../../protocol/protocol.js';
 import type {CdpClient} from '../../BidiMapper.js';
 import type {MapperOptionsStorage} from '../../MapperOptions.js';
@@ -203,14 +204,14 @@ export function getProxyStr(
   }
 
   if (proxyConfig.proxyType === 'pac') {
-    throw new InvalidArgumentException(
+    throw new UnsupportedOperationException(
       `PAC proxy configuration is not supported per user context`,
     );
   }
 
   if (proxyConfig.proxyType === 'autodetect') {
-    throw new InvalidArgumentException(
-      `Proxy auto-detection is not supported per user context`,
+    throw new UnsupportedOperationException(
+      `Autodetect proxy is not supported per user context`,
     );
   }
 
@@ -235,9 +236,17 @@ export function getProxyStr(
     }
 
     // SOCKS Proxy
-    if (proxyConfig.socksProxy !== undefined) {
+    if (
+      proxyConfig.socksProxy !== undefined ||
+      proxyConfig.socksVersion !== undefined
+    ) {
       // socksVersion is mandatory and must be a valid integer if socksProxy is
       // specified.
+      if (proxyConfig.socksProxy === undefined) {
+        throw new InvalidArgumentException(
+          `'socksVersion' cannot be set without 'socksProxy'`,
+        );
+      }
       if (
         proxyConfig.socksVersion === undefined ||
         typeof proxyConfig.socksVersion !== 'number' ||

--- a/src/bidiMapper/modules/browser/BrowserProcessot.spec.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessot.spec.ts
@@ -21,6 +21,7 @@ import {
   InvalidArgumentException,
   UnknownErrorException,
   type Session,
+  UnsupportedOperationException,
 } from '../../../protocol/protocol.js';
 
 import {getProxyStr} from './BrowserProcessor.js';
@@ -36,17 +37,21 @@ describe('BrowserProcessor:getProxyStr', () => {
     expect(getProxyStr(proxyConfig)).to.be.undefined;
   });
 
-  it('should throw InvalidArgumentException for "pac" proxyType', () => {
+  it('should throw UnsupportedOperationException for "pac" proxyType', () => {
     const proxyConfig: Session.ProxyConfiguration = {
       proxyType: 'pac',
       proxyAutoconfigUrl: 'some_url',
     };
-    expect(() => getProxyStr(proxyConfig)).to.throw(InvalidArgumentException);
+    expect(() => getProxyStr(proxyConfig)).to.throw(
+      UnsupportedOperationException,
+    );
   });
 
-  it('should throw InvalidArgumentException for "autodetect" proxyType', () => {
+  it('should throw UnsupportedOperationException for "autodetect" proxyType', () => {
     const proxyConfig: Session.ProxyConfiguration = {proxyType: 'autodetect'};
-    expect(() => getProxyStr(proxyConfig)).to.throw(InvalidArgumentException);
+    expect(() => getProxyStr(proxyConfig)).to.throw(
+      UnsupportedOperationException,
+    );
   });
 
   describe('manual proxyType', () => {
@@ -99,6 +104,16 @@ describe('BrowserProcessor:getProxyStr', () => {
         };
         expect(getProxyStr(proxyConfig)).to.equal(
           'socks=socks0://socks.server:1080',
+        );
+      });
+
+      it('should throw InvalidArgumentException if socksProxy is undefined while socksVersion is not', () => {
+        const proxyConfig: Session.ProxyConfiguration = {
+          proxyType: 'manual',
+          socksVersion: 5,
+        };
+        expect(() => getProxyStr(proxyConfig)).to.throw(
+          InvalidArgumentException,
         );
       });
 


### PR DESCRIPTION
and return "unsupported" instead of "invalid argument" for unsupported cases