### PR TITLE
ci: e2e test improvements

### DIFF
--- a/tests/browsing_context/test_create.py
+++ b/tests/browsing_context/test_create.py
@@ -476,7 +476,7 @@ async def test_browsingContext_create_background(websocket, background,
         else:
             assert visible == "visible", "New tab should be visible when created in foreground"
 
-    if test_headless_mode != "false" and type == "window":
-        pytest.xfail("Window is not always selected in headless mode")
+    if test_headless_mode != "false":
+        pytest.xfail("Background check is not guaranteed in headless mode")
 
     assert has_focus is not background, "New context should not have focus" if background else "New context should have focus"

--- a/tests/input/test_input.py
+++ b/tests/input/test_input.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import pytest
+from anys import ANY_STR
 from syrupy.filters import props
 from test_helpers import (AnyExtending, execute_command, goto_url,
                           read_JSON_message, send_JSON_command, subscribe,
@@ -968,6 +969,6 @@ async def test_input_keyDown_closes_browsing_context(websocket, context_id,
     assert resp == {
         'error': 'no such frame',
         'id': command_id,
-        'message': f'Context {new_context} not found',
+        'message': ANY_STR,
         'type': 'error',
     }


### PR DESCRIPTION
Namely:
* Retry session creation in case of timeouts to address [this kind of issues](https://github.com/user-attachments/files/20591312/test_input_performActionsEmitsDblClicks.log.txt).
* Return `no such frame` error if CDP command failed due to CDP session being closed during BiDi command processing. 
* Disable background tests for headless.

ChromeDriver headless tests passed 40 times: https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/15446563361.