### PR TITLE
fix: round cookie expiry field

### DIFF
--- a/src/bidiMapper/modules/network/NetworkUtils.ts
+++ b/src/bidiMapper/modules/network/NetworkUtils.ts
@@ -195,7 +195,7 @@ export function cdpToBiDiCookie(
       cookie.sameSite === undefined
         ? Network.SameSite.None
         : sameSiteCdpToBiDi(cookie.sameSite),
-    ...(cookie.expires >= 0 ? {expiry: cookie.expires} : undefined),
+    ...(cookie.expires >= 0 ? {expiry: Math.round(cookie.expires)} : undefined),
   };
 
   // Extending with CDP-specific properties with `goog:` prefix.


### PR DESCRIPTION
Align with WebDriver BiDi spec, which requires the `expiry` to be integer.

Addressing https://github.com/GoogleChromeLabs/chromium-bidi/issues/3936