### PR TITLE
chore: fail-safe update CDDL action

### DIFF
--- a/.github/workflows/update-bidi-types.yml
+++ b/.github/workflows/update-bidi-types.yml
@@ -27,6 +27,10 @@ jobs:
     name: Build main spec cddl types
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: |
+          cargo install cddlconv@0.1.6;
+          npm install parse5
       - name: Check out the main spec repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -46,6 +50,10 @@ jobs:
     name: Build Permissions CDDL
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: |
+          cargo install cddlconv@0.1.6;
+          npm install parse5
       - name: Check out the main spec repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -71,6 +79,10 @@ jobs:
     name: Build Bluetooth CDDL
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: |
+          cargo install cddlconv@0.1.6;
+          npm install parse5
       - name: Check out the main spec repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Until Permissions and Bluetooth fixes are merged, move the task to a dedicated action.
* https://github.com/w3c/permissions/pull/464
* https://github.com/WebBluetoothCG/web-bluetooth/pull/659

Another option would be tolerating exception during CDDL update, but that would mask the issues.