### PR TITLE
feat: do not fail command with aborted navigation

### DIFF
--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -1033,9 +1033,11 @@ export class BrowsingContextImpl {
 
     if (result instanceof NavigationResult) {
       if (
-        // TODO: check after decision on the spec is done:
-        //  https://github.com/w3c/webdriver-bidi/issues/799.
-        result.eventName === NavigationEventName.NavigationAborted ||
+        // If the navigation was committed and then another navigation started, the
+        // command should be considered as successfully finished.
+        // Details:
+        // * https://github.com/w3c/webdriver-bidi/issues/763
+        // * https://github.com/w3c/webdriver-bidi/issues/799
         result.eventName === NavigationEventName.NavigationFailed
       ) {
         throw new UnknownErrorException(result.message ?? 'unknown exception');

--- a/tests/browsing_context/test_navigate.py
+++ b/tests/browsing_context/test_navigate.py
@@ -45,9 +45,11 @@ async def test_browsingContext_navigateWaitInteractive_redirect(
     assert messages == [
         AnyExtending({
             'id': command_id,
-            'error': 'unknown error',
-            'message': 'navigation canceled by concurrent navigation',
-            'type': 'error',
+            'result': {
+                'navigation': 'stable_0',
+                'url': initial_url
+            },
+            'type': 'success',
         }),
         {
             'method': 'browsingContext.navigationAborted',

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -4,6 +4,3 @@
 
   [test_close_iframe]
     expected: FAIL
-
-  [test_close_context[tab\]]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -4,3 +4,6 @@
 
   [test_close_iframe]
     expected: FAIL
+
+  [test_close_context[tab\]]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,6 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL
+
+  [test_close_iframe]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/navigate.py.ini
+++ b/wpt-metadata/chromedriver/headful/webdriver/tests/bidi/browsing_context/navigate/navigate.py.ini
@@ -1,9 +1,0 @@
-[navigate.py]
-  [test_interrupted_navigation[interactive-Interrupted immediately\]]
-    expected: FAIL
-
-  [test_interrupted_navigation[complete-Interrupted immediately\]]
-    expected: FAIL
-
-  [test_interrupted_navigation[complete-Interrupted on DOMContentLoaded\]]
-    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,6 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL
+
+  [test_close_iframe]
+    expected: FAIL

--- a/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/navigate.py.ini
+++ b/wpt-metadata/chromedriver/headless/webdriver/tests/bidi/browsing_context/navigate/navigate.py.ini
@@ -1,9 +1,0 @@
-[navigate.py]
-  [test_interrupted_navigation[interactive-Interrupted immediately\]]
-    expected: FAIL
-
-  [test_interrupted_navigation[complete-Interrupted immediately\]]
-    expected: FAIL
-
-  [test_interrupted_navigation[complete-Interrupted on DOMContentLoaded\]]
-    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/error.py.ini
@@ -1,0 +1,6 @@
+[error.py]
+  [test_with_new_navigation_inside_page]
+    expected: FAIL
+
+  [test_close_iframe]
+    expected: FAIL

--- a/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/navigate.py.ini
+++ b/wpt-metadata/mapper/headless/webdriver/tests/bidi/browsing_context/navigate/navigate.py.ini
@@ -1,9 +1,0 @@
-[navigate.py]
-  [test_interrupted_navigation[interactive-Interrupted immediately\]]
-    expected: FAIL
-
-  [test_interrupted_navigation[complete-Interrupted immediately\]]
-    expected: FAIL
-
-  [test_interrupted_navigation[complete-Interrupted on DOMContentLoaded\]]
-    expected: FAIL


### PR DESCRIPTION
As described in https://github.com/w3c/webdriver-bidi/issues/799, the aborted navigation should not cancel the navigation