### PR TITLE
fix: handle uncaught exceptions in close method

### DIFF
--- a/src/bidiMapper/modules/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessor.ts
@@ -54,7 +54,10 @@ export class BrowserProcessor {
     // Ensure that it is put at the end of the event loop.
     // This way we send back the response before closing the tab.
     // Always catch uncaught exceptions.
-    setTimeout(() => this.#browserCdpClient.sendCommand('Browser.close').catch(() => {}), 0);
+    setTimeout(
+      () => this.#browserCdpClient.sendCommand('Browser.close').catch(() => {}),
+      0,
+    );
 
     return {};
   }


### PR DESCRIPTION
Added error handling for uncaught exceptions when closing the browser.