### PR TITLE
feat: `emulation.setUserAgentOverride`

### DIFF
--- a/src/bidiMapper/BidiNoOpParser.ts
+++ b/src/bidiMapper/BidiNoOpParser.ts
@@ -211,6 +211,11 @@ export class BidiNoOpParser implements BidiCommandParameterParser {
   ): Emulation.SetTimezoneOverrideParameters {
     return params as Emulation.SetTimezoneOverrideParameters;
   }
+  parseSetUserAgentOverrideParams(
+    params: unknown,
+  ): Emulation.SetUserAgentOverrideParameters {
+    return params as Emulation.SetUserAgentOverrideParameters;
+  }
   // keep-sorted end
 
   // Script module

--- a/src/bidiMapper/BidiParser.ts
+++ b/src/bidiMapper/BidiParser.ts
@@ -137,6 +137,9 @@ export interface BidiCommandParameterParser {
   parseSetTimezoneOverrideParams(
     params: unknown,
   ): Emulation.SetTimezoneOverrideParameters;
+  parseSetUserAgentOverrideParams(
+    params: unknown,
+  ): Emulation.SetUserAgentOverrideParameters;
   // keep-sorted end
 
   // Input module

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -345,6 +345,11 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
         return await this.#emulationProcessor.setTimezoneOverride(
           this.#parser.parseSetTimezoneOverrideParams(command.params),
         );
+      case 'emulation.setUserAgentOverride':
+        this.#parser.parseSetUserAgentOverrideParams(command.params);
+        throw new UnknownErrorException(
+          `Method ${command.method} is not implemented.`,
+        );
       // keep-sorted end
 
       // Input module

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -346,9 +346,8 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
           this.#parser.parseSetTimezoneOverrideParams(command.params),
         );
       case 'emulation.setUserAgentOverride':
-        this.#parser.parseSetUserAgentOverrideParams(command.params);
-        throw new UnknownErrorException(
-          `Method ${command.method} is not implemented.`,
+        return await this.#emulationProcessor.setUserAgentOverrideParams(
+          this.#parser.parseSetUserAgentOverrideParams(command.params),
         );
       // keep-sorted end
 

