### PR TITLE
feat: support `emulation.setScreenOrientationOverride`

### DIFF
--- a/src/bidiMapper/BidiNoOpParser.ts
+++ b/src/bidiMapper/BidiNoOpParser.ts
@@ -181,6 +181,11 @@ export class BidiNoOpParser implements BidiCommandParameterParser {
   ): Emulation.SetGeolocationOverrideParameters {
     return params as Emulation.SetGeolocationOverrideParameters;
   }
+  parseSetScreenOrientationOverrideParams(
+    params: unknown,
+  ): Emulation.SetScreenOrientationOverrideParameters {
+    return params as Emulation.SetScreenOrientationOverrideParameters;
+  }
   // keep-sorted end
 
   // Script module

--- a/src/bidiMapper/BidiParser.ts
+++ b/src/bidiMapper/BidiParser.ts
@@ -119,6 +119,9 @@ export interface BidiCommandParameterParser {
   parseSetGeolocationOverrideParams(
     params: unknown,
   ): Emulation.SetGeolocationOverrideParameters;
+  parseSetScreenOrientationOverrideParams(
+    params: unknown,
+  ): Emulation.SetScreenOrientationOverrideParameters;
   // keep-sorted end
 
   // Input module

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -316,6 +316,10 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
         return await this.#emulationProcessor.setGeolocationOverride(
           this.#parser.parseSetGeolocationOverrideParams(command.params),
         );
+      case 'emulation.setScreenOrientationOverride':
+        return await this.#emulationProcessor.setScreenOrientationOverride(
+          this.#parser.parseSetScreenOrientationOverrideParams(command.params),
+        );
       // keep-sorted end
 
       // Input module

--- a/src/bidiMapper/modules/browser/UserContextConfig.ts
+++ b/src/bidiMapper/modules/browser/UserContextConfig.ts
@@ -33,6 +33,7 @@ export class UserContextConfig {
     | Emulation.GeolocationCoordinates
     | Emulation.GeolocationPositionError
     | null;
+  screenOrientation?: Emulation.ScreenOrientation | null;
 
   constructor(userContextId: string) {
     this.userContextId = userContextId;

--- a/src/bidiMapper/modules/emulation/EmulationProcessor.ts
+++ b/src/bidiMapper/modules/emulation/EmulationProcessor.ts
@@ -95,6 +95,31 @@ export class EmulationProcessor {
     return {};
   }
 
+  async setScreenOrientationOverride(
+    params: Emulation.SetScreenOrientationOverrideParameters,
+  ): Promise<EmptyResult> {
+    const browsingContexts = await this.#getRelatedTopLevelBrowsingContexts(
+      params.contexts,
+      params.userContexts,
+    );
+
+    for (const userContextId of params.userContexts ?? []) {
+      const userContextConfig =
+        this.#userContextStorage.getConfig(userContextId);
+      userContextConfig.screenOrientation = params.screenOrientation;
+    }
+
+    await Promise.all(
+      browsingContexts.map(
+        async (context) =>
+          await context.cdpTarget.setScreenOrientationOverride(
+            params.screenOrientation,
+          ),
+      ),
+    );
+    return {};
+  }
+
   /**
    * Returns a list of top-level browsing contexts.
    */

--- a/src/bidiTab/BidiParser.ts
+++ b/src/bidiTab/BidiParser.ts
@@ -182,6 +182,11 @@ export class BidiParser implements BidiCommandParameterParser {
   ): Emulation.SetGeolocationOverrideParameters {
     return Parser.Emulation.parseSetGeolocationOverrideParams(params);
   }
+  parseSetScreenOrientationOverrideParams(
+    params: unknown,
+  ): Emulation.SetScreenOrientationOverrideParameters {
+    return Parser.Emulation.parseSetScreenOrientationOverrideParams(params);
+  }
   // keep-sorted end
 
   // Input module

--- a/src/protocol-parser/generated/webdriver-bidi.ts
+++ b/src/protocol-parser/generated/webdriver-bidi.ts
@@ -1210,8 +1210,11 @@ export namespace BrowsingContext {
     }),
   );
 }
