### PR TITLE
[DC] Implement support for non-top-level contexts in digitalCredentia…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/sinon": "21.0.1",
         "@types/websocket": "1.0.10",
         "chai": "6.2.2",
-        "devtools-protocol": "0.0.1655900",
+        "devtools-protocol": "0.0.1658499",
         "eslint": "10.5.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-import-resolver-typescript": "4.4.5",
@@ -1956,9 +1956,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1655900",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1655900.tgz",
-      "integrity": "sha512-mgjlBJ7tTnTcIAks1HQKvd1XBRiZPzHd/HOW8MUr7XqsfZWtrBFdRG4XOM9wnrZ2bx6OLGWkbD6y5whjh36GgQ==",
+      "version": "0.0.1658499",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1658499.tgz",
+      "integrity": "sha512-ErMPzWOOgJU/Ftl1Qj2iGGsVqHceICIgeLeFuuVah4vQjC3hE1XwGlXA34syuduBCK1y3dn3VCI8a/MlfSnL/A==",
       "dev": true,
       "license": "BSD-3-Clause"
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/sinon": "21.0.1",
     "@types/websocket": "1.0.10",
     "chai": "6.2.2",
-    "devtools-protocol": "0.0.1655900",
+    "devtools-protocol": "0.0.1658499",
     "eslint": "10.5.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-import-resolver-typescript": "4.4.5",

--- a/src/bidiMapper/modules/browser/ContextConfigStorage.ts
+++ b/src/bidiMapper/modules/browser/ContextConfigStorage.ts
@@ -80,6 +80,22 @@ export class ContextConfigStorage {
   }
 
   /**
+   * Returns the configuration for a specific browsing context.
+   */
+  getBrowsingContextConfig(
+    browsingContextId: string,
+  ): ContextConfig | undefined {
+    return this.#browsingContextConfigs.get(browsingContextId);
+  }
+
+  /**
+   * Returns the configuration for a specific user context.
+   */
+  getUserContextConfig(userContext: string): ContextConfig | undefined {
+    return this.#userContextConfigs.get(userContext);
+  }
+
+  /**
    * Extra headers is a special case. The headers from the different levels have to be
    * merged instead of being overridden.
    */

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -719,23 +719,6 @@ export class CdpTarget {
       promises.push(this.setTouchOverride(config.maxTouchPoints));
     }
 
