### PR TITLE
perf: allow loggin per perfix

### DIFF
--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -62,7 +62,7 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
 
   #handleIncomingMessage = (message: ChromiumBidi.Command) => {
     void this.#commandProcessor.processCommand(message).catch((error) => {
-      this.#logger?.(LogType.debugError, error);
+      this.#logger?.(LogType.debugError)?.(error);
     });
   };
 

--- a/src/bidiMapper/CommandProcessor.ts
+++ b/src/bidiMapper/CommandProcessor.ts
@@ -597,7 +597,7 @@ export class CommandProcessor extends EventEmitter<CommandProcessorEventsMap> {
         });
       } else {
         const error = e as Error;
-        this.#logger?.(LogType.bidi, error);
+        this.#logger?.(LogType.bidi)?.(error);
         // Heuristic required for processing cases when a browsing context is gone
         // during the command processing, e.g. like in test
         // `test_input_keyDown_closes_browsing_context`.

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -192,8 +192,7 @@ export class CdpTarget {
    */
   get windowId(): number {
     if (this.#windowId === undefined) {
-      this.#logger?.(
-        LogType.debugError,
+      this.#logger?.(LogType.debugError)?.(
         'Getting windowId before it was set, returning 0',
       );
     }
@@ -264,8 +263,7 @@ export class CdpTarget {
     for (const result of results) {
       if (result instanceof Error) {
         // Ignore errors during configuring targets, just log them.
-        this.#logger?.(
-          LogType.debugError,
+        this.#logger?.(LogType.debugError)?.(
           'Error happened when configuring a new target',
           result,
         );
@@ -365,7 +363,7 @@ export class CdpTarget {
           return await this.#cdpClient.sendCommand('Fetch.disable');
         })
         .catch((error) => {
-          this.#logger?.(LogType.bidi, 'Disable failed', error);
+          this.#logger?.(LogType.bidi)?.('Disable failed', error);
         });
     }
   }
@@ -382,7 +380,7 @@ export class CdpTarget {
         this.toggleFetchIfNeeded(),
       ]);
     } catch (err) {
-      this.#logger?.(LogType.debugError, err);
+      this.#logger?.(LogType.debugError)?.(err);
       if (!this.#isExpectedError(err)) {
         throw err;
       }
@@ -403,7 +401,7 @@ export class CdpTarget {
         cacheDisabled,
       });
     } catch (err) {
-      this.#logger?.(LogType.debugError, err);
+      this.#logger?.(LogType.debugError)?.(err);
       this.#cacheDisableState = !cacheDisabled;
       if (!this.#isExpectedError(err)) {
         throw err;
@@ -425,7 +423,7 @@ export class CdpTarget {
         enabled ? 'DeviceAccess.enable' : 'DeviceAccess.disable',
       );
     } catch (err) {
-      this.#logger?.(LogType.debugError, err);
+      this.#logger?.(LogType.debugError)?.(err);
       this.#deviceAccessEnabled = !enabled;
       if (!this.#isExpectedError(err)) {
         throw err;
@@ -447,7 +445,7 @@ export class CdpTarget {
         enabled ? 'Preload.enable' : 'Preload.disable',
       );
     } catch (err) {
-      this.#logger?.(LogType.debugError, err);
+      this.#logger?.(LogType.debugError)?.(err);
       this.#preloadEnabled = !enabled;
       if (!this.#isExpectedError(err)) {
         throw err;
@@ -546,8 +544,7 @@ export class CdpTarget {
       this.#fetchDomainStages.response !== stages.response ||
       this.#fetchDomainStages.auth !== stages.auth;
 
-    this.#logger?.(
-      LogType.debugInfo,
+    this.#logger?.(LogType.debugInfo)?.(
       'Toggle Network',
       `Fetch (${fetchEnable}) ${fetchChanged}`,
     );

--- a/src/bidiMapper/modules/cdp/CdpTargetManager.ts
+++ b/src/bidiMapper/modules/cdp/CdpTargetManager.ts
@@ -170,7 +170,7 @@ export class CdpTargetManager {
         .then(() =>
           parentSessionCdpClient.sendCommand('Target.detachFromTarget', params),
         )
-        .catch((error) => this.#logger?.(LogType.debugError, error));
+        .catch((error) => this.#logger?.(LogType.debugError)?.(error));
     };
 
     // Do not attach to the Mapper target.

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -256,7 +256,7 @@ export class BrowsingContextImpl {
   /** Sets the parent context ID and updates parent's children. */
   set parentId(parentId: BrowsingContext.BrowsingContext | null) {
     if (this.#parentId !== null) {
-      this.#logger?.(LogType.debugError, 'Parent context already set');
+      this.#logger?.(LogType.debugError)?.('Parent context already set');
       // Cannot do anything except logging, as throwing will stop event processing. So
       // just return,
       return;
@@ -434,8 +434,7 @@ export class BrowsingContextImpl {
       }
 
       if (this.#loaderId === undefined) {
-        this.#logger?.(
-          LogType.debugError,
+        this.#logger?.(LogType.debugError)?.(
           'LoaderId should be defined when file upload is shown',
           params,
         );
@@ -618,8 +617,7 @@ export class BrowsingContextImpl {
             // Sandbox should have the same origin as the context itself, but in CDP
             // it has an empty one.
             if (!this.#defaultRealmDeferred.isFinished) {
-              this.#logger?.(
-                LogType.debugError,
+              this.#logger?.(LogType.debugError)?.(
                 'Unexpectedly, isolated realm created before the default one',
               );
             }
@@ -716,8 +714,7 @@ export class BrowsingContextImpl {
       }
       const accepted = params.result;
       if (this.#lastUserPromptType === undefined) {
-        this.#logger?.(
-          LogType.debugError,
+        this.#logger?.(LogType.debugError)?.(
           'Unexpectedly no opening prompt event before closing one',
         );
       }
@@ -963,8 +960,7 @@ export class BrowsingContextImpl {
     if (this.#lifecycle.DOMContentLoaded.isFinished) {
       this.#lifecycle.DOMContentLoaded = new Deferred();
     } else {
-      this.#logger?.(
-        BrowsingContextImpl.LOGGER_PREFIX,
+      this.#logger?.(BrowsingContextImpl.LOGGER_PREFIX)?.(
         'Document changed (DOMContentLoaded)',
       );
     }
@@ -972,8 +968,7 @@ export class BrowsingContextImpl {
     if (this.#lifecycle.load.isFinished) {
       this.#lifecycle.load = new Deferred();
     } else {
-      this.#logger?.(
-        BrowsingContextImpl.LOGGER_PREFIX,
+      this.#logger?.(BrowsingContextImpl.LOGGER_PREFIX)?.(
         'Document changed (load)',
       );
     }
@@ -1716,8 +1711,7 @@ export class BrowsingContextImpl {
     );
 
     if (locatorResult.type !== 'success') {
-      this.#logger?.(
-        BrowsingContextImpl.LOGGER_PREFIX,
+      this.#logger?.(BrowsingContextImpl.LOGGER_PREFIX)?.(
         'Failed locateNodesByLocator',
         locatorResult,
       );

--- a/src/bidiMapper/modules/context/NavigationTracker.ts
+++ b/src/bidiMapper/modules/context/NavigationTracker.ts
@@ -243,7 +243,7 @@ export class NavigationTracker {
     url: string,
     canBeInitialNavigation: boolean = false,
   ): NavigationState {
-    this.#logger?.(LogType.debug, 'createCommandNavigation');
+    this.#logger?.(LogType.debug)?.('createCommandNavigation');
     this.#isInitialNavigation =
       canBeInitialNavigation &&
       this.#isInitialNavigation &&
@@ -271,7 +271,7 @@ export class NavigationTracker {
 
   // Update the current url.
   onTargetInfoChanged(url: string) {
-    this.#logger?.(LogType.debug, `onTargetInfoChanged ${url}`);
+    this.#logger?.(LogType.debug)?.(`onTargetInfoChanged ${url}`);
     this.#lastCommittedNavigation.url = url;
   }
 
@@ -299,7 +299,7 @@ export class NavigationTracker {
    * @param {string} unreachableUrl indicated the navigation is actually failed.
    */
   frameNavigated(url: string, loaderId: string, unreachableUrl?: string) {
-    this.#logger?.(LogType.debug, `frameNavigated ${url}`);
+    this.#logger?.(LogType.debug)?.(`frameNavigated ${url}`);
 
     if (unreachableUrl !== undefined) {
       // The navigation failed.
@@ -339,8 +339,7 @@ export class NavigationTracker {
     url: string,
     navigationType: Protocol.Page.NavigatedWithinDocumentEvent['navigationType'],
   ) {
-    this.#logger?.(
-      LogType.debug,
+    this.#logger?.(LogType.debug)?.(
       `navigatedWithinDocument ${url}, ${navigationType}`,
     );
 
@@ -378,7 +377,7 @@ export class NavigationTracker {
    * `Page.frameNavigated` or on navigating command finished with a new loader Id.
    */
   loadPageEvent(loaderId: string) {
-    this.#logger?.(LogType.debug, 'loadPageEvent');
+    this.#logger?.(LogType.debug)?.('loadPageEvent');
     // Even if it was an initial navigation, it is finished.
     this.#isInitialNavigation = false;
 
@@ -389,7 +388,7 @@ export class NavigationTracker {
    * Fail navigation due to navigation command failed.
    */
   failNavigation(navigation: NavigationState, errorText: string) {
-    this.#logger?.(LogType.debug, 'failCommandNavigation');
+    this.#logger?.(LogType.debug)?.('failCommandNavigation');
     navigation.fail(errorText);
   }
 
@@ -398,8 +397,7 @@ export class NavigationTracker {
    * cross-document navigation.
    */
   navigationCommandFinished(navigation: NavigationState, loaderId?: string) {
-    this.#logger?.(
-      LogType.debug,
+    this.#logger?.(LogType.debug)?.(
       `finishCommandNavigation ${navigation.navigationId}, ${loaderId}`,
     );
 
@@ -416,7 +414,9 @@ export class NavigationTracker {
     loaderId: string,
     navigationType: string,
   ) {
-    this.#logger?.(LogType.debug, `frameStartedNavigating ${url}, ${loaderId}`);
+    this.#logger?.(LogType.debug)?.(
+      `frameStartedNavigating ${url}, ${loaderId}`,
+    );
 
     if (
       this.#pendingNavigation &&

--- a/src/bidiMapper/modules/log/LogManager.ts
+++ b/src/bidiMapper/modules/log/LogManager.ts
@@ -161,7 +161,7 @@ export class LogManager {
       });
       if (realm === undefined) {
         // Ignore exceptions not attached to any realm.
-        this.#logger?.(LogType.cdp, params);
+        this.#logger?.(LogType.cdp)?.(params);
         return;
       }
 
@@ -209,7 +209,7 @@ export class LogManager {
       });
       if (realm === undefined) {
         // Ignore exceptions not attached to any realm.
-        this.#logger?.(LogType.cdp, params);
+        this.#logger?.(LogType.cdp)?.(params);
         return;
       }
 

--- a/src/bidiMapper/modules/network/CollectorsStorage.ts
+++ b/src/bidiMapper/modules/network/CollectorsStorage.ts
@@ -167,8 +167,7 @@ export class CollectorsStorage {
       dataType === Network.DataType.Request &&
       request.bodySize > collector.maxEncodedDataSize
     ) {
-      this.#logger?.(
-        LogType.debug,
+      this.#logger?.(LogType.debug)?.(
         `Request's ${request.id} body size is too big for the collector ${collectorId}`,
       );
       return false;
@@ -178,15 +177,13 @@ export class CollectorsStorage {
       dataType === Network.DataType.Response &&
       request.encodedResponseBodySize > collector.maxEncodedDataSize
     ) {
-      this.#logger?.(
-        LogType.debug,
+      this.#logger?.(LogType.debug)?.(
         `Request's ${request.id} response is too big for the collector ${collectorId}`,
       );
       return false;
     }
 
-    this.#logger?.(
-      LogType.debug,
+    this.#logger?.(LogType.debug)?.(
       `Collector ${collectorId} collected ${dataType} of ${request.id}`,
     );
     return true;

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -185,8 +185,7 @@ export class NetworkRequest {
   /** CdpTarget can be changed when frame is moving out of process. */
   updateCdpTarget(cdpTarget: CdpTarget) {
     if (cdpTarget !== this.#cdpTarget) {
-      this.#logger?.(
-        LogType.debugInfo,
+      this.#logger?.(LogType.debugInfo)?.(
         `Request ${this.id} was moved from ${this.#cdpTarget.id} to ${cdpTarget.id}`,
       );
       this.#cdpTarget = cdpTarget;
@@ -265,8 +264,7 @@ export class NetworkRequest {
       if (Number.isInteger(bodySize)) {
         return bodySize;
       }
-      this.#logger?.(
-        LogType.debugError,
+      this.#logger?.(LogType.debugError)?.(
         "Unexpected non-integer 'Content-Length' header",
       );
     }
@@ -921,7 +919,7 @@ export class NetworkRequest {
     try {
       event = getEvent();
     } catch (error) {
-      this.#logger?.(LogType.debugError, error);
+      this.#logger?.(LogType.debugError)?.(error);
       return;
     }
 

--- a/src/bidiMapper/modules/network/NetworkStorage.test.ts
+++ b/src/bidiMapper/modules/network/NetworkStorage.test.ts
@@ -38,9 +38,12 @@ import {NetworkStorage} from './NetworkStorage.js';
 function logger(...args: any[]) {
   // eslint-disable-next-line no-constant-condition
   if (false) {
-    // eslint-disable-next-line no-console
-    console.log(...args);
+    return () => {
+      // eslint-disable-next-line no-console
+      console.log(...args);
+    };
   }
+  return;
 }
 
 describe('NetworkStorage', () => {

--- a/src/bidiMapper/modules/script/ChannelProxy.ts
+++ b/src/bidiMapper/modules/script/ChannelProxy.ts
@@ -60,7 +60,7 @@ export class ChannelProxy {
       const channelHandle = await this.#getHandleFromWindow(realm);
       void this.#startListener(realm, channelHandle, eventManager);
     } catch (error) {
-      this.#logger?.(LogType.debugError, error);
+      this.#logger?.(LogType.debugError)?.(error);
     }
   }
 
@@ -213,7 +213,7 @@ export class ChannelProxy {
       } catch (error) {
         // If an error is thrown, then the channel is permanently broken, so we
         // exit the loop.
-        this.#logger?.(LogType.debugError, error);
+        this.#logger?.(LogType.debugError)?.(error);
         break;
       }
     }

--- a/src/bidiMapper/modules/script/Realm.ts
+++ b/src/bidiMapper/modules/script/Realm.ts
@@ -82,7 +82,7 @@ export abstract class Realm {
       } else {
         // No need to await for the object to be released.
         void this.#releaseObject(objectId).catch((error) =>
-          this.#logger?.(LogType.debugError, error),
+          this.#logger?.(LogType.debugError)?.(error),
         );
       }
     }

--- a/src/bidiMapper/modules/speculation/SpeculationProcessor.ts
+++ b/src/bidiMapper/modules/speculation/SpeculationProcessor.ts
@@ -48,8 +48,7 @@ export class SpeculationProcessor {
           break;
         default:
           // If status is not recognized, skip the event
-          this.#logger?.(
-            LogType.debugWarn,
+          this.#logger?.(LogType.debugWarn)?.(
             `Unknown prefetch status: ${event.status}`,
           );
           return;

--- a/src/bidiMapper/modules/storage/StorageProcessor.ts
+++ b/src/bidiMapper/modules/storage/StorageProcessor.ts
@@ -154,7 +154,7 @@ export class StorageProcessor {
         throw new NoSuchUserContextException(err.message);
       }
 
-      this.#logger?.(LogType.debugError, err);
+      this.#logger?.(LogType.debugError)?.(err);
       throw new UnableToSetCookieException(err.toString());
     }
     return {
@@ -219,8 +219,7 @@ export class StorageProcessor {
     }
 
     if (unsupportedPartitionKeys.size > 0) {
-      this.#logger?.(
-        LogType.debugInfo,
+      this.#logger?.(LogType.debugInfo)?.(
         `Unsupported partition keys: ${JSON.stringify(
           Object.fromEntries(unsupportedPartitionKeys),
         )}`,

--- a/src/bidiTab/Transport.ts
+++ b/src/bidiTab/Transport.ts
@@ -35,7 +35,7 @@ export class WindowBidiTransport implements BidiTransport {
 
   constructor() {
     window.onBidiMessage = (message: string) => {
-      log(WindowBidiTransport.LOGGER_PREFIX_RECV, message);
+      log(WindowBidiTransport.LOGGER_PREFIX_RECV)?.(message);
       try {
         const command = WindowBidiTransport.#parseBidiMessage(message);
         this.#onMessage?.call(null, command);
@@ -52,7 +52,7 @@ export class WindowBidiTransport implements BidiTransport {
   }
 
   sendMessage(message: ChromiumBidi.Message) {
-    log(WindowBidiTransport.LOGGER_PREFIX_SEND, message);
+    log(WindowBidiTransport.LOGGER_PREFIX_SEND)?.(message);
     const json = JSON.stringify(message);
     window.sendBidiResponse(json);
   }

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -85,7 +85,7 @@ async function runMapperInstance(selfTargetId: string) {
     log,
   );
 
-  log(LogType.debugInfo, 'Mapper instance has been launched');
+  log(LogType.debugInfo)?.('Mapper instance has been launched');
 
   return bidiServer;
 }

--- a/src/bidiTab/mapperTabPage.ts
+++ b/src/bidiTab/mapperTabPage.ts
@@ -39,7 +39,7 @@ function stringify(message: unknown) {
   return message;
 }
 
-export function log(logPrefix: LogPrefix, ...messages: unknown[]) {
+export function log(logPrefix: LogPrefix) {
   // If run not in browser (e.g. unit test), do nothing.
   if (!globalThis.document.documentElement) {
     return;
@@ -48,9 +48,11 @@ export function log(logPrefix: LogPrefix, ...messages: unknown[]) {
   // Skip sending BiDi logs as they are logged once by `bidi:server:*`
   if (!logPrefix.startsWith(LogType.bidi)) {
     // If `sendDebugMessage` is defined, send the log message there.
-    globalThis.window?.sendDebugMessage?.(
-      JSON.stringify({logType: logPrefix, messages}, null, 2),
-    );
+    return (...messages: unknown[]) => {
+      globalThis.window?.sendDebugMessage?.(
+        JSON.stringify({logType: logPrefix, messages}, null, 2),
+      );
+    };
   }
 
   const debugContainer = document.getElementById('logs');
@@ -58,14 +60,16 @@ export function log(logPrefix: LogPrefix, ...messages: unknown[]) {
     return;
   }
 
-  // This piece of HTML should be added:
-  // <div class="pre">...log message...</div>
-  const lineElement = document.createElement('div');
-  lineElement.className = 'pre';
+  return (...messages: unknown[]) => {
+    // This piece of HTML should be added:
+    // <div class="pre">...log message...</div>
+    const lineElement = document.createElement('div');
+    lineElement.className = 'pre';
 
-  lineElement.textContent = [logPrefix, ...messages].map(stringify).join(' ');
-  debugContainer.appendChild(lineElement);
-  if (debugContainer.childNodes.length > 400) {
-    debugContainer.removeChild(debugContainer.childNodes[0]!);
-  }
+    lineElement.textContent = [logPrefix, ...messages].map(stringify).join(' ');
+    debugContainer.appendChild(lineElement);
+    if (debugContainer.childNodes.length > 400) {
+      debugContainer.removeChild(debugContainer.childNodes[0]!);
+    }
+  };
 }

--- a/src/cdp/CdpConnection.ts
+++ b/src/cdp/CdpConnection.ts
@@ -121,16 +121,16 @@ export class MapperCdpConnection implements CdpConnection {
       void this.#transport
         .sendMessage(JSON.stringify(cdpMessage))
         ?.catch((error) => {
-          this.#logger?.(LogType.debugError, error);
+          this.#logger?.(LogType.debugError)?.(error);
           this.#transport.close();
         });
-      this.#logger?.(MapperCdpConnection.LOGGER_PREFIX_SEND, cdpMessage);
+      this.#logger?.(MapperCdpConnection.LOGGER_PREFIX_SEND)?.(cdpMessage);
     });
   }
 
   #onMessage = (json: string) => {
     const message: CdpMessage<any> = JSON.parse(json);
-    this.#logger?.(MapperCdpConnection.LOGGER_PREFIX_RECV, message);
+    this.#logger?.(MapperCdpConnection.LOGGER_PREFIX_RECV)?.(message);
 
     // Update client map if a session is attached
     // Listen for these events on every session.

--- a/src/utils/ProcessingQueue.test.ts
+++ b/src/utils/ProcessingQueue.test.ts
@@ -66,7 +66,7 @@ describe('ProcessingQueue', () => {
     const error = new Error('Processor reject');
     const processor = sinon.stub().returns(Promise.reject(error));
     const logger = sinon.spy();
-    const queue = new ProcessingQueue<number>(processor, logger);
+    const queue = new ProcessingQueue<number>(processor, () => logger);
     const deferred = new Deferred<Result<number>>();
 
     queue.add(deferred, '');
@@ -92,7 +92,7 @@ describe('ProcessingQueue', () => {
     const error = new Error('Processor reject');
     const processor = sinon.stub().returns(Promise.resolve());
     const logger = sinon.spy();
-    const queue = new ProcessingQueue<number>(processor, logger);
+    const queue = new ProcessingQueue<number>(processor, () => logger);
     const deferred1 = new Deferred<Result<number>>();
     const deferred2 = new Deferred<Result<number>>();
 
@@ -121,7 +121,7 @@ describe('ProcessingQueue', () => {
     const error = new Error('Processor reject');
     const processor = sinon.stub().returns(Promise.resolve());
     const logger = sinon.spy();
-    const queue = new ProcessingQueue<number>(processor, logger);
+    const queue = new ProcessingQueue<number>(processor, () => logger);
     const deferred1 = new Deferred<Result<number>>();
     const deferred2 = new Deferred<Result<number>>();
 
@@ -181,7 +181,7 @@ describe('ProcessingQueue', () => {
   it('processing log name when starting to process new values', async () => {
     const processor = sinon.stub().returns(Promise.resolve());
     const logger = sinon.spy();
-    const queue = new ProcessingQueue<number>(processor, logger);
+    const queue = new ProcessingQueue<number>(processor, () => logger);
     const eventNames = [
       'EventNameOne',
       'EventNameTwo',

--- a/src/utils/ProcessingQueue.test.ts
+++ b/src/utils/ProcessingQueue.test.ts
@@ -20,7 +20,6 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 
 import {Deferred} from './Deferred.js';
-import {LogType} from './log.js';
 import {ProcessingQueue} from './ProcessingQueue.js';
 import type {Result} from './result.js';
 
@@ -83,8 +82,8 @@ describe('ProcessingQueue', () => {
     // Assert `_catch` was called for waiting entry and processor call.
     const loggerErrorValues = logger
       .getCalls()
-      .filter((c) => c.args[0] === LogType.debugError)
-      .map((c) => c.args[2]);
+      .filter((c) => c.args[0] === 'Event was not processed:')
+      .map((c) => c.args[1]);
     expect(loggerErrorValues).to.deep.equal([error.message]);
   });
 
@@ -112,8 +111,8 @@ describe('ProcessingQueue', () => {
     // Assert `_catch` was called for waiting entry and processor call.
     const loggerErrorValues = logger
       .getCalls()
-      .filter((c) => c.args[0] === LogType.debugError)
-      .map((c) => c.args[2]);
+      .filter((c) => c.args[0] === 'Event was not processed:')
+      .map((c) => c.args[1]);
     expect(loggerErrorValues).to.deep.equal([error.message]);
   });
 
@@ -144,8 +143,8 @@ describe('ProcessingQueue', () => {
     // Assert `_catch` was called for waiting entry and processor call.
     const loggerErrorValues = logger
       .getCalls()
-      .filter((c) => c.args[0] === LogType.debugError)
-      .map((c) => c.args[2]);
+      .filter((c) => c.args[0] === 'Event threw before sending:')
+      .map((c) => c.args[1]);
     expect(loggerErrorValues).to.deep.equal([error.message]);
   });
 
@@ -207,8 +206,8 @@ describe('ProcessingQueue', () => {
 
     const processedValues = logger
       .getCalls()
-      .filter((c) => c.args[0] === ProcessingQueue.LOGGER_PREFIX)
-      .map((c) => c.args[2]);
+      .filter((c) => c.args[0] === 'Processing event:')
+      .map((c) => c.args[1]);
     expect(processedValues).to.deep.equal(eventNames);
   });
 });

--- a/src/utils/ProcessingQueue.ts
+++ b/src/utils/ProcessingQueue.ts
@@ -50,13 +50,15 @@ export class ProcessingQueue<T> {
         continue;
       }
       const [entryPromise, name] = arrayEntry;
-      this.#logger?.(ProcessingQueue.LOGGER_PREFIX, 'Processing event:', name);
+      this.#logger?.(ProcessingQueue.LOGGER_PREFIX)?.(
+        'Processing event:',
+        name,
+      );
 
       await entryPromise
         .then((entry) => {
           if (entry.kind === 'error') {
-            this.#logger?.(
-              LogType.debugError,
+            this.#logger?.(LogType.debugError)?.(
               'Event threw before sending:',
               entry.error.message,
               entry.error.stack,
@@ -66,8 +68,7 @@ export class ProcessingQueue<T> {
           return this.#processor(entry.value);
         })
         .catch((error) => {
-          this.#logger?.(
-            LogType.debugError,
+          this.#logger?.(LogType.debugError)?.(
             'Event was not processed:',
             error?.message,
           );

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -28,4 +28,6 @@ export enum LogType {
 
 export type LogPrefix = LogType | `${LogType}:${string}`;
 
-export type LoggerFn = (type: LogPrefix, ...messages: unknown[]) => void;
+export type LoggerFn = (
+  type: LogPrefix,
+) => ((...messages: unknown[]) => void) | undefined;


### PR DESCRIPTION
This will allow the downstream consumers to check if a prefix is enabled or not, allowing finer controls such that if it's disable we can skip some of the object creation from code like `this.logger()?.({ tempObject: true})`