### PR TITLE
fix: correct broken realm lookup

### DIFF
--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -263,6 +263,7 @@ export class CdpTargetManager {
       case 'worker': {
         const realm = this.#realmStorage.findRealm({
           cdpSessionId: parentSessionCdpClient.sessionId,
+          sandbox: null, // Non-sandboxed realms.
         });
         // If there is no browsing context, this worker is already terminated.
         if (!realm) {


### PR DESCRIPTION
- Why would findReam return nothing on more than one match?
- Add support for filtering for non-sandboxed realms.
- Use the first matching realm. 