-    if (config.digitalCredentialsBehavior && this.id === this.topLevelId) {
-      promises.push(
-        this.cdpClient
-          .sendCommand('DigitalCredentials.setVirtualWalletBehavior', {
-            // @ts-expect-error action is kept for backward compatibility with older Chromium CDP versions
-            action: config.digitalCredentialsBehavior.action,
-            behavior: config.digitalCredentialsBehavior.action,
-            protocol: config.digitalCredentialsBehavior.protocol,
-            response: config.digitalCredentialsBehavior.response,
-          })
-          .catch(() => {
-            // Ignore CDP errors, as the command is not supported by iframe targets
-            // or older browser versions.
-          }),
-      );
-    }
-
     await Promise.all(promises);
   }
 

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -20,6 +20,7 @@ import type {Protocol} from 'devtools-protocol';
 import {
   BrowsingContext,
   ChromiumBidi,
+  DigitalCredentials,
   type Emulation,
   InvalidArgumentException,
   InvalidSelectorException,
@@ -55,6 +56,11 @@ import {
   type NavigationState,
   NavigationTracker,
 } from './NavigationTracker.js';
+
+type DigitalCredentialsBehavior = Omit<
+  DigitalCredentials.SetVirtualWalletBehaviorParameters,
+  'context'
+>;
 
 export class BrowsingContextImpl {
   static readonly LOGGER_PREFIX = `${LogType.debug}:browsingContext` as const;
@@ -166,31 +172,34 @@ export class BrowsingContextImpl {
     // as the parent of the context can be set later in case of reconnecting to an
     // existing browser instance + OOPiF.
     eventManager.registerPromiseEvent(
-      context.targetUnblockedOrThrow().then(
-        () => {
-          return {
-            kind: 'success',
-            value: {
-              type: 'event',
-              method: ChromiumBidi.BrowsingContext.EventNames.ContextCreated,
-              params: {
-                ...context.serializeToBidiValue(),
-                // Hack to provide the initial URL of the context, as it can be changed
-                // between the page target is attached and unblocked, as the page is not
-                // fully paused in MPArch session (https://crbug.com/372842894).
-                // TODO: remove once https://crbug.com/372842894 is addressed.
-                url,
+      context
+        .targetUnblockedOrThrow()
+        .then(() => context.applyDigitalCredentialsBehavior())
+        .then(
+          () => {
+            return {
+              kind: 'success',
+              value: {
+                type: 'event',
+                method: ChromiumBidi.BrowsingContext.EventNames.ContextCreated,
+                params: {
+                  ...context.serializeToBidiValue(),
+                  // Hack to provide the initial URL of the context, as it can be changed
+                  // between the page target is attached and unblocked, as the page is not
+                  // fully paused in MPArch session (https://crbug.com/372842894).
+                  // TODO: remove once https://crbug.com/372842894 is addressed.
+                  url,
+                },
               },
-            },
-          };
-        },
-        (error) => {
-          return {
-            kind: 'error',
-            error,
-          };
-        },
-      ),
+            };
+          },
+          (error) => {
+            return {
+              kind: 'error',
+              error,
+            };
+          },
+        ),
       context.id,
       ChromiumBidi.BrowsingContext.EventNames.ContextCreated,
     );
@@ -339,6 +348,48 @@ export class BrowsingContextImpl {
     if (result.kind === 'error') {
       throw result.error;
     }
+  }
+
+  async applyDigitalCredentialsBehavior() {
+    const behavior = this.#resolveDigitalCredentialsBehavior();
+    const action =
+      behavior?.action ?? DigitalCredentials.VirtualWalletAction.Clear;
+    const protocol = behavior?.protocol;
+    const response = behavior?.response;
+
+    try {
+      await this.cdpTarget.cdpClient.sendCommand(
+        'DigitalCredentials.setVirtualWalletBehavior',
+        {
+          action,
+          protocol,
+          response,
+          frameId: this.id,
+        },
+      );
+    } catch {
+      // Ignore
+    }
+  }
+
+  #resolveDigitalCredentialsBehavior():
+    | DigitalCredentialsBehavior
+    | null
+    | undefined {
+    const config = this.#configStorage.getBrowsingContextConfig(this.id);
+    if (config?.digitalCredentialsBehavior !== undefined) {
+      return config.digitalCredentialsBehavior;
+    }
+
+    const userContextConfig = this.#configStorage.getUserContextConfig(
+      this.userContext,
+    );
+    if (userContextConfig?.digitalCredentialsBehavior !== undefined) {
+      return userContextConfig.digitalCredentialsBehavior;
+    }
+
+    const globalConfig = this.#configStorage.getGlobalConfig();
+    return globalConfig.digitalCredentialsBehavior;
   }
 
   /** Returns a sandbox for internal helper scripts which is not exposed to the user.*/

--- a/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.test.ts
+++ b/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.test.ts
@@ -22,7 +22,6 @@ import sinon from 'sinon';
 import {
   DigitalCredentials,
   InvalidArgumentException,
-  UnsupportedOperationException,
 } from '../../../protocol/protocol.js';
 import type {CdpTarget} from '../cdp/CdpTarget.js';
 import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
@@ -162,6 +161,9 @@ describe('DigitalCredentialsProcessor', () => {
       browsingContextStorage.getContext
         .withArgs('context_id')
         .returns(mockContext);
+      browsingContextStorage.findContext
+        .withArgs('context_id')
+        .returns(mockContext);
       browsingContextStorage.getAllContexts.returns([mockContext]);
 
       await processor.setVirtualWalletBehavior({
@@ -175,9 +177,9 @@ describe('DigitalCredentialsProcessor', () => {
           'DigitalCredentials.setVirtualWalletBehavior',
           {
             action: DigitalCredentials.VirtualWalletAction.Decline,
-            behavior: DigitalCredentials.VirtualWalletAction.Decline,
             protocol: undefined,
             response: undefined,
+            frameId: 'context_id',
           },
         ),
       );
@@ -193,29 +195,47 @@ describe('DigitalCredentialsProcessor', () => {
       });
     });
 
-    it('should throw UnsupportedOperationException if context is not top-level', async () => {
+    it('should allow configuring behavior for subframe contexts', async () => {
+      const mockCdpClient = {
+        sendCommand: sinon.stub().resolves({}),
+      };
+      const mockTarget = {
+        cdpClient: mockCdpClient,
+        id: 'child_context_id',
+        topLevelId: 'parent_context_id',
+        userContext: 'default',
+      } as unknown as CdpTarget;
       const mockContext = {
         id: 'child_context_id',
         parentId: 'parent_context_id',
+        cdpTarget: mockTarget,
       } as unknown as BrowsingContextImpl;
 
       browsingContextStorage.getContext
         .withArgs('child_context_id')
         .returns(mockContext);
+      browsingContextStorage.findContext
+        .withArgs('child_context_id')
+        .returns(mockContext);
+      browsingContextStorage.getAllContexts.returns([mockContext]);
 
-      try {
-        await processor.setVirtualWalletBehavior({
-          context: 'child_context_id',
-          action: DigitalCredentials.VirtualWalletAction.Decline,
-        });
-        assert.fail('Expected UnsupportedOperationException to be thrown');
-      } catch (error) {
-        assert.instanceOf(error, UnsupportedOperationException);
-        assert.strictEqual(
-          (error as Error).message,
-          'Only top-level contexts are supported',
-        );
-      }
+      await processor.setVirtualWalletBehavior({
+        context: 'child_context_id',
+        action: DigitalCredentials.VirtualWalletAction.Decline,
+      });
+
+      assert.isTrue(mockCdpClient.sendCommand.calledOnce);
+      assert.isTrue(
+        mockCdpClient.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {
+            action: DigitalCredentials.VirtualWalletAction.Decline,
+            protocol: undefined,
+            response: undefined,
+            frameId: 'child_context_id',
+          },
+        ),
+      );
     });
   });
 
@@ -246,6 +266,12 @@ describe('DigitalCredentialsProcessor', () => {
         cdpTarget: mockTarget2,
       } as unknown as BrowsingContextImpl;
 
+      browsingContextStorage.findContext
+        .withArgs('context_1')
+        .returns(mockContext1);
+      browsingContextStorage.findContext
+        .withArgs('context_2')
+        .returns(mockContext2);
       browsingContextStorage.getAllContexts.returns([
         mockContext1,
         mockContext2,
@@ -262,14 +288,19 @@ describe('DigitalCredentialsProcessor', () => {
 
       const expectedCdpParams = {
         action: DigitalCredentials.VirtualWalletAction.Respond,
-        behavior: DigitalCredentials.VirtualWalletAction.Respond,
         protocol: 'openid4vp',
         response: {token: 'abc'},
       };
       assert.isTrue(
         mockCdpClient1.sendCommand.calledWith(
           'DigitalCredentials.setVirtualWalletBehavior',
-          expectedCdpParams,
+          {...expectedCdpParams, frameId: 'context_1'},
+        ),
+      );
+      assert.isTrue(
+        mockCdpClient2.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {...expectedCdpParams, frameId: 'context_2'},
         ),
       );
 
@@ -295,6 +326,9 @@ describe('DigitalCredentialsProcessor', () => {
         cdpTarget: mockTarget,
       } as unknown as BrowsingContextImpl;
 
+      browsingContextStorage.findContext
+        .withArgs('context_1')
+        .returns(mockContext);
       browsingContextStorage.getAllContexts.returns([mockContext]);
 
       await processor.setVirtualWalletBehavior({
@@ -313,9 +347,9 @@ describe('DigitalCredentialsProcessor', () => {
           'DigitalCredentials.setVirtualWalletBehavior',
           {
             action: DigitalCredentials.VirtualWalletAction.Clear,
-            behavior: DigitalCredentials.VirtualWalletAction.Clear,
             protocol: undefined,
             response: undefined,
+            frameId: 'context_1',
           },
         ),
       );
@@ -324,7 +358,7 @@ describe('DigitalCredentialsProcessor', () => {
       assert.isUndefined(config.digitalCredentialsBehavior);
     });
 
-    it('should not inherit behavior from parent context if on different targets', async () => {
+    it('should not inherit behavior from parent context', async () => {
       const mockCdpClient1 = {sendCommand: sinon.stub().resolves({})};
       const mockCdpClient2 = {sendCommand: sinon.stub().resolves({})};
       const mockTarget1 = {
@@ -344,12 +378,14 @@ describe('DigitalCredentialsProcessor', () => {
         id: 'parent_id',
         parentId: null,
         cdpTarget: mockTarget1,
+        userContext: 'default',
       } as unknown as BrowsingContextImpl;
 
       const childContext = {
         id: 'child_id',
         parentId: 'parent_id',
         cdpTarget: mockTarget2,
+        userContext: 'default',
       } as unknown as BrowsingContextImpl;
 
       browsingContextStorage.getContext
@@ -358,6 +394,12 @@ describe('DigitalCredentialsProcessor', () => {
       browsingContextStorage.getContext
         .withArgs('child_id')
         .returns(childContext);
+      browsingContextStorage.findContext
+        .withArgs('child_id')
+        .returns(childContext);
+      browsingContextStorage.findContext
+        .withArgs('parent_id')
+        .returns(parentContext);
 
       browsingContextStorage.getAllContexts.returns([
         parentContext,
@@ -370,9 +412,30 @@ describe('DigitalCredentialsProcessor', () => {
       });
 
       assert.isTrue(mockCdpClient1.sendCommand.calledOnce);
-      // child_id has different target, and even though it is child of parent_id,
-      // #applyBehaviorToTarget should reject it because target.id !== target.topLevelId
-      assert.isFalse(mockCdpClient2.sendCommand.called);
+      assert.isTrue(
+        mockCdpClient1.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {
+            action: DigitalCredentials.VirtualWalletAction.Decline,
+            protocol: undefined,
+            response: undefined,
+            frameId: 'parent_id',
+          },
+        ),
+      );
+
+      assert.isTrue(mockCdpClient2.sendCommand.calledOnce);
+      assert.isTrue(
+        mockCdpClient2.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {
+            action: DigitalCredentials.VirtualWalletAction.Clear,
+            protocol: undefined,
+            response: undefined,
+            frameId: 'child_id',
+          },
+        ),
+      );
     });
   });
 });

--- a/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.ts
+++ b/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.ts
@@ -17,13 +17,13 @@
 
 import {
   InvalidArgumentException,
-  UnsupportedOperationException,
   type EmptyResult,
   DigitalCredentials,
 } from '../../../protocol/protocol.js';
 import type {ContextConfigStorage} from '../browser/ContextConfigStorage.js';
 import type {CdpTarget} from '../cdp/CdpTarget.js';
 import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
+import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
 
 type Behavior = Omit<
   DigitalCredentials.SetVirtualWalletBehaviorParameters,
@@ -72,12 +72,6 @@ export class DigitalCredentialsProcessor {
         });
       }
     } else {
-      const browsingContext = this.#browsingContextStorage.getContext(context);
-      if (browsingContext.parentId !== null) {
-        throw new UnsupportedOperationException(
-          'Only top-level contexts are supported',
-        );
-      }
       if (action === DigitalCredentials.VirtualWalletAction.Clear) {
         this.#contextConfigStorage.updateBrowsingContextConfig(context, {
           digitalCredentialsBehavior: null,
@@ -89,54 +83,66 @@ export class DigitalCredentialsProcessor {
       }
     }
 
-    await this.#applyToAllTargets();
+    await this.#applyBehavior();
 
     return {};
   }
 
-  async #applyToAllTargets() {
+  #resolveBehavior(contextId: string): Behavior | null | undefined {
+    const config =
+      this.#contextConfigStorage.getBrowsingContextConfig(contextId);
+    if (config?.digitalCredentialsBehavior !== undefined) {
+      return config.digitalCredentialsBehavior;
+    }
+
+    const context = this.#browsingContextStorage.findContext(contextId);
+    if (context) {
+      const userContextConfig = this.#contextConfigStorage.getUserContextConfig(
+        context.userContext,
+      );
+      if (userContextConfig?.digitalCredentialsBehavior !== undefined) {
+        return userContextConfig.digitalCredentialsBehavior;
+      }
+    }
+
+    const globalConfig = this.#contextConfigStorage.getGlobalConfig();
+    return globalConfig.digitalCredentialsBehavior;
+  }
+
+  async #applyBehavior() {
     const contexts = this.#browsingContextStorage.getAllContexts();
-    const targets = new Set<CdpTarget>();
-    for (const c of contexts) {
-      targets.add(c.cdpTarget);
-    }
-
     await Promise.all(
-      Array.from(targets).map((target) => this.#applyBehaviorToTarget(target)),
+      contexts.map((context) => this.#applyBehaviorToContext(context)),
     );
   }
 
-  async #applyBehaviorToTarget(target: CdpTarget) {
-    if (target.id !== target.topLevelId) {
-      return;
-    }
-    const config = this.#contextConfigStorage.getActiveConfig(
-      target.topLevelId,
-      target.userContext,
-    );
-
-    const behavior = config.digitalCredentialsBehavior;
-
-    if (behavior === null || behavior === undefined) {
-      await this.#sendCdpCommand(target, {
-        action: DigitalCredentials.VirtualWalletAction.Clear,
-      });
-      return;
-    }
-
-    await this.#sendCdpCommand(target, behavior);
+  async #applyBehaviorToContext(context: BrowsingContextImpl) {
+    const behavior = this.#resolveBehavior(context.id);
+    await this.#sendCdpCommand(context.cdpTarget, context.id, behavior);
   }
 
-  async #sendCdpCommand(cdpTarget: CdpTarget, behavior: Behavior) {
-    await cdpTarget.cdpClient.sendCommand(
-      'DigitalCredentials.setVirtualWalletBehavior',
-      {
-        // @ts-expect-error action is kept for backward compatibility with older Chromium CDP versions
-        action: behavior.action,
-        behavior: behavior.action,
-        protocol: behavior.protocol,
-        response: behavior.response,
-      },
-    );
+  async #sendCdpCommand(
+    cdpTarget: CdpTarget,
+    frameId: string,
+    behavior: Behavior | null | undefined,
+  ) {
+    const action =
+      behavior?.action ?? DigitalCredentials.VirtualWalletAction.Clear;
+    const protocol = behavior?.protocol;
+    const response = behavior?.response;
+
+    try {
+      await cdpTarget.cdpClient.sendCommand(
+        'DigitalCredentials.setVirtualWalletBehavior',
+        {
+          action,
+          protocol,
+          response,
+          frameId,
+        },
+      );
+    } catch {
+      // Ignore errors if the target is closed or command not supported
+    }
   }
 }

--- a/tests/digital_credentials/test_virtual_wallet.py
+++ b/tests/digital_credentials/test_virtual_wallet.py
@@ -16,7 +16,7 @@
 import json
 
 import pytest
-from test_helpers import execute_command, goto_url
+from test_helpers import execute_command, get_tree, goto_url
 
 # The Digital Credentials API options used in the tests.
 CREDENTIAL_OPTIONS = """{
@@ -124,3 +124,142 @@ async def test_digital_credentials_respond(websocket, context_id, url_secure_con
     result = await trigger_credentials_get(websocket, context_id)
     assert result["status"] == "success"
     assert "mock_token_123" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_digital_credentials_iframe_decline(
+    websocket, context_id, local_server_good_ssl
+):
+    # Set up same-origin iframe
+    iframe_url = local_server_good_ssl.url_200(content="<h1>Iframe</h1>")
+    iframe_tag = f'<iframe allow="identity-credentials-get" src="{iframe_url}" />'
+    main_url = local_server_good_ssl.url_200(content=f"<h1>Main</h1>{iframe_tag}")
+
+    await goto_url(websocket, context_id, main_url)
+
+    # Get iframe context ID
+    tree = await get_tree(websocket, context_id)
+    iframe_id = tree["contexts"][0]["children"][0]["context"]
+
+    # Set behavior to decline on iframe
+    resp = await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": iframe_id,
+                "action": "decline",
+            },
+        },
+    )
+    assert resp == {}
+
+    # Trigger request in iframe and verify it is declined
+    result = await trigger_credentials_get(websocket, iframe_id)
+    assert result["status"] == "error"
+    assert result["name"] == "NotAllowedError"
+
+
+@pytest.mark.asyncio
+async def test_digital_credentials_iframe_no_inheritance(
+    websocket, context_id, local_server_good_ssl
+):
+    # Set up same-origin iframe
+    iframe_url = local_server_good_ssl.url_200(content="<h1>Iframe</h1>")
+    iframe_tag = f'<iframe allow="identity-credentials-get" src="{iframe_url}" />'
+    main_url = local_server_good_ssl.url_200(content=f"<h1>Main</h1>{iframe_tag}")
+
+    await goto_url(websocket, context_id, main_url)
+
+    # Get iframe context ID
+    tree = await get_tree(websocket, context_id)
+    iframe_id = tree["contexts"][0]["children"][0]["context"]
+
+    # Set behavior globally to respond with global_token
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "action": "respond",
+                "protocol": "openid4vp",
+                "response": {"token": "global_token"},
+            },
+        },
+    )
+
+    # Set behavior on main frame to respond with main_token
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": context_id,
+                "action": "respond",
+                "protocol": "openid4vp",
+                "response": {"token": "main_token"},
+            },
+        },
+    )
+
+    # Trigger request in iframe and verify it gets global_token (no inheritance from main)
+    result = await trigger_credentials_get(websocket, iframe_id)
+    assert result["status"] == "success"
+    assert "global_token" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_digital_credentials_iframe_override(
+    websocket, context_id, local_server_good_ssl
+):
+    # Set up same-origin iframe
+    iframe_url = local_server_good_ssl.url_200(content="<h1>Iframe</h1>")
+    iframe_tag = f'<iframe allow="identity-credentials-get" src="{iframe_url}" />'
+    main_url = local_server_good_ssl.url_200(content=f"<h1>Main</h1>{iframe_tag}")
+
+    await goto_url(websocket, context_id, main_url)
+
+    # Get iframe context ID
+    tree = await get_tree(websocket, context_id)
+    iframe_id = tree["contexts"][0]["children"][0]["context"]
+
+    # Set behavior to decline on main frame
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": context_id,
+                "action": "decline",
+            },
+        },
+    )
+
+    # Set behavior to respond on iframe
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": iframe_id,
+                "action": "respond",
+                "protocol": "openid4vp",
+                "response": {"token": "iframe_token"},
+            },
+        },
+    )
+
+    # Trigger request in main frame and verify it is declined (before iframe request)
+    result_main = await trigger_credentials_get(websocket, context_id)
+    assert result_main["status"] == "error"
+    assert result_main["name"] == "NotAllowedError"
+
+    # Trigger request in iframe and verify it succeeds with iframe's token (override)
+    result = await trigger_credentials_get(websocket, iframe_id)
+    assert result["status"] == "success"
+    assert "iframe_token" in str(result)
+
+    # Trigger request in main frame and verify it is still declined
+    result_main_2 = await trigger_credentials_get(websocket, context_id)
+    assert result_main_2["status"] == "error"
+    assert result_main_2["name"] == "NotAllowedError"


### PR DESCRIPTION
…ls.setVirtualWalletBehavior

This CL expands support for digitalCredentials.setVirtualWalletBehavior to accept non-top-level contexts (subframes).

If a subframe does not have an explicitly configured virtual wallet behavior, it falls back to the global configuration (or user context configuration), rather than inheriting from its parent context. This is achieved by explicitly sending the resolved behavior (which defaults to 'clear') to the subframe via CDP to override Chromium's internal parent-inheritance behavior.

Updates `devtools-protocol` dependency to `0.0.1658499` to get updated CDP typings that support `action` and `frameId` in `DigitalCredentials.setVirtualWalletBehavior`. Cleans up the code by removing the legacy `behavior` parameter and associated `@ts-expect-error` comments.

TAG=agy
CONV=ce3d0ebd-0f95-4b7d-ab74-fc357eac15ed