### PR TITLE
fix: remove sameParty Cookie attribute

### DIFF
--- a/src/bidiMapper/modules/network/NetworkUtils.ts
+++ b/src/bidiMapper/modules/network/NetworkUtils.ts
@@ -201,7 +201,6 @@ export function cdpToBiDiCookie(
   // Extending with CDP-specific properties with `goog:` prefix.
   result[`goog:session`] = cookie.session;
   result[`goog:priority`] = cookie.priority;
-  result[`goog:sameParty`] = cookie.sameParty;
   result[`goog:sourceScheme`] = cookie.sourceScheme;
   result[`goog:sourcePort`] = cookie.sourcePort;
   if (cookie.partitionKey !== undefined) {
@@ -263,9 +262,6 @@ export function bidiToCdpCookie(
   }
   if (params.cookie[`goog:priority`] !== undefined) {
     result.priority = params.cookie[`goog:priority`];
-  }
-  if (params.cookie[`goog:sameParty`] !== undefined) {
-    result.sameParty = params.cookie[`goog:sameParty`];
   }
   if (params.cookie[`goog:sourceScheme`] !== undefined) {
     result.sourceScheme = params.cookie[`goog:sourceScheme`];

--- a/tests/storage/test_get_cookies.py
+++ b/tests/storage/test_get_cookies.py
@@ -67,7 +67,6 @@ async def test_cookies_get_result_cdp_specific_fields(websocket, context_id):
         'cookies': [
             cookie | {
                 'goog:priority': 'Medium',
-                'goog:sameParty': False,
                 'goog:session': True,
                 'goog:sourcePort': 443,
                 'goog:sourceScheme': 'Secure',

--- a/tests/storage/test_set_cookies.py
+++ b/tests/storage/test_set_cookies.py
@@ -401,7 +401,6 @@ async def test_cookies_set_params_cookie_cdp_specific_fields(
                                               # CDP-specific fields.
                                               'goog:url': SOME_URL,
                                               'goog:priority': 'High',
-                                              'goog:sameParty': True,
                                               'goog:sourceScheme': 'Secure',
                                               'goog:sourcePort': 1234
                                           },
@@ -433,9 +432,6 @@ async def test_cookies_set_params_cookie_cdp_specific_fields(
                     'hasCrossSiteAncestor': False,
                 },
                 'goog:priority': 'High',
-                # `someParty` is not set for whatever reason.
-                # TODO: add test for `sameParty: true`.
-                'goog:sameParty': False,
                 'goog:session': True,
                 'goog:sourcePort': 1234,
                 'goog:sourceScheme': 'Secure',


### PR DESCRIPTION
Chrome never shipped support for HTTP Set-Cookie directive and Cookie.sameParty APIs. This commit removes code for mapping `Cookie.sameParty` values which were never fully supported.

## Background
- In 2022, [Chrome deprecated](https://github.com/WICG/first-party-sets/issues/92) `SameParty` cookie attribute (in all contexts, including HTTP Set-Cookie header and all JS APIs).
- In 2023, [CL 4219615](https://chromium-review.googlesource.com/c/chromium/src/+/4219615) removed `sameParty` attributes from `Cookie` and `CookieInit` JS APIs  and setting corresponding internal Boolean to `false` ([diff](https://chromium.googlesource.com/chromium/src/+/1b2855445a38ce9258cdbffde8bfcd0150ec12bf%5E%21/)).
- In 2024 Chromium BiDi Mapper PR #1759 added mapping for `sameParty` and in tests remarked that miraculously [`sameParty` is not set for whatever reason](https://github.com/GoogleChromeLabs/chromium-bidi/pull/1759/files#diff-bb27db29812eb6dd20a6902cf9e7ab0efe6022a736f6c9df08c9c333ef3f7d3cR250).