### PR TITLE
ci: allow manual dispatch for puppeteer workflow

### DIFF
--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -4,6 +4,9 @@ name: Puppeteer CI
 permissions: read-all
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types:
       # These are the defaults. See
@@ -24,8 +27,8 @@ jobs:
   puppeteer-test:
     name: Run Puppeteer tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    # Run on manual dispatch or if the PR has the 'puppeteer' label.
-    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'puppeteer') }}
+    # Run on manual dispatch, push to main, or if the PR has the 'puppeteer' label.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'puppeteer') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Allow for manual dispatch puppeteer CI workflow. Also run it on each merge to main for keeping history.