### PR TITLE
fix: set mobile device metrics on Android targets

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -174,6 +174,7 @@ ts_library("unit_tests") {
   sources = [
     "bidiMapper/modules/browser/BrowserProcessot.test.ts",
     "bidiMapper/modules/browser/ContextConfigStorage.test.ts",
+    "bidiMapper/modules/cdp/CdpTarget.test.ts",
     "bidiMapper/modules/context/BrowsingContextStorage.test.ts",
     "bidiMapper/modules/context/NavigationTracker.test.ts",
     "bidiMapper/modules/emulation/EmulationProcessor.test.ts",

--- a/src/bidiMapper/modules/cdp/CdpTarget.test.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {describe, it} from 'node:test';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import type {SinonStub} from 'sinon';
+
+import type {CdpClient} from '../../../cdp/CdpClient.js';
+
+import {CdpTarget} from './CdpTarget.js';
+
+function createCdpTarget(defaultUserAgent: string): {
+  target: CdpTarget;
+  sendCommand: SinonStub;
+} {
+  const sendCommand = sinon.stub().resolves({});
+  const cdpClient = {
+    sendCommand,
+  } as unknown as CdpClient;
+
+  return {
+    target: new CdpTarget(
+      'target-id',
+      cdpClient,
+      cdpClient,
+      cdpClient,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      'default',
+      defaultUserAgent,
+      undefined,
+    ),
+    sendCommand,
+  };
+}
+
+describe('CdpTarget', () => {
+  describe('setDeviceMetricsOverride', () => {
+    it('sets mobile device metrics for Android targets', async () => {
+      const {target, sendCommand} = createCdpTarget(
+        'Mozilla/5.0 (Linux; Android 15; Pixel 8) AppleWebKit/537.36',
+      );
+
+      await target.setDeviceMetricsOverride(
+        {width: 320, height: 640},
+        2,
+        null,
+        null,
+      );
+
+      expect(sendCommand.firstCall.args).to.deep.equal([
+        'Emulation.setDeviceMetricsOverride',
+        {
+          width: 320,
+          height: 640,
+          deviceScaleFactor: 2,
+          screenOrientation: undefined,
+          mobile: true,
+          screenWidth: undefined,
+          screenHeight: undefined,
+          scrollbarType: 'default',
+        },
+      ]);
+    });
+
+    it('keeps desktop targets in non-mobile device metrics mode', async () => {
+      const {target, sendCommand} = createCdpTarget(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+      );
+
+      await target.setDeviceMetricsOverride(
+        {width: 800, height: 600},
+        1,
+        null,
+        null,
+      );
+
+      expect(sendCommand.firstCall.args).to.deep.equal([
+        'Emulation.setDeviceMetricsOverride',
+        {
+          width: 800,
+          height: 600,
+          deviceScaleFactor: 1,
+          screenOrientation: undefined,
+          mobile: false,
+          screenWidth: undefined,
+          screenHeight: undefined,
+          scrollbarType: 'default',
+        },
+      ]);
+    });
+  });
+});

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -592,6 +592,10 @@ export class CdpTarget {
     );
   }
 
+  #isAndroidTarget(): boolean {
+    return /Android/i.test(this.#defaultUserAgent);
+  }
+
   async setDeviceMetricsOverride(
     viewport: BrowsingContext.Viewport | null,
     devicePixelRatio: number | null,
@@ -617,7 +621,7 @@ export class CdpTarget {
         deviceScaleFactor: devicePixelRatio ?? 0,
         screenOrientation:
           this.#toCdpScreenOrientationAngle(screenOrientation) ?? undefined,
-        mobile: false,
+        mobile: this.#isAndroidTarget(),
         screenWidth: screenArea?.width,
         screenHeight: screenArea?.height,
         scrollbarType: scrollbarType === 'overlay' ? 'overlay' : 'default',


### PR DESCRIPTION
I want to support for BiDi viewport emulation through `browsingContext.setViewport for Android. while doing it, I found that Android targets need CDP mobile viewport semantics for the emulated viewport and DPR to match the actual Android layout behavior.

Android BiDi viewport emulation was using desktop CDP viewport semantics, which can produce incorrect viewport sizing after `browsingContext.setViewport`.

So I am pushing this PR to set the CDP mobile flag for android targets when BiDi applies viewport emulation

Android needs mobile viewport semantics for viewport and DPR overrides to match the target’s actual layout behavior. Desktop targets keep the existing `mobile: false` behavior.

## Testing

- `npm run gn:gen`
- `npm run build`
- `npm run unit`
- `npx eslint src/bidiMapper/modules/cdp/CdpTarget.ts src/bidiMapper/modules/cdp/CdpTarget.test.ts`
- `npx prettier --check package.json src/bidiMapper/modules/cdp/CdpTarget.ts src/bidiMapper/modules/cdp/CdpTarget.test.ts`