### PR TITLE
test: deflake tests

### DIFF
--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -147,7 +147,7 @@ export class MapperServerCdpConnection {
       'Target.createTarget',
       {
         url: 'about:blank#MAPPER_TARGET',
-        hidden: !verbose,
+        hidden: true,
         background: true,
       } as any,
     );

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -89,9 +89,15 @@ async def execute_command(websocket, command: dict, timeout: int = 5) -> dict:
     await send_JSON_command(websocket, command)
 
     logger.info(
-        f"Executing command with method '{command['method']}' and params '{command['params']}'..."
+        f"Executing command {command['id']} with method '{command['method']}' and params '{command['params']}'..."
     )
-    return await wait_for_command(websocket, command["id"], timeout)
+    try:
+        result = await wait_for_command(websocket, command["id"], timeout)
+        logger.info(f"Command {command['id']} finished with {result}")
+        return result
+    except Exception as e:
+        logger.info(f"Command {command['id']} failed with {type(e)}, {e}")
+        raise
 
 
 async def wait_for_command(websocket,


### PR DESCRIPTION
* Always hidden Mapper tab in Node runner.
* Improve conftest logging.
* Tolerate expected teardown exceptions.

Example run on headless ubuntu node: https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/15486876047