### PR TITLE
feat!: validate `browser.createUserContext:proxy`

### DIFF
--- a/src/bidiMapper/modules/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessor.ts
@@ -188,6 +188,35 @@ export class BrowserProcessor {
   }
 }
 
+export function asserProxyHost(proxyHost: string): void {
+  // A "host and optional port" string is defined as being a valid host, optionally
+  // followed by a colon and a valid port.
+  if (proxyHost.includes('://')) {
+    throw new InvalidArgumentException('Proxy URL should not have a scheme');
+  }
+  if (proxyHost.includes('/')) {
+    throw new InvalidArgumentException('Proxy URL should not have a path');
+  }
+  if (proxyHost.includes('?')) {
+    throw new InvalidArgumentException(
+      'Proxy URL should not have search parameters',
+    );
+  }
+  if (proxyHost.includes('#')) {
+    throw new InvalidArgumentException('Proxy URL should not have a hash');
+  }
+
+  try {
+    new URL(`http://${proxyHost}`);
+  } catch (error) {
+    throw error instanceof TypeError
+      ? new InvalidArgumentException(
+          `Invalid proxy format: ${proxyHost}. ${error.message}`,
+        )
+      : error;
+  }
+}
+
 /**
  * Proxy config parse implementation:
  * https://source.chromium.org/chromium/chromium/src/+/main:net/proxy_resolution/proxy_config.h;drc=743a82d08e59d803c94ee1b8564b8b11dd7b462f;l=107
@@ -222,13 +251,13 @@ export function getProxyStr(
 
     // HTTP Proxy
     if (proxyConfig.httpProxy !== undefined) {
-      // servers.push(proxyConfig.httpProxy);
+      asserProxyHost(proxyConfig.httpProxy);
       servers.push(`http=${proxyConfig.httpProxy}`);
     }
 
     // SSL Proxy (uses 'https' scheme)
     if (proxyConfig.sslProxy !== undefined) {
-      // servers.push(proxyConfig.sslProxy);
+      asserProxyHost(proxyConfig.sslProxy);
       servers.push(`https=${proxyConfig.sslProxy}`);
     }
 
@@ -255,6 +284,7 @@ export function getProxyStr(
           `'socksVersion' must be between 0 and 255`,
         );
       }
+      asserProxyHost(proxyConfig.socksProxy);
       servers.push(
         `socks=socks${proxyConfig.socksVersion}://${proxyConfig.socksProxy}`,
       );

--- a/src/bidiMapper/modules/browser/BrowserProcessot.spec.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessot.spec.ts
@@ -19,181 +19,236 @@ import {expect} from 'chai';
 
 import {
   InvalidArgumentException,
-  UnknownErrorException,
   type Session,
+  UnknownErrorException,
   UnsupportedOperationException,
 } from '../../../protocol/protocol.js';
 
-import {getProxyStr} from './BrowserProcessor.js';
+import {asserProxyHost, getProxyStr} from './BrowserProcessor.js';
 
-describe('BrowserProcessor:getProxyStr', () => {
-  it('should return undefined for "direct" proxyType', () => {
-    const proxyConfig: Session.ProxyConfiguration = {proxyType: 'direct'};
-    expect(getProxyStr(proxyConfig)).to.be.undefined;
-  });
-
-  it('should return undefined for "system" proxyType', () => {
-    const proxyConfig: Session.ProxyConfiguration = {proxyType: 'system'};
-    expect(getProxyStr(proxyConfig)).to.be.undefined;
-  });
-
-  it('should throw UnsupportedOperationException for "pac" proxyType', () => {
-    const proxyConfig: Session.ProxyConfiguration = {
-      proxyType: 'pac',
-      proxyAutoconfigUrl: 'some_url',
-    };
-    expect(() => getProxyStr(proxyConfig)).to.throw(
-      UnsupportedOperationException,
-    );
-  });
-
-  it('should throw UnsupportedOperationException for "autodetect" proxyType', () => {
-    const proxyConfig: Session.ProxyConfiguration = {proxyType: 'autodetect'};
-    expect(() => getProxyStr(proxyConfig)).to.throw(
-      UnsupportedOperationException,
-    );
-  });
-
-  describe('manual proxyType', () => {
-    it('should return undefined if no specific proxies are provided', () => {
-      const proxyConfig: Session.ProxyConfiguration = {proxyType: 'manual'};
+describe('BrowserProcessor', () => {
+  describe('getProxyStr', () => {
+    it('should return undefined for "direct" proxyType', () => {
+      const proxyConfig: Session.ProxyConfiguration = {proxyType: 'direct'};
       expect(getProxyStr(proxyConfig)).to.be.undefined;
     });
 
-    it('should correctly format httpProxy', () => {
-      const proxyConfig: Session.ProxyConfiguration = {
-        proxyType: 'manual',
-        httpProxy: 'localhost:8080',
-      };
-      expect(getProxyStr(proxyConfig)).to.equal('http=localhost:8080');
+    it('should return undefined for "system" proxyType', () => {
+      const proxyConfig: Session.ProxyConfiguration = {proxyType: 'system'};
+      expect(getProxyStr(proxyConfig)).to.be.undefined;
     });
 
-    it('should correctly format sslProxy', () => {
+    it('should throw UnsupportedOperationException for "pac" proxyType', () => {
       const proxyConfig: Session.ProxyConfiguration = {
-        proxyType: 'manual',
-        sslProxy: 'secure.proxy:443',
+        proxyType: 'pac',
+        proxyAutoconfigUrl: 'some_url',
       };
-      expect(getProxyStr(proxyConfig)).to.equal('https=secure.proxy:443');
+      expect(() => getProxyStr(proxyConfig)).to.throw(
+        UnsupportedOperationException,
+      );
     });
 
-    describe('socksProxy', () => {
-      it('should correctly format socksProxy with valid socksVersion', () => {
+    it('should throw UnsupportedOperationException for "autodetect" proxyType', () => {
+      const proxyConfig: Session.ProxyConfiguration = {proxyType: 'autodetect'};
+      expect(() => getProxyStr(proxyConfig)).to.throw(
+        UnsupportedOperationException,
+      );
+    });
+
+    describe('manual proxyType', () => {
+      it('should return undefined if no specific proxies are provided', () => {
+        const proxyConfig: Session.ProxyConfiguration = {proxyType: 'manual'};
+        expect(getProxyStr(proxyConfig)).to.be.undefined;
+      });
+
+      it('should correctly format httpProxy', () => {
         const proxyConfig: Session.ProxyConfiguration = {
           proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
+          httpProxy: 'localhost:8080',
+        };
+        expect(getProxyStr(proxyConfig)).to.equal('http=localhost:8080');
+      });
+
+      it('should correctly format sslProxy', () => {
+        const proxyConfig: Session.ProxyConfiguration = {
+          proxyType: 'manual',
+          sslProxy: 'secure.proxy:443',
+        };
+        expect(getProxyStr(proxyConfig)).to.equal('https=secure.proxy:443');
+      });
+
+      describe('socksProxy', () => {
+        it('should correctly format socksProxy with valid socksVersion', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+            socksVersion: 5,
+          };
+          expect(getProxyStr(proxyConfig)).to.equal(
+            'socks=socks5://socks.server:1080',
+          );
+        });
+
+        it('should correctly format socksProxy with socksVersion 0', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+            socksVersion: 0,
+          };
+          expect(getProxyStr(proxyConfig)).to.equal(
+            'socks=socks0://socks.server:1080',
+          );
+        });
+
+        it('should throw InvalidArgumentException if socksProxy is undefined while socksVersion is not', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksVersion: 5,
+          };
+          expect(() => getProxyStr(proxyConfig)).to.throw(
+            InvalidArgumentException,
+          );
+        });
+
+        it('should throw InvalidArgumentException if socksVersion is undefined', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+          };
+          expect(() => getProxyStr(proxyConfig)).to.throw(
+            InvalidArgumentException,
+          );
+        });
+
+        it('should throw InvalidArgumentException if socksVersion is not a number', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+            socksVersion: '5' as any, // Force incorrect type
+          };
+          expect(() => getProxyStr(proxyConfig)).to.throw(
+            InvalidArgumentException,
+          );
+        });
+
+        it('should throw InvalidArgumentException if socksVersion is not an integer', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+            socksVersion: 5.5,
+          };
+          expect(() => getProxyStr(proxyConfig)).to.throw(
+            InvalidArgumentException,
+          );
+        });
+
+        it('should throw InvalidArgumentException if socksVersion is less than 0', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+            socksVersion: -1,
+          };
+          expect(() => getProxyStr(proxyConfig)).to.throw(
+            InvalidArgumentException,
+          );
+        });
+
+        it('should throw InvalidArgumentException if socksVersion is greater than 255', () => {
+          const proxyConfig: Session.ProxyConfiguration = {
+            proxyType: 'manual',
+            socksProxy: 'socks.server:1080',
+            socksVersion: 256,
+          };
+          expect(() => getProxyStr(proxyConfig)).to.throw(
+            InvalidArgumentException,
+          );
+        });
+      });
+
+      it('should correctly format multiple proxies', () => {
+        const proxyConfig: Session.ProxyConfiguration = {
+          proxyType: 'manual',
+          httpProxy: 'http.proxy:80',
+          sslProxy: 'https.proxy:443',
+          socksProxy: 'socks.proxy:1080',
+          socksVersion: 4,
+        };
+        const expected =
+          'http=http.proxy:80;https=https.proxy:443;socks=socks4://socks.proxy:1080';
+        expect(getProxyStr(proxyConfig)).to.equal(expected);
+      });
+
+      it('should correctly format multiple proxies in different order', () => {
+        const proxyConfig: Session.ProxyConfiguration = {
+          proxyType: 'manual',
+          socksProxy: 'socks.proxy:1080',
           socksVersion: 5,
+          httpProxy: 'http.proxy:80',
         };
-        expect(getProxyStr(proxyConfig)).to.equal(
-          'socks=socks5://socks.server:1080',
-        );
-      });
-
-      it('should correctly format socksProxy with socksVersion 0', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
-          socksVersion: 0,
-        };
-        expect(getProxyStr(proxyConfig)).to.equal(
-          'socks=socks0://socks.server:1080',
-        );
-      });
-
-      it('should throw InvalidArgumentException if socksProxy is undefined while socksVersion is not', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksVersion: 5,
-        };
-        expect(() => getProxyStr(proxyConfig)).to.throw(
-          InvalidArgumentException,
-        );
-      });
-
-      it('should throw InvalidArgumentException if socksVersion is undefined', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
-        };
-        expect(() => getProxyStr(proxyConfig)).to.throw(
-          InvalidArgumentException,
-        );
-      });
-
-      it('should throw InvalidArgumentException if socksVersion is not a number', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
-          socksVersion: '5' as any, // Force incorrect type
-        };
-        expect(() => getProxyStr(proxyConfig)).to.throw(
-          InvalidArgumentException,
-        );
-      });
-
-      it('should throw InvalidArgumentException if socksVersion is not an integer', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
-          socksVersion: 5.5,
-        };
-        expect(() => getProxyStr(proxyConfig)).to.throw(
-          InvalidArgumentException,
-        );
-      });
-
-      it('should throw InvalidArgumentException if socksVersion is less than 0', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
-          socksVersion: -1,
-        };
-        expect(() => getProxyStr(proxyConfig)).to.throw(
-          InvalidArgumentException,
-        );
-      });
-
-      it('should throw InvalidArgumentException if socksVersion is greater than 255', () => {
-        const proxyConfig: Session.ProxyConfiguration = {
-          proxyType: 'manual',
-          socksProxy: 'socks.server:1080',
-          socksVersion: 256,
-        };
-        expect(() => getProxyStr(proxyConfig)).to.throw(
-          InvalidArgumentException,
-        );
+        // Order of servers in the output string is defined by the function's implementation
+        const expected = 'http=http.proxy:80;socks=socks5://socks.proxy:1080';
+        expect(getProxyStr(proxyConfig)).to.equal(expected);
       });
     });
 
-    it('should correctly format multiple proxies', () => {
+    it('should throw UnknownErrorException for an unknown proxyType', () => {
       const proxyConfig: Session.ProxyConfiguration = {
-        proxyType: 'manual',
-        httpProxy: 'http.proxy:80',
-        sslProxy: 'https.proxy:443',
-        socksProxy: 'socks.proxy:1080',
-        socksVersion: 4,
+        proxyType: 'unknown_type' as any,
       };
-      const expected =
-        'http=http.proxy:80;https=https.proxy:443;socks=socks4://socks.proxy:1080';
-      expect(getProxyStr(proxyConfig)).to.equal(expected);
-    });
-
-    it('should correctly format multiple proxies in different order', () => {
-      const proxyConfig: Session.ProxyConfiguration = {
-        proxyType: 'manual',
-        socksProxy: 'socks.proxy:1080',
-        socksVersion: 5,
-        httpProxy: 'http.proxy:80',
-      };
-      // Order of servers in the output string is defined by the function's implementation
-      const expected = 'http=http.proxy:80;socks=socks5://socks.proxy:1080';
-      expect(getProxyStr(proxyConfig)).to.equal(expected);
+      expect(() => getProxyStr(proxyConfig)).to.throw(UnknownErrorException);
     });
   });
+  describe('assertHttpProxy', () => {
+    it('should not throw for valid proxy formats', () => {
+      expect(() => asserProxyHost('localhost')).to.not.throw();
+      expect(() => asserProxyHost('localhost:8080')).to.not.throw();
+      expect(() => asserProxyHost('127.0.0.1')).to.not.throw();
+      expect(() => asserProxyHost('127.0.0.1:8080')).to.not.throw();
+      expect(() => asserProxyHost('[::1]')).to.not.throw();
+      expect(() => asserProxyHost('[::1]:8080')).to.not.throw();
+      expect(() => asserProxyHost('user:pass@localhost:8080')).to.not.throw();
+    });
 
-  it('should throw UnknownErrorException for an unknown proxyType', () => {
-    const proxyConfig: Session.ProxyConfiguration = {
-      proxyType: 'unknown_type' as any,
-    };
-    expect(() => getProxyStr(proxyConfig)).to.throw(UnknownErrorException);
+    it('should throw InvalidArgumentException for proxy with scheme', () => {
+      expect(() => asserProxyHost('http://localhost')).to.throw(
+        InvalidArgumentException,
+      );
+    });
+
+    it('should throw InvalidArgumentException for proxy with invalid port', () => {
+      expect(() => asserProxyHost('localhost:invalid')).to.throw(
+        InvalidArgumentException,
+      );
+    });
+
+    it('should throw InvalidArgumentException for port out of range', () => {
+      expect(() => asserProxyHost('localhost:-1')).to.throw(
+        InvalidArgumentException,
+      );
+      expect(() => asserProxyHost('localhost:65536')).to.throw(
+        InvalidArgumentException,
+      );
+      expect(() => asserProxyHost('localhost:1.1')).to.throw(
+        InvalidArgumentException,
+      );
+    });
+
+    it('should throw InvalidArgumentException for proxy with path', () => {
+      expect(() => asserProxyHost('localhost/path')).to.throw(
+        InvalidArgumentException,
+      );
+    });
+
+    it('should throw InvalidArgumentException for proxy with search params', () => {
+      expect(() => asserProxyHost('localhost?foo=bar')).to.throw(
+        InvalidArgumentException,
+      );
+    });
+
+    it('should throw InvalidArgumentException for proxy with hash', () => {
+      expect(() => asserProxyHost('localhost#hash')).to.throw(
+        InvalidArgumentException,
+      );
+    });
   });
 });

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browser/create_user_context/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browser/create_user_context/invalid.py.ini
@@ -1,50 +1,8 @@
 [invalid.py]
-  [test_params_proxy_http_proxy_invalid_value[http://foo\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo:-1\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo:65536\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo/test\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo#42\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo?foo=bar\]]
-    expected: FAIL
-
-  [1\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[https://foo\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo:-1\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo:65536\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo/test\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo#42\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo?foo=bar\]]
-    expected: FAIL
-
   [test_params_proxy_socks_proxy_invalid_type[42\]]
     expected: FAIL
 
   [test_params_proxy_socks_proxy_invalid_type[True\]]
-    expected: FAIL
-
-  [test_params_proxy_socks_proxy_invalid_type[value2\]]
     expected: FAIL
 
   [test_params_proxy_socks_proxy_invalid_type[value3\]]

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browser/create_user_context/invalid.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browser/create_user_context/invalid.py.ini
@@ -1,50 +1,8 @@
 [invalid.py]
-  [test_params_proxy_http_proxy_invalid_value[http://foo\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo:-1\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo:65536\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo/test\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo#42\]]
-    expected: FAIL
-
-  [test_params_proxy_http_proxy_invalid_value[foo?foo=bar\]]
-    expected: FAIL
-
-  [1\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[https://foo\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo:-1\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo:65536\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo/test\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo#42\]]
-    expected: FAIL
-
-  [test_params_proxy_ssl_proxy_invalid_value[foo?foo=bar\]]
-    expected: FAIL
-
   [test_params_proxy_socks_proxy_invalid_type[42\]]
     expected: FAIL
 
   [test_params_proxy_socks_proxy_invalid_type[True\]]
-    expected: FAIL
-
-  [test_params_proxy_socks_proxy_invalid_type[value2\]]
     expected: FAIL
 
   [test_params_proxy_socks_proxy_invalid_type[value3\]]


### PR DESCRIPTION
### Blocked on https://github.com/w3c/webdriver/issues/1920

Spec: https://github.com/w3c/webdriver-bidi/pull/988

**Breaking change:** `proxy` parameter does not allow for schema.