### PR TITLE
test: increase Flask server timeout

### DIFF
--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -283,7 +283,7 @@ class LocalHttpServer:
             if self._check_server_readiness():
                 return
             # Short sleep before retrying
-            time.sleep(0.05)
+            time.sleep(0.1)
         raise RuntimeError(
             f"Flask server failed to start on {self.__protocol}://{self.__host}:{self.__port} within {max_wait_s}s."
         )

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -276,7 +276,7 @@ class LocalHttpServer:
             # Catch any other unexpected errors during check
             return False
 
-    def _wait_for_server_startup(self, max_wait_s: int = 60) -> None:
+    def _wait_for_server_startup(self, max_wait_s: int = 5) -> None:
         """Waits for the Flask server to start by polling a readiness check."""
         start_time_monotonic = time.monotonic()
         while time.monotonic() - start_time_monotonic < max_wait_s:
@@ -295,7 +295,7 @@ class LocalHttpServer:
             return
 
         kwargs = {
-            'host': self.__host,
+            'host': '0.0.0.0',  # nosec B104
             'port': self.__port,
             # Should be False for stability and threaded mode
             'debug': False,

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -276,7 +276,7 @@ class LocalHttpServer:
             # Catch any other unexpected errors during check
             return False
 
-    def _wait_for_server_startup(self, max_wait_s: int = 5) -> None:
+    def _wait_for_server_startup(self, max_wait_s: int = 60) -> None:
         """Waits for the Flask server to start by polling a readiness check."""
         start_time_monotonic = time.monotonic()
         while time.monotonic() - start_time_monotonic < max_wait_s:

--- a/tests/tools/local_http_server.py
+++ b/tests/tools/local_http_server.py
@@ -276,7 +276,7 @@ class LocalHttpServer:
             # Catch any other unexpected errors during check
             return False
 
-    def _wait_for_server_startup(self, max_wait_s: int = 5) -> None:
+    def _wait_for_server_startup(self, max_wait_s: int = 60) -> None:
         """Waits for the Flask server to start by polling a readiness check."""
         start_time_monotonic = time.monotonic()
         while time.monotonic() - start_time_monotonic < max_wait_s:
@@ -295,7 +295,7 @@ class LocalHttpServer:
             return
 
         kwargs = {
-            'host': '0.0.0.0',  # nosec B104
+            'host': self.__host,
             'port': self.__port,
             # Should be False for stability and threaded mode
             'debug': False,

--- a/tests/tools/test_local_http_server.py
+++ b/tests/tools/test_local_http_server.py
@@ -76,3 +76,24 @@ async def test_local_server_redirect(websocket, context_id, local_server_http):
 async def test_local_server_html(websocket, context_id, html):
     content = "SOME CONTENT"
     assert await get_content(websocket, context_id, html(content)) == content
+
+
+@pytest.mark.asyncio
+async def test_local_server_bad_ssl(websocket, context_id,
+                                    local_server_bad_ssl):
+    with pytest.raises(Exception,
+                       match=str({
+                           "error": "unknown error",
+                           "message": "net::ERR_CERT_AUTHORITY_INVALID"
+                       })):
+        assert await get_content(
+            websocket, context_id,
+            local_server_bad_ssl.url_200()) == local_server_bad_ssl.content_200
+
+
+@pytest.mark.asyncio
+async def test_local_server_good_ssl(websocket, context_id,
+                                     local_server_good_ssl):
+    assert await get_content(
+        websocket, context_id,
+        local_server_good_ssl.url_200()) == local_server_good_ssl.content_200


### PR DESCRIPTION
Trying to address e2e tests failures on MacOS started recently:
```
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[read] RERUN [  1%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[read] RERUN [  1%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[read] ERROR [  1%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[writeWithoutResponse] RERUN [  1%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[writeWithoutResponse] RERUN [  1%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[writeWithoutResponse] ERROR [  1%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[write] RERUN [  2%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[write] RERUN [  2%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_simulateCharacteristic[write] PASSED [  2%]
tests/bluetooth/test_characteristic_emulation.py::test_bluetooth_add_characteristic_to_unknown_service PASSED [  2%]

...

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tools.local_http_server.LocalHttpServer object at 0x1036e76d0>
max_wait_s = 5

    def _wait_for_server_startup(self, max_wait_s: int = 5) -> None:
        """Waits for the Flask server to start by polling a readiness check."""
        start_time_monotonic = time.monotonic()
        while time.monotonic() - start_time_monotonic < max_wait_s:
            if self._check_server_readiness():
                return
            # Short sleep before retrying
            time.sleep(0.05)
>       raise RuntimeError(
            f"Flask server failed to start on {self.__protocol}://{self.__host}:{self.__port} within {max_wait_s}s."
        )
E       RuntimeError: Flask server failed to start on http://localhost:49438 within 5s.

tests/tools/local_http_server.py:287: RuntimeError
```