### PR TITLE
build: use relative paths in gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -18,6 +18,6 @@
 group("default") {
   testonly = true
   deps = [
-    "//src:all",
+    "src:all",
   ]
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//tools/build/bidi_module.gni")
+import("../tools/build/bidi_module.gni")
 
 bidi_foundation_module("utils") {
   sources = [

--- a/tools/build/bidi_module.gni
+++ b/tools/build/bidi_module.gni
@@ -15,7 +15,7 @@
 
 # Custom modular build templates wrapping our standalone ts_library template.
 
-import("//tools/build/ts_library.gni")
+import("ts_library.gni")
 
 # A foundation module that compiles TS files and runs dual type-checking:
 # 1. A browser check (validating DOM, DOM.iterable, and standard ES2023 APIs).
@@ -63,7 +63,7 @@ template("bidi_foundation_module") {
 # Bundler template wrapping Rollup.
 template("bidi_bundle") {
   action(target_name) {
-    script = "//tools/build/scripts/rollup.py"
+    script = "../tools/build/scripts/rollup.py"
     
     forward_variables_from(invoker, [
       "entrypoint",
@@ -72,7 +72,7 @@ template("bidi_bundle") {
     ])
     
     inputs = [
-      "//rollup.config.mjs",
+      "../rollup.config.mjs",
       entrypoint,
     ]
     
@@ -81,7 +81,7 @@ template("bidi_bundle") {
     ]
     
     args = [
-      "--config", rebase_path("//rollup.config.mjs", root_build_dir),
+      "--config", rebase_path("../rollup.config.mjs", root_build_dir),
       "--entrypoint", rebase_path(entrypoint, root_build_dir),
       "--output", rebase_path(output_file, root_build_dir),
       "--gen-dir", rebase_path(root_out_dir, "//"),

--- a/tools/build/scripts/compile_ts.py
+++ b/tools/build/scripts/compile_ts.py
@@ -51,6 +51,9 @@ def main():
         os.path.abspath(args.root_dir) if args.root_dir else repo_root
     )
     config["files"] = abs_sources
+    config["compilerOptions"]["typeRoots"] = [
+        os.path.join(repo_root, "node_modules", "@types")
+    ]
 
     if args.es_target:
         config["compilerOptions"]["target"] = args.es_target

--- a/tools/build/ts_library.gni
+++ b/tools/build/ts_library.gni
@@ -17,7 +17,7 @@
 
 template("ts_library") {
   action(target_name) {
-    script = "//tools/build/scripts/compile_ts.py"
+    script = "../tools/build/scripts/compile_ts.py"
 
     forward_variables_from(invoker, [
       "sources",
@@ -31,8 +31,8 @@ template("ts_library") {
       inputs = []
     }
     inputs += [
-      "//tsconfig.base.json",
-      "//node_modules/typescript/lib/tsc.js",
+      "../tsconfig.base.json",
+      "../node_modules/typescript/lib/tsc.js",
     ]
 
     if (defined(deps)) {
@@ -50,7 +50,7 @@ template("ts_library") {
     _tsconfig_output = "$target_gen_dir/$target_name-tsconfig.json"
 
     args = [
-      "--tsconfig_template", rebase_path("//tsconfig.base.json", root_build_dir),
+      "--tsconfig_template", rebase_path("../tsconfig.base.json", root_build_dir),
       "--tsconfig_output", rebase_path(_tsconfig_output, root_build_dir),
       "--output_dir", rebase_path(target_gen_dir, root_build_dir),
       "--root_dir", rebase_path(".", root_build_dir),


### PR DESCRIPTION
It makes it usable in other GN build trees.