-export const EmulationCommandSchema = z.lazy(
-  () => Emulation.SetGeolocationOverrideSchema,
+export const EmulationCommandSchema = z.lazy(() =>
+  z.union([
+    Emulation.SetGeolocationOverrideSchema,
+    Emulation.SetScreenOrientationOverrideSchema,
+  ]),
 );
 export namespace Emulation {
   export const SetGeolocationOverrideSchema = z.lazy(() =>
@@ -1267,6 +1270,49 @@ export namespace Emulation {
   export const GeolocationPositionErrorSchema = z.lazy(() =>
     z.object({
       type: z.literal('positionUnavailable'),
+    }),
+  );
+}
+export namespace Emulation {
+  export const SetScreenOrientationOverrideSchema = z.lazy(() =>
+    z.object({
+      method: z.literal('emulation.setScreenOrientationOverride'),
+      params: Emulation.SetScreenOrientationOverrideParametersSchema,
+    }),
+  );
+}
+export namespace Emulation {
+  export const ScreenOrientationNaturalSchema = z.lazy(() =>
+    z.enum(['portrait', 'landscape']),
+  );
+}
+export namespace Emulation {
+  export const ScreenOrientationTypeSchema = z.lazy(() =>
+    z.enum([
+      'portrait-primary',
+      'portrait-secondary',
+      'landscape-primary',
+      'landscape-secondary',
+    ]),
+  );
+}
+export namespace Emulation {
+  export const ScreenOrientationSchema = z.lazy(() =>
+    z.object({
+      natural: Emulation.ScreenOrientationNaturalSchema,
+      type: Emulation.ScreenOrientationTypeSchema,
+    }),
+  );
+}
+export namespace Emulation {
+  export const SetScreenOrientationOverrideParametersSchema = z.lazy(() =>
+    z.object({
+      screenOrientation: z.union([Emulation.ScreenOrientationSchema, z.null()]),
+      contexts: z
+        .array(BrowsingContext.BrowsingContextSchema)
+        .min(1)
+        .optional(),
+      userContexts: z.array(Browser.UserContextSchema).min(1).optional(),
     }),
   );
 }

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -318,6 +318,12 @@ export namespace Emulation {
       WebDriverBidi.Emulation.SetGeolocationOverrideParametersSchema,
     ) as Protocol.Emulation.SetGeolocationOverrideParameters;
   }
+  export function parseSetScreenOrientationOverrideParams(params: unknown) {
+    return parseObject(
+      params,
+      WebDriverBidi.Emulation.SetScreenOrientationOverrideParametersSchema,
+    ) as Protocol.Emulation.SetScreenOrientationOverrideParameters;
+  }
 }
 
 export namespace Input {

--- a/src/protocol/generated/webdriver-bidi.ts
+++ b/src/protocol/generated/webdriver-bidi.ts
@@ -973,7 +973,9 @@ export namespace BrowsingContext {
     defaultValue?: string;
   };
 }
-export type EmulationCommand = Emulation.SetGeolocationOverride;
+export type EmulationCommand =
+  | Emulation.SetGeolocationOverride
+  | Emulation.SetScreenOrientationOverride;
 export namespace Emulation {
   export type SetGeolocationOverride = {
     method: 'emulation.setGeolocationOverride';
@@ -1039,6 +1041,41 @@ export namespace Emulation {
 export namespace Emulation {
   export type GeolocationPositionError = {
     type: 'positionUnavailable';
+  };
+}
+export namespace Emulation {
+  export type SetScreenOrientationOverride = {
+    method: 'emulation.setScreenOrientationOverride';
+    params: Emulation.SetScreenOrientationOverrideParameters;
+  };
+}
+export namespace Emulation {
+  export const enum ScreenOrientationNatural {
+    Portrait = 'portrait',
+    Landscape = 'landscape',
+  }
+}
+export namespace Emulation {
+  export type ScreenOrientationType =
+    | 'portrait-primary'
+    | 'portrait-secondary'
+    | 'landscape-primary'
+    | 'landscape-secondary';
+}
+export namespace Emulation {
+  export type ScreenOrientation = {
+    natural: Emulation.ScreenOrientationNatural;
+    type: Emulation.ScreenOrientationType;
+  };
+}
+export namespace Emulation {
+  export type SetScreenOrientationOverrideParameters = {
+    screenOrientation: Emulation.ScreenOrientation | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
   };
 }
 export type NetworkCommand =

--- a/tests/emulation/test_orientation.py
+++ b/tests/emulation/test_orientation.py
@@ -1,0 +1,167 @@
+#   Copyright 2025 Google LLC.
+#   Copyright (c) Microsoft Corporation.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+import pytest_asyncio
+from test_helpers import execute_command
+
+SOME_BIDI_SCREEN_ORIENTATION = {
+    "natural": "landscape",
+    "type": "portrait-secondary"
+}
+SOME_WEB_SCREEN_ORIENTATION = {"angle": 270, "type": "portrait-secondary"}
+
+ANOTHER_BIDI_SCREEN_ORIENTATION = {
+    "natural": "portrait",
+    "type": "landscape-primary"
+}
+ANOTHER_WEB_SCREEN_ORIENTATION = {"angle": 90, "type": "landscape-primary"}
+
+
+@pytest_asyncio.fixture
+async def initial_screen_orientation(websocket, context_id):
+    return await get_screen_orientation(websocket, context_id)
+
+
+async def get_screen_orientation(websocket, context_id):
+    """
+    Returns browsing context's current orientation.
+    """
+    # Activation is required, as orientation is only available on an active
+    # context.
+    await execute_command(websocket, {
+        "method": "browsingContext.activate",
+        "params": {
+            "context": context_id
+        }
+    })
+
+    resp = await execute_command(
+        websocket, {
+            "method": "script.evaluate",
+            "params": {
+                "expression": """({
+                    angle: screen.orientation.angle,
+                    type: screen.orientation.type
+                })""",
+                "target": {
+                    "context": context_id
+                },
+                "awaitPromise": True,
+            }
+        })
+    if "result" not in resp:
+        return resp
+
+    result = {}
+    for key, value in resp["result"]["value"]:
+        result[key] = value["value"]
+    return result
+
+
+@pytest.mark.asyncio
+async def test_screen_orientation_set_and_clear(
+    websocket,
+    context_id,
+    initial_screen_orientation,
+):
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setScreenOrientationOverride',
+            'params': {
+                'contexts': [context_id],
+                'screenOrientation': SOME_BIDI_SCREEN_ORIENTATION
+            }
+        })
+
+    assert await get_screen_orientation(
+        websocket, context_id) == SOME_WEB_SCREEN_ORIENTATION
+
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setScreenOrientationOverride',
+            'params': {
+                'contexts': [context_id],
+                'screenOrientation': None
+            }
+        })
+    assert await get_screen_orientation(
+        websocket, context_id) == initial_screen_orientation
+
+
+@pytest.mark.asyncio
+async def test_screen_orientation_per_user_context(
+    websocket,
+    user_context_id,
+    create_context,
+):
+    # Set different orientation overrides for different user contexts.
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setScreenOrientationOverride',
+            'params': {
+                'userContexts': ["default"],
+                'screenOrientation': SOME_BIDI_SCREEN_ORIENTATION
+            }
+        })
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setScreenOrientationOverride',
+            'params': {
+                'userContexts': [user_context_id],
+                'screenOrientation': ANOTHER_BIDI_SCREEN_ORIENTATION
+            }
+        })
+
+    # Assert the overrides applied for the right contexts.
+    browsing_context_id_1 = await create_context()
+    emulated_screen_orientation_1 = await get_screen_orientation(
+        websocket, browsing_context_id_1)
+    assert emulated_screen_orientation_1 == SOME_WEB_SCREEN_ORIENTATION
+
+    browsing_context_id_2 = await create_context(user_context_id)
+    emulated_screen_orientation_2 = await get_screen_orientation(
+        websocket, browsing_context_id_2)
+    assert emulated_screen_orientation_2 == ANOTHER_WEB_SCREEN_ORIENTATION
+
+
+@pytest.mark.asyncio
+async def test_screen_orientation_per_browsing_context(
+    websocket,
+    context_id,
+    another_context_id,
+):
+    # Set different orientation overrides for different user contexts.
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setScreenOrientationOverride',
+            'params': {
+                'contexts': [context_id],
+                'screenOrientation': SOME_BIDI_SCREEN_ORIENTATION
+            }
+        })
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setScreenOrientationOverride',
+            'params': {
+                'contexts': [another_context_id],
+                'screenOrientation': ANOTHER_BIDI_SCREEN_ORIENTATION
+            }
+        })
+
+    assert await get_screen_orientation(
+        websocket, context_id) == SOME_WEB_SCREEN_ORIENTATION
+    assert await get_screen_orientation(
+        websocket, another_context_id) == ANOTHER_WEB_SCREEN_ORIENTATION


### PR DESCRIPTION
Implement [`emulation.setScreenOrientationOverride`](https://www.w3.org/TR/webdriver-bidi/#command-emulation-setScreenOrientationOverride).