### PR TITLE
chore: touch dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 
-# touch ++++++
+# touch +++++++
 
 updates:
   - package-ecosystem: gitsubmodule


### PR DESCRIPTION
The dependabot got disabled for this repo, updating configs makes it work again.