--- a/src/bidiMapper/modules/browser/ContextConfig.ts
+++ b/src/bidiMapper/modules/browser/ContextConfig.ts
@@ -44,6 +44,7 @@ export class ContextConfig {
   scriptingEnabled?: false | null;
   // Timezone is kept in CDP format with GMT prefix for offset values.
   timezone?: string | null;
+  userAgent?: string | null;
   userPromptHandler?: Session.UserPromptHandler;
 
   /**

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -680,6 +680,10 @@ export class CdpTarget {
       promises.push(this.setExtraHeaders(config.extraHeaders));
     }
 
+    if (config.userAgent !== undefined) {
+      promises.push(this.setUserAgent(config.userAgent));
+    }
+
     if (config.scriptingEnabled !== undefined) {
       promises.push(this.setScriptingEnabled(config.scriptingEnabled));
     }
@@ -876,6 +880,12 @@ export class CdpTarget {
   async setExtraHeaders(headers: Protocol.Network.Headers): Promise<void> {
     await this.cdpClient.sendCommand('Network.setExtraHTTPHeaders', {
       headers,
+    });
+  }
+
+  async setUserAgent(userAgent: string | null): Promise<void> {
+    await this.cdpClient.sendCommand('Emulation.setUserAgentOverride', {
+      userAgent: userAgent ?? '',
     });
   }
 }

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1941,6 +1941,14 @@ export class BrowsingContextImpl {
       ),
     );
   }
+
+  async setUserAgentOverrideParams(userAgent: string | null) {
+    await Promise.all(
+      this.#getAllRelatedCdpTargets().map(
+        async (cdpTarget) => await cdpTarget.setUserAgent(userAgent),
+      ),
+    );
+  }
 }
 
 export function serializeOrigin(origin: string) {

--- a/src/bidiTab/BidiParser.ts
+++ b/src/bidiTab/BidiParser.ts
@@ -212,6 +212,11 @@ export class BidiParser implements BidiCommandParameterParser {
   ): Emulation.SetTimezoneOverrideParameters {
     return Parser.Emulation.parseSetTimezoneOverrideParams(params);
   }
+  parseSetUserAgentOverrideParams(
+    params: unknown,
+  ): Emulation.SetUserAgentOverrideParameters {
+    return Parser.Emulation.parseSetUserAgentOverrideParams(params);
+  }
   // keep-sorted end
 
   // Input module

--- a/src/protocol-parser/generated/webdriver-bidi.ts
+++ b/src/protocol-parser/generated/webdriver-bidi.ts
@@ -1219,6 +1219,7 @@ export const EmulationCommandSchema = z.lazy(() =>
     Emulation.SetScreenOrientationOverrideSchema,
     Emulation.SetScriptingEnabledSchema,
     Emulation.SetTimezoneOverrideSchema,
+    Emulation.SetUserAgentOverrideSchema,
   ]),
 );
 export namespace Emulation {
@@ -1358,6 +1359,26 @@ export namespace Emulation {
   export const SetScreenOrientationOverrideParametersSchema = z.lazy(() =>
     z.object({
       screenOrientation: z.union([Emulation.ScreenOrientationSchema, z.null()]),
+      contexts: z
+        .array(BrowsingContext.BrowsingContextSchema)
+        .min(1)
+        .optional(),
+      userContexts: z.array(Browser.UserContextSchema).min(1).optional(),
+    }),
+  );
+}
+export namespace Emulation {
+  export const SetUserAgentOverrideSchema = z.lazy(() =>
+    z.object({
+      method: z.literal('emulation.setUserAgentOverride'),
+      params: Emulation.SetUserAgentOverrideParametersSchema,
+    }),
+  );
+}
+export namespace Emulation {
+  export const SetUserAgentOverrideParametersSchema = z.lazy(() =>
+    z.object({
+      userAgent: z.union([z.string(), z.null()]),
       contexts: z
         .array(BrowsingContext.BrowsingContextSchema)
         .min(1)

--- a/src/protocol-parser/protocol-parser.ts
+++ b/src/protocol-parser/protocol-parser.ts
@@ -382,6 +382,12 @@ export namespace Emulation {
       WebDriverBidi.Emulation.SetTimezoneOverrideParametersSchema,
     ) as Protocol.Emulation.SetTimezoneOverrideParameters;
   }
+  export function parseSetUserAgentOverrideParams(params: unknown) {
+    return parseObject(
+      params,
+      WebDriverBidi.Emulation.SetUserAgentOverrideParametersSchema,
+    ) as Protocol.Emulation.SetUserAgentOverrideParameters;
+  }
   // keep-sorted end
 }
 

--- a/src/protocol/generated/webdriver-bidi.ts
+++ b/src/protocol/generated/webdriver-bidi.ts
@@ -980,7 +980,8 @@ export type EmulationCommand =
   | Emulation.SetLocaleOverride
   | Emulation.SetScreenOrientationOverride
   | Emulation.SetScriptingEnabled
-  | Emulation.SetTimezoneOverride;
+  | Emulation.SetTimezoneOverride
+  | Emulation.SetUserAgentOverride;
 export namespace Emulation {
   export type SetForcedColorsModeThemeOverride = {
     method: 'emulation.setForcedColorsModeThemeOverride';
@@ -1114,6 +1115,22 @@ export namespace Emulation {
 export namespace Emulation {
   export type SetScreenOrientationOverrideParameters = {
     screenOrientation: Emulation.ScreenOrientation | null;
+    contexts?: [
+      BrowsingContext.BrowsingContext,
+      ...BrowsingContext.BrowsingContext[],
+    ];
+    userContexts?: [Browser.UserContext, ...Browser.UserContext[]];
+  };
+}
+export namespace Emulation {
+  export type SetUserAgentOverride = {
+    method: 'emulation.setUserAgentOverride';
+    params: Emulation.SetUserAgentOverrideParameters;
+  };
+}
+export namespace Emulation {
+  export type SetUserAgentOverrideParameters = {
+    userAgent: string | null;
     contexts?: [
       BrowsingContext.BrowsingContext,
       ...BrowsingContext.BrowsingContext[],

--- a/tests/emulation/test_user_agent.py
+++ b/tests/emulation/test_user_agent.py
@@ -1,0 +1,263 @@
+# Copyright 2025 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from json import JSONDecoder
+
+import pytest
+import pytest_asyncio
+from test_helpers import execute_command, goto_url
+
+USER_AGENT_HEADER_NAME = "User-Agent"
+SOME_USER_AGENT = "some user agent"
+ANOTHER_USER_AGENT = "another user agent"
+
+
+@pytest_asyncio.fixture
+async def default_user_agent(context_id, get_navigator_user_agent):
+    """
+    Returns default user agent.
+    """
+    return await get_navigator_user_agent(context_id)
+
+
+@pytest.fixture
+def get_navigator_user_agent(websocket):
+    async def get_navigator_user_agent(context_id):
+        """
+        Returns browsing context's current user agent accessed via navigator.
+        """
+        resp = await execute_command(
+            websocket, {
+                "method": "script.evaluate",
+                "params": {
+                    "expression": "window.navigator.userAgent",
+                    "target": {
+                        "context": context_id
+                    },
+                    "awaitPromise": True,
+                }
+            })
+
+        return resp["result"]["value"] if "result" in resp else resp
+
+    return get_navigator_user_agent
+
+
+@pytest.fixture
+def assert_network_user_agent(websocket, get_url_echo):
+    """ Assert the `User-Agent` header is set during navigation and during fetch. """
+    async def assert_network_user_agent(context_id, expected_user_agent,
+                                        same_origin):
+        # First navigate to the echo page.
+        await goto_url(websocket, context_id, get_url_echo(same_origin))
+        # Get the navigation headers.
+        response = await execute_command(
+            websocket, {
+                'method': 'script.evaluate',
+                'params': {
+                    'expression': "window.document.body.textContent",
+                    'awaitPromise': True,
+                    'target': {
+                        'context': context_id
+                    }
+                }
+            })
+        response_obj = JSONDecoder().decode(response['result']['value'])
+        headers = response_obj['headers']
+        # Assert the right user agent header was sent on the navigation request.
+        assert USER_AGENT_HEADER_NAME in headers
+        assert headers[USER_AGENT_HEADER_NAME] == expected_user_agent
+
+        # Make a fetch request.
+        response = await execute_command(
+            websocket, {
+                'method': 'script.evaluate',
+                'params': {
+                    'expression': f"fetch('{get_url_echo(same_origin)}').then(r => r.text())",
+                    'awaitPromise': True,
+                    'target': {
+                        'context': context_id
+                    }
+                }
+            })
+        response_obj = JSONDecoder().decode(response['result']['value'])
+        headers = response_obj['headers']
+        # Assert the right user agent header was sent on the navigation request.
+        assert USER_AGENT_HEADER_NAME in headers
+        assert headers[USER_AGENT_HEADER_NAME] == expected_user_agent
+
+    return assert_network_user_agent
+
+
+@pytest.fixture
+def assert_navigator_user_agent(get_navigator_user_agent):
+    """ Assert the `window.navigator.userAgent` returns the expected value. """
+    async def assert_navigator_user_agent(context_id, expected_user_agent):
+        assert await get_navigator_user_agent(context_id
+                                              ) == expected_user_agent
+
+    return assert_navigator_user_agent
+
+
+@pytest.fixture
+def assert_user_agent(assert_navigator_user_agent, assert_network_user_agent):
+    """ Assert the user agent is emulated properly both in DOM and in network. """
+    async def assert_user_agent(context_id,
+                                expected_user_agent,
+                                same_origin=True):
+        await assert_navigator_user_agent(context_id, expected_user_agent)
+        await assert_network_user_agent(context_id, expected_user_agent,
+                                        same_origin)
+
+    return assert_user_agent
+
+
+@pytest.mark.asyncio
+async def test_user_agent_set_and_clear(websocket, context_id,
+                                        default_user_agent, assert_user_agent):
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [context_id],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+
+    await assert_user_agent(context_id, SOME_USER_AGENT)
+
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [context_id],
+                'userAgent': None
+            }
+        })
+    await assert_user_agent(context_id, default_user_agent)
+
+
+@pytest.mark.asyncio
+async def test_user_agent_per_user_context(websocket, user_context_id,
+                                           create_context, assert_user_agent):
+    # Set different user_agent overrides for different user contexts.
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'userContexts': ["default"],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'userContexts': [user_context_id],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+
+    # Assert the overrides applied for the right contexts.
+    browsing_context_id_1 = await create_context()
+    await assert_user_agent(browsing_context_id_1, SOME_USER_AGENT)
+
+    browsing_context_id_2 = await create_context(user_context_id)
+    await assert_user_agent(browsing_context_id_2, SOME_USER_AGENT)
+
+
+@pytest.mark.asyncio
+async def test_user_agent_per_browsing_context(websocket, context_id,
+                                               another_context_id,
+                                               assert_user_agent):
+    # Set different user_agent overrides for different user contexts.
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [context_id],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [another_context_id],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+
+    await assert_user_agent(context_id, SOME_USER_AGENT)
+    await assert_user_agent(another_context_id, SOME_USER_AGENT)
+
+
+@pytest.mark.asyncio
+async def test_user_agent_iframe(websocket, context_id, iframe_id, html,
+                                 default_user_agent, assert_user_agent):
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [context_id],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+
+    await assert_user_agent(iframe_id, SOME_USER_AGENT)
+
+    # Move iframe out of process
+    await goto_url(websocket, iframe_id,
+                   html("<h1>FRAME</h1>", same_origin=False))
+    # Assert user_agent emulation persisted.
+    await assert_user_agent(iframe_id, SOME_USER_AGENT, same_origin=False)
+
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [context_id],
+                'userAgent': SOME_USER_AGENT
+            }
+        })
+    await assert_user_agent(iframe_id, SOME_USER_AGENT, same_origin=False)
+
+    await execute_command(
+        websocket, {
+            'method': 'emulation.setUserAgentOverride',
+            'params': {
+                'contexts': [context_id],
+                'userAgent': None
+            }
+        })
+    await assert_user_agent(iframe_id, default_user_agent, same_origin=False)
+
+
+@pytest.mark.asyncio
+async def test_user_agent_invalid(websocket, context_id):
+    invalid_user_agent = ""
+    with pytest.raises(
+            Exception,
+            match=str({
+                "error": "unsupported operation",
+                "message": "empty user agent string is not supported"
+            })):
+        await execute_command(
+            websocket, {
+                'method': 'emulation.setUserAgentOverride',
+                'params': {
+                    'contexts': [context_id],
+                    'userAgent': invalid_user_agent
+                }
+            })


### PR DESCRIPTION
### Blocked on https://github.com/w3c/webdriver-bidi/pull/947

* Implement `emulation.setUserAgentOverride`.
* Add e2e tests verifying the user agent is emulated both in DOM and in network.