### PR TITLE
feat(digital-credentials): support non-top-level contexts in setVirtualWalletBehavior

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -56,10 +56,10 @@ deps = {
     'bucket': 'chromium-nodejs',
     'objects': [
       {
-        'object_name': 'chromium-bidi/888cf5993c20a0758494796bc4931b2fa85d7ac32f81095cbc02108a3ecdc453',
-        'sha256sum': '888cf5993c20a0758494796bc4931b2fa85d7ac32f81095cbc02108a3ecdc453',
-        'size_bytes': 17602252,
-        'generation': 1783417539972035,
+        'object_name': 'chromium-bidi/7c104177eca374d34b95c558bc7bbbc60f95627ab1d02d6da8b013b4af6f27b8',
+        'sha256sum': '7c104177eca374d34b95c558bc7bbbc60f95627ab1d02d6da8b013b4af6f27b8',
+        'size_bytes': 18765168,
+        'generation': 1784278936764883,
         'output_file': 'node_modules.tar.gz',
       },
     ],

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,6 +11,7 @@ This file provides context for the Gemini AI code assistant.
 ## Git Workflow
 
 - Do not commit, pull, or push unless explicitly asked.
+- Always run `npm run format` (or `npm run format:prettier` if global tools like `keep-sorted` are missing) before committing to ensure all modified files (including documentation) are correctly formatted.
 
 ## Common Commands
 
@@ -92,3 +93,21 @@ WebDriver BiDi CDDL. Run the following steps to fix it:
 5.  **Run `npm run build` and `npm run format`** to verify the fix.
 6.  **Do not commit the changes.**
 7.  **Do not run e2e tests for this kind of fixes.**
+
+## Dependency Updates (node_modules & GCS)
+
+The project manages `node_modules` using `gclient` with archives stored in a GCS bucket (`chromium-nodejs`). Whenever you update dependencies (resulting in changes to `package.json` or `package-lock.json`):
+
+1.  Run `npm install` to update `package-lock.json` locally.
+2.  Run `tools/update_node_modules.mjs --force` to filter, upload the updated `node_modules` to GCS, and automatically update the `DEPS` file.
+3.  Commit both the dependency files (`package.json`, `package-lock.json`) and the updated `DEPS` file in your PR.
+4.  Run `./third_party/depot_tools/gclient sync` (adding `depot_tools` to your `PATH` if necessary) to ensure your local environment is synchronized.
+
+## Architecture & CDP Configuration
+
+To prevent race conditions where page scripts execute before target-level configurations are applied:
+
+- **Target Initialization:** Always apply initial target configurations (e.g., emulation overrides, setting virtual wallet behaviors) inside `CdpTarget.#unblock` (specifically within `#setUserContextConfig` or similar helper methods).
+- **Timing:** These configurations must be sent to the browser _before_ the `Runtime.runIfWaitingForDebugger` command is executed to ensure they are active when the page starts running.
+- **Avoid Async Post-Unblock Setup:** Do not apply initial target-wide configurations asynchronously in `BrowsingContextImpl` after `targetUnblockedOrThrow()` resolves, as this occurs after the target has already been resumed.
+- **Same-Process Subframes:** For same-process subframes (which do not trigger a new target unblocking), apply configurations immediately upon context creation in `BrowsingContextImpl.create` to set them as early as possible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/sinon": "21.0.1",
         "@types/websocket": "1.0.10",
         "chai": "6.2.2",
-        "devtools-protocol": "0.0.1655900",
+        "devtools-protocol": "0.0.1662358",
         "eslint": "10.5.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-import-resolver-typescript": "4.4.5",
@@ -1956,9 +1956,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1655900",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1655900.tgz",
-      "integrity": "sha512-mgjlBJ7tTnTcIAks1HQKvd1XBRiZPzHd/HOW8MUr7XqsfZWtrBFdRG4XOM9wnrZ2bx6OLGWkbD6y5whjh36GgQ==",
+      "version": "0.0.1662358",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1662358.tgz",
+      "integrity": "sha512-2QEjq2DqI9JjRYImbJmhdpzcoibPEfpcv7sydS9S05KJurVudhyBYTVdXJZrHE45B1doI/xJbRP2JJ4Is/AhNw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },

--- a/src/bidiMapper/modules/cdp/CdpTarget.ts
+++ b/src/bidiMapper/modules/cdp/CdpTarget.ts
@@ -23,6 +23,7 @@ import {
   type Browser,
   type BrowsingContext,
   type ChromiumBidi,
+  DigitalCredentials,
   Emulation,
   Session,
   type UAClientHints,
@@ -719,22 +720,27 @@ export class CdpTarget {
       promises.push(this.setTouchOverride(config.maxTouchPoints));
     }
 
-    if (config.digitalCredentialsBehavior && this.id === this.topLevelId) {
-      promises.push(
-        this.cdpClient
-          .sendCommand('DigitalCredentials.setVirtualWalletBehavior', {
-            // @ts-expect-error action is kept for backward compatibility with older Chromium CDP versions
-            action: config.digitalCredentialsBehavior.action,
-            behavior: config.digitalCredentialsBehavior.action,
-            protocol: config.digitalCredentialsBehavior.protocol,
-            response: config.digitalCredentialsBehavior.response,
-          })
-          .catch(() => {
-            // Ignore CDP errors, as the command is not supported by iframe targets
-            // or older browser versions.
-          }),
-      );
-    }
+    const dcConfig = this.contextConfigStorage.getActiveConfig(
+      this.id,
+      this.userContext,
+    );
+    const dcBehavior = dcConfig.digitalCredentialsBehavior;
+    promises.push(
+      this.cdpClient
+        .sendCommand('DigitalCredentials.setVirtualWalletBehavior', {
+          action:
+            dcBehavior?.action ?? DigitalCredentials.VirtualWalletAction.Clear,
+          protocol: dcBehavior?.protocol,
+          response: dcBehavior?.response,
+          frameId: this.id,
+        })
+        .catch((error) => {
+          this.#logger?.(LogType.debugError)?.(
+            'Error setting virtual wallet behavior',
+            error,
+          );
+        }),
+    );
 
     await Promise.all(promises);
   }

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -20,6 +20,7 @@ import type {Protocol} from 'devtools-protocol';
 import {
   BrowsingContext,
   ChromiumBidi,
+  DigitalCredentials,
   type Emulation,
   InvalidArgumentException,
   InvalidSelectorException,
@@ -55,6 +56,11 @@ import {
   type NavigationState,
   NavigationTracker,
 } from './NavigationTracker.js';
+
+type DigitalCredentialsBehavior = Omit<
+  DigitalCredentials.SetVirtualWalletBehaviorParameters,
+  'context'
+>;
 
 export class BrowsingContextImpl {
   static readonly LOGGER_PREFIX = `${LogType.debug}:browsingContext` as const;
@@ -160,6 +166,9 @@ export class BrowsingContextImpl {
     browsingContextStorage.addContext(context);
     if (!context.isTopLevelContext()) {
       context.parent!.addChild(context.id);
+      if (context.cdpTarget === context.parent!.cdpTarget) {
+        void context.applyDigitalCredentialsBehavior();
+      }
     }
 
     // Hold on the `contextCreated` event until the target is unblocked. This is required,
@@ -339,6 +348,39 @@ export class BrowsingContextImpl {
     if (result.kind === 'error') {
       throw result.error;
     }
+  }
+
+  async applyDigitalCredentialsBehavior() {
+    const behavior = this.#resolveDigitalCredentialsBehavior();
+    const action =
+      behavior?.action ?? DigitalCredentials.VirtualWalletAction.Clear;
+    const protocol = behavior?.protocol;
+    const response = behavior?.response;
+
+    try {
+      await this.cdpTarget.cdpClient.sendCommand(
+        'DigitalCredentials.setVirtualWalletBehavior',
+        {
+          action,
+          protocol,
+          response,
+          frameId: this.id,
+        },
+      );
+    } catch {
+      // Ignore
+    }
+  }
+
+  #resolveDigitalCredentialsBehavior():
+    | DigitalCredentialsBehavior
+    | null
+    | undefined {
+    const config = this.#configStorage.getActiveConfig(
+      this.id,
+      this.userContext,
+    );
+    return config.digitalCredentialsBehavior;
   }
 
   /** Returns a sandbox for internal helper scripts which is not exposed to the user.*/

--- a/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.test.ts
+++ b/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.test.ts
@@ -22,7 +22,6 @@ import sinon from 'sinon';
 import {
   DigitalCredentials,
   InvalidArgumentException,
-  UnsupportedOperationException,
 } from '../../../protocol/protocol.js';
 import type {CdpTarget} from '../cdp/CdpTarget.js';
 import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
@@ -162,6 +161,9 @@ describe('DigitalCredentialsProcessor', () => {
       browsingContextStorage.getContext
         .withArgs('context_id')
         .returns(mockContext);
+      browsingContextStorage.findContext
+        .withArgs('context_id')
+        .returns(mockContext);
       browsingContextStorage.getAllContexts.returns([mockContext]);
 
       await processor.setVirtualWalletBehavior({
@@ -175,9 +177,9 @@ describe('DigitalCredentialsProcessor', () => {
           'DigitalCredentials.setVirtualWalletBehavior',
           {
             action: DigitalCredentials.VirtualWalletAction.Decline,
-            behavior: DigitalCredentials.VirtualWalletAction.Decline,
             protocol: undefined,
             response: undefined,
+            frameId: 'context_id',
           },
         ),
       );
@@ -193,29 +195,47 @@ describe('DigitalCredentialsProcessor', () => {
       });
     });
 
-    it('should throw UnsupportedOperationException if context is not top-level', async () => {
+    it('should allow configuring behavior for subframe contexts', async () => {
+      const mockCdpClient = {
+        sendCommand: sinon.stub().resolves({}),
+      };
+      const mockTarget = {
+        cdpClient: mockCdpClient,
+        id: 'child_context_id',
+        topLevelId: 'parent_context_id',
+        userContext: 'default',
+      } as unknown as CdpTarget;
       const mockContext = {
         id: 'child_context_id',
         parentId: 'parent_context_id',
+        cdpTarget: mockTarget,
       } as unknown as BrowsingContextImpl;
 
       browsingContextStorage.getContext
         .withArgs('child_context_id')
         .returns(mockContext);
+      browsingContextStorage.findContext
+        .withArgs('child_context_id')
+        .returns(mockContext);
+      browsingContextStorage.getAllContexts.returns([mockContext]);
 
-      try {
-        await processor.setVirtualWalletBehavior({
-          context: 'child_context_id',
-          action: DigitalCredentials.VirtualWalletAction.Decline,
-        });
-        assert.fail('Expected UnsupportedOperationException to be thrown');
-      } catch (error) {
-        assert.instanceOf(error, UnsupportedOperationException);
-        assert.strictEqual(
-          (error as Error).message,
-          'Only top-level contexts are supported',
-        );
-      }
+      await processor.setVirtualWalletBehavior({
+        context: 'child_context_id',
+        action: DigitalCredentials.VirtualWalletAction.Decline,
+      });
+
+      assert.isTrue(mockCdpClient.sendCommand.calledOnce);
+      assert.isTrue(
+        mockCdpClient.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {
+            action: DigitalCredentials.VirtualWalletAction.Decline,
+            protocol: undefined,
+            response: undefined,
+            frameId: 'child_context_id',
+          },
+        ),
+      );
     });
   });
 
@@ -246,6 +266,12 @@ describe('DigitalCredentialsProcessor', () => {
         cdpTarget: mockTarget2,
       } as unknown as BrowsingContextImpl;
 
+      browsingContextStorage.findContext
+        .withArgs('context_1')
+        .returns(mockContext1);
+      browsingContextStorage.findContext
+        .withArgs('context_2')
+        .returns(mockContext2);
       browsingContextStorage.getAllContexts.returns([
         mockContext1,
         mockContext2,
@@ -262,14 +288,19 @@ describe('DigitalCredentialsProcessor', () => {
 
       const expectedCdpParams = {
         action: DigitalCredentials.VirtualWalletAction.Respond,
-        behavior: DigitalCredentials.VirtualWalletAction.Respond,
         protocol: 'openid4vp',
         response: {token: 'abc'},
       };
       assert.isTrue(
         mockCdpClient1.sendCommand.calledWith(
           'DigitalCredentials.setVirtualWalletBehavior',
-          expectedCdpParams,
+          {...expectedCdpParams, frameId: 'context_1'},
+        ),
+      );
+      assert.isTrue(
+        mockCdpClient2.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {...expectedCdpParams, frameId: 'context_2'},
         ),
       );
 
@@ -295,6 +326,9 @@ describe('DigitalCredentialsProcessor', () => {
         cdpTarget: mockTarget,
       } as unknown as BrowsingContextImpl;
 
+      browsingContextStorage.findContext
+        .withArgs('context_1')
+        .returns(mockContext);
       browsingContextStorage.getAllContexts.returns([mockContext]);
 
       await processor.setVirtualWalletBehavior({
@@ -313,9 +347,9 @@ describe('DigitalCredentialsProcessor', () => {
           'DigitalCredentials.setVirtualWalletBehavior',
           {
             action: DigitalCredentials.VirtualWalletAction.Clear,
-            behavior: DigitalCredentials.VirtualWalletAction.Clear,
             protocol: undefined,
             response: undefined,
+            frameId: 'context_1',
           },
         ),
       );
@@ -324,7 +358,7 @@ describe('DigitalCredentialsProcessor', () => {
       assert.isUndefined(config.digitalCredentialsBehavior);
     });
 
-    it('should not inherit behavior from parent context if on different targets', async () => {
+    it('should not inherit behavior from parent context', async () => {
       const mockCdpClient1 = {sendCommand: sinon.stub().resolves({})};
       const mockCdpClient2 = {sendCommand: sinon.stub().resolves({})};
       const mockTarget1 = {
@@ -344,12 +378,14 @@ describe('DigitalCredentialsProcessor', () => {
         id: 'parent_id',
         parentId: null,
         cdpTarget: mockTarget1,
+        userContext: 'default',
       } as unknown as BrowsingContextImpl;
 
       const childContext = {
         id: 'child_id',
         parentId: 'parent_id',
         cdpTarget: mockTarget2,
+        userContext: 'default',
       } as unknown as BrowsingContextImpl;
 
       browsingContextStorage.getContext
@@ -358,6 +394,12 @@ describe('DigitalCredentialsProcessor', () => {
       browsingContextStorage.getContext
         .withArgs('child_id')
         .returns(childContext);
+      browsingContextStorage.findContext
+        .withArgs('child_id')
+        .returns(childContext);
+      browsingContextStorage.findContext
+        .withArgs('parent_id')
+        .returns(parentContext);
 
       browsingContextStorage.getAllContexts.returns([
         parentContext,
@@ -370,9 +412,30 @@ describe('DigitalCredentialsProcessor', () => {
       });
 
       assert.isTrue(mockCdpClient1.sendCommand.calledOnce);
-      // child_id has different target, and even though it is child of parent_id,
-      // #applyBehaviorToTarget should reject it because target.id !== target.topLevelId
-      assert.isFalse(mockCdpClient2.sendCommand.called);
+      assert.isTrue(
+        mockCdpClient1.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {
+            action: DigitalCredentials.VirtualWalletAction.Decline,
+            protocol: undefined,
+            response: undefined,
+            frameId: 'parent_id',
+          },
+        ),
+      );
+
+      assert.isTrue(mockCdpClient2.sendCommand.calledOnce);
+      assert.isTrue(
+        mockCdpClient2.sendCommand.calledWith(
+          'DigitalCredentials.setVirtualWalletBehavior',
+          {
+            action: DigitalCredentials.VirtualWalletAction.Clear,
+            protocol: undefined,
+            response: undefined,
+            frameId: 'child_id',
+          },
+        ),
+      );
     });
   });
 });

--- a/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.ts
+++ b/src/bidiMapper/modules/digitalCredentials/DigitalCredentialsProcessor.ts
@@ -17,13 +17,13 @@
 
 import {
   InvalidArgumentException,
-  UnsupportedOperationException,
   type EmptyResult,
   DigitalCredentials,
 } from '../../../protocol/protocol.js';
 import type {ContextConfigStorage} from '../browser/ContextConfigStorage.js';
 import type {CdpTarget} from '../cdp/CdpTarget.js';
 import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
+import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
 
 type Behavior = Omit<
   DigitalCredentials.SetVirtualWalletBehaviorParameters,
@@ -72,12 +72,6 @@ export class DigitalCredentialsProcessor {
         });
       }
     } else {
-      const browsingContext = this.#browsingContextStorage.getContext(context);
-      if (browsingContext.parentId !== null) {
-        throw new UnsupportedOperationException(
-          'Only top-level contexts are supported',
-        );
-      }
       if (action === DigitalCredentials.VirtualWalletAction.Clear) {
         this.#contextConfigStorage.updateBrowsingContextConfig(context, {
           digitalCredentialsBehavior: null,
@@ -89,54 +83,55 @@ export class DigitalCredentialsProcessor {
       }
     }
 
-    await this.#applyToAllTargets();
+    await this.#applyBehavior();
 
     return {};
   }
 
-  async #applyToAllTargets() {
-    const contexts = this.#browsingContextStorage.getAllContexts();
-    const targets = new Set<CdpTarget>();
-    for (const c of contexts) {
-      targets.add(c.cdpTarget);
-    }
-
-    await Promise.all(
-      Array.from(targets).map((target) => this.#applyBehaviorToTarget(target)),
-    );
-  }
-
-  async #applyBehaviorToTarget(target: CdpTarget) {
-    if (target.id !== target.topLevelId) {
-      return;
-    }
+  #resolveBehavior(contextId: string): Behavior | null | undefined {
+    const context = this.#browsingContextStorage.findContext(contextId);
+    const userContext = context?.userContext ?? 'default';
     const config = this.#contextConfigStorage.getActiveConfig(
-      target.topLevelId,
-      target.userContext,
+      contextId,
+      userContext,
     );
-
-    const behavior = config.digitalCredentialsBehavior;
-
-    if (behavior === null || behavior === undefined) {
-      await this.#sendCdpCommand(target, {
-        action: DigitalCredentials.VirtualWalletAction.Clear,
-      });
-      return;
-    }
-
-    await this.#sendCdpCommand(target, behavior);
+    return config.digitalCredentialsBehavior;
   }
 
-  async #sendCdpCommand(cdpTarget: CdpTarget, behavior: Behavior) {
-    await cdpTarget.cdpClient.sendCommand(
-      'DigitalCredentials.setVirtualWalletBehavior',
-      {
-        // @ts-expect-error action is kept for backward compatibility with older Chromium CDP versions
-        action: behavior.action,
-        behavior: behavior.action,
-        protocol: behavior.protocol,
-        response: behavior.response,
-      },
+  async #applyBehavior() {
+    const contexts = this.#browsingContextStorage.getAllContexts();
+    await Promise.all(
+      contexts.map((context) => this.#applyBehaviorToContext(context)),
     );
+  }
+
+  async #applyBehaviorToContext(context: BrowsingContextImpl) {
+    const behavior = this.#resolveBehavior(context.id);
+    await this.#sendCdpCommand(context.cdpTarget, context.id, behavior);
+  }
+
+  async #sendCdpCommand(
+    cdpTarget: CdpTarget,
+    frameId: string,
+    behavior: Behavior | null | undefined,
+  ) {
+    const action =
+      behavior?.action ?? DigitalCredentials.VirtualWalletAction.Clear;
+    const protocol = behavior?.protocol;
+    const response = behavior?.response;
+
+    try {
+      await cdpTarget.cdpClient.sendCommand(
+        'DigitalCredentials.setVirtualWalletBehavior',
+        {
+          action,
+          protocol,
+          response,
+          frameId,
+        },
+      );
+    } catch {
+      // Ignore errors if the target is closed or command not supported
+    }
   }
 }

--- a/tests/digital_credentials/test_virtual_wallet.py
+++ b/tests/digital_credentials/test_virtual_wallet.py
@@ -16,7 +16,7 @@
 import json
 
 import pytest
-from test_helpers import execute_command, goto_url
+from test_helpers import execute_command, get_tree, goto_url
 
 # The Digital Credentials API options used in the tests.
 CREDENTIAL_OPTIONS = """{
@@ -124,3 +124,142 @@ async def test_digital_credentials_respond(websocket, context_id, url_secure_con
     result = await trigger_credentials_get(websocket, context_id)
     assert result["status"] == "success"
     assert "mock_token_123" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_digital_credentials_iframe_decline(
+    websocket, context_id, local_server_good_ssl
+):
+    # Set up same-origin iframe
+    iframe_url = local_server_good_ssl.url_200(content="<h1>Iframe</h1>")
+    iframe_tag = f'<iframe allow="identity-credentials-get" src="{iframe_url}" />'
+    main_url = local_server_good_ssl.url_200(content=f"<h1>Main</h1>{iframe_tag}")
+
+    await goto_url(websocket, context_id, main_url)
+
+    # Get iframe context ID
+    tree = await get_tree(websocket, context_id)
+    iframe_id = tree["contexts"][0]["children"][0]["context"]
+
+    # Set behavior to decline on iframe
+    resp = await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": iframe_id,
+                "action": "decline",
+            },
+        },
+    )
+    assert resp == {}
+
+    # Trigger request in iframe and verify it is declined
+    result = await trigger_credentials_get(websocket, iframe_id)
+    assert result["status"] == "error"
+    assert result["name"] == "NotAllowedError"
+
+
+@pytest.mark.asyncio
+async def test_digital_credentials_iframe_no_inheritance(
+    websocket, context_id, local_server_good_ssl
+):
+    # Set up same-origin iframe
+    iframe_url = local_server_good_ssl.url_200(content="<h1>Iframe</h1>")
+    iframe_tag = f'<iframe allow="identity-credentials-get" src="{iframe_url}" />'
+    main_url = local_server_good_ssl.url_200(content=f"<h1>Main</h1>{iframe_tag}")
+
+    await goto_url(websocket, context_id, main_url)
+
+    # Get iframe context ID
+    tree = await get_tree(websocket, context_id)
+    iframe_id = tree["contexts"][0]["children"][0]["context"]
+
+    # Set behavior globally to respond with global_token
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "action": "respond",
+                "protocol": "openid4vp",
+                "response": {"token": "global_token"},
+            },
+        },
+    )
+
+    # Set behavior on main frame to respond with main_token
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": context_id,
+                "action": "respond",
+                "protocol": "openid4vp",
+                "response": {"token": "main_token"},
+            },
+        },
+    )
+
+    # Trigger request in iframe and verify it gets global_token (no inheritance from main)
+    result = await trigger_credentials_get(websocket, iframe_id)
+    assert result["status"] == "success"
+    assert "global_token" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_digital_credentials_iframe_override(
+    websocket, context_id, local_server_good_ssl
+):
+    # Set up same-origin iframe
+    iframe_url = local_server_good_ssl.url_200(content="<h1>Iframe</h1>")
+    iframe_tag = f'<iframe allow="identity-credentials-get" src="{iframe_url}" />'
+    main_url = local_server_good_ssl.url_200(content=f"<h1>Main</h1>{iframe_tag}")
+
+    await goto_url(websocket, context_id, main_url)
+
+    # Get iframe context ID
+    tree = await get_tree(websocket, context_id)
+    iframe_id = tree["contexts"][0]["children"][0]["context"]
+
+    # Set behavior to decline on main frame
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": context_id,
+                "action": "decline",
+            },
+        },
+    )
+
+    # Set behavior to respond on iframe
+    await execute_command(
+        websocket,
+        {
+            "method": "digitalCredentials.setVirtualWalletBehavior",
+            "params": {
+                "context": iframe_id,
+                "action": "respond",
+                "protocol": "openid4vp",
+                "response": {"token": "iframe_token"},
+            },
+        },
+    )
+
+    # Trigger request in main frame and verify it is declined (before iframe request)
+    result_main = await trigger_credentials_get(websocket, context_id)
+    assert result_main["status"] == "error"
+    assert result_main["name"] == "NotAllowedError"
+
+    # Trigger request in iframe and verify it succeeds with iframe's token (override)
+    result = await trigger_credentials_get(websocket, iframe_id)
+    assert result["status"] == "success"
+    assert "iframe_token" in str(result)
+
+    # Trigger request in main frame and verify it is still declined
+    result_main_2 = await trigger_credentials_get(websocket, context_id)
+    assert result_main_2["status"] == "error"
+    assert result_main_2["name"] == "NotAllowedError"


### PR DESCRIPTION
This CL expands support for digitalCredentials.setVirtualWalletBehavior
to accept non-top-level contexts (subframes).

If a subframe does not have an explicitly configured virtual wallet behavior,
it falls back to the global configuration (or user context configuration),
rather than inheriting from its parent context. This is achieved by explicitly
sending the resolved behavior (which defaults to 'clear') to the subframe via
CDP to override Chromium's internal parent-inheritance behavior.

TAG=agy
CONV=ce3d0ebd-0f95-4b7d-ab74-fc357eac15ed
