### PR TITLE
fix: adjust npm publish after gn migration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,10 @@ jobs:
           cache: npm
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+      - name: Sync dependencies
+        run: bash tools/gclient-sync.sh
+      - name: Generate Ninja config
+        run: npm run gn:gen
       - name: Install and build npm dependencies
         run: npm ci
       - name: Publish


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: adjust npm publish after gn migration

END_COMMIT_OVERRIDE