### PR TITLE
feat: support timezone offset emulation

### DIFF
--- a/src/bidiMapper/modules/emulation/EmulationProcessor.ts
+++ b/src/bidiMapper/modules/emulation/EmulationProcessor.ts
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  InvalidArgumentException,
-  UnsupportedOperationException,
-} from '../../../protocol/ErrorResponse.js';
+import {InvalidArgumentException} from '../../../protocol/ErrorResponse.js';
 import type {
   EmptyResult,
   Emulation,
@@ -214,18 +211,15 @@ export class EmulationProcessor {
   async setTimezoneOverride(
     params: Emulation.SetTimezoneOverrideParameters,
   ): Promise<EmptyResult> {
-    const timezone = params.timezone ?? null;
+    let timezone = params.timezone ?? null;
 
     if (timezone !== null && !isValidTimezone(timezone)) {
       throw new InvalidArgumentException(`Invalid timezone "${timezone}"`);
     }
 
     if (timezone !== null && isTimeZoneOffsetString(timezone)) {
-      // CDP does not support timezone offset emulation.
-      // TODO: remove after http://b/432670902 is addressed.
-      throw new UnsupportedOperationException(
-        'Timezone offsets are not yet supported',
-      );
+      // CDP supports offset timezone with `GMT` prefix.
+      timezone = `GMT${timezone}`;
     }
 
     const browsingContexts = await this.#getRelatedTopLevelBrowsingContexts(
@@ -278,12 +272,6 @@ export function isValidTimezone(timezone: string): boolean {
 }
 
 // Export for testing.
-// TODO: remove after http://b/432670902 is addressed.
-/**
- * Implementation of spec method. Required, until CDP supports :
- * https://tc39.es/ecma262/#sec-istimezoneoffsetstring
- * @param timezone
- */
 export function isTimeZoneOffsetString(timezone: string): boolean {
   return /^[+-](?:2[0-3]|[01]\d)(?::[0-5]\d)?$/.test(timezone);
 }

--- a/tests/emulation/test_timezone.py
+++ b/tests/emulation/test_timezone.py
@@ -20,6 +20,7 @@ from test_helpers import execute_command, goto_url
 TIMEZONES = [
     "Asia/Yekaterinburg", "Europe/Berlin", "America/New_York", "Asia/Tokyo"
 ]
+TIMEZONE_OFFSET = "+10:00"
 
 
 @pytest_asyncio.fixture
@@ -228,18 +229,14 @@ async def test_timezone_invalid(websocket, context_id):
 
 
 @pytest.mark.asyncio
-async def test_timezone_unsupported(websocket, context_id):
-    UNSUPORTED_TIMEZONE = "+10:00"
-    with pytest.raises(Exception,
-                       match=str({
-                           "error": "unsupported operation",
-                           "message": "Timezone offsets are not yet supported"
-                       })):
-        await execute_command(
-            websocket, {
-                'method': 'emulation.setTimezoneOverride',
-                'params': {
-                    'contexts': [context_id],
-                    'timezone': UNSUPORTED_TIMEZONE
-                }
-            })
+async def test_timezone_offset(websocket, context_id, default_timezone):
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setTimezoneOverride',
+            'params': {
+                'contexts': [context_id],
+                'timezone': TIMEZONE_OFFSET
+            }
+        })
+
+    assert (await get_timezone(websocket, context_id)) == TIMEZONE_OFFSET


### PR DESCRIPTION
Apparently CDP supports timezone offset emulations, they just have to be prefixed with `GTM`.