### PR TITLE
[EXPERIMENTAL] feat: implement WebDriver Classic logic in Mapper

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -87,6 +87,8 @@ bidi_foundation_module("bidi_mapper") {
     "bidiMapper/BidiParser.ts",
     "bidiMapper/BidiServer.ts",
     "bidiMapper/BidiTransport.ts",
+    "bidiMapper/ClassicCommandProcessor.ts",
+    "bidiMapper/ClassicTransport.ts",
     "bidiMapper/CommandProcessor.ts",
     "bidiMapper/MapperOptions.ts",
     "bidiMapper/OutgoingMessage.ts",
@@ -185,6 +187,7 @@ ts_library("unit_tests") {
     "es2023",
   ]
   sources = [
+    "bidiMapper/ClassicCommandProcessor.test.ts",
     "bidiMapper/modules/browser/BrowserProcessot.test.ts",
     "bidiMapper/modules/browser/ContextConfigStorage.test.ts",
     "bidiMapper/modules/context/BrowsingContextStorage.test.ts",
@@ -200,6 +203,7 @@ ts_library("unit_tests") {
     "bidiMapper/modules/script/SharedId.test.ts",
     "bidiMapper/modules/session/SubscriptionManager.test.ts",
     "bidiMapper/modules/session/events.test.ts",
+    "bidiTab/Transport.test.ts",
     "cdp/CdpClient.test.ts",
     "cdp/CdpConnection.test.ts",
     "protocol/ErrorResponse.test.ts",

--- a/src/bidiMapper/BidiMapper.ts
+++ b/src/bidiMapper/BidiMapper.ts
@@ -28,3 +28,9 @@ export {EventEmitter} from '../utils/EventEmitter.js';
 export type {BidiTransport} from './BidiTransport.js';
 export {OutgoingMessage} from './OutgoingMessage.js';
 export type {BidiCommandParameterParser} from './BidiParser.js';
+export {
+  type ClassicRequest,
+  type ClassicResponse,
+  type ClassicTransport,
+  ClassicException,
+} from './ClassicTransport.js';

--- a/src/bidiMapper/BidiServer.ts
+++ b/src/bidiMapper/BidiServer.ts
@@ -25,6 +25,8 @@ import type {Result} from '../utils/result.js';
 
 import type {BidiCommandParameterParser} from './BidiParser.js';
 import type {BidiTransport} from './BidiTransport.js';
+import {ClassicCommandProcessor} from './ClassicCommandProcessor.js';
+import type {ClassicTransport} from './ClassicTransport.js';
 import {CommandProcessor, CommandProcessorEvents} from './CommandProcessor.js';
 import type {MapperOptions} from './MapperOptions.js';
 import {BluetoothProcessor} from './modules/bluetooth/BluetoothProcessor.js';
@@ -87,6 +89,7 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
     defaultUserAgent: string,
     parser?: BidiCommandParameterParser,
     logger?: LoggerFn,
+    classicTransport?: ClassicTransport,
   ) {
     super();
     this.#logger = logger;
@@ -190,6 +193,19 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
       },
       this.#logger,
     );
+    if (classicTransport) {
+      new ClassicCommandProcessor(
+        this.#eventManager,
+        this.#browsingContextStorage,
+        this.#realmStorage,
+        this.#preloadScriptStorage,
+        userContextStorage,
+        contextConfigStorage,
+        browserCdpClient,
+        classicTransport,
+        this.#logger,
+      );
+    }
     this.#eventManager.on(EventManagerEvents.Event, ({message, event}) => {
       this.emitOutgoingMessage(message, event);
     });
@@ -211,6 +227,7 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
     selfTargetId: string,
     parser?: BidiCommandParameterParser,
     logger?: LoggerFn,
+    classicTransport?: ClassicTransport,
   ): Promise<BidiServer> {
     const [defaultUserContextId, version] = await Promise.all([
       this.#getDefaultUserContextId(browserCdpClient),
@@ -233,6 +250,7 @@ export class BidiServer extends EventEmitter<BidiServerEvent> {
       version.userAgent,
       parser,
       logger,
+      classicTransport,
     );
 
     return server;

--- a/src/bidiMapper/ClassicCommandProcessor.test.ts
+++ b/src/bidiMapper/ClassicCommandProcessor.test.ts
@@ -40,7 +40,7 @@ class MockClassicTransport implements ClassicTransport {
     this.onMessage = onMessage;
   }
 
-  async sendMessage(response: ClassicResponse): Promise<void> {
+  sendMessage(response: ClassicResponse): void {
     this.lastSentResponse = response;
   }
 
@@ -108,5 +108,127 @@ describe('ClassicCommandProcessor', () => {
     });
     assert.equal(res.status, 404);
     assert.equal((res.body.value as any).error, 'no such window');
+  });
+
+  it('should return 404 no such window for navigation endpoints when no active context', async () => {
+    for (const path of ['/back', '/forward', '/refresh']) {
+      const res = await processor.processCommand({
+        id: `test-${path}`,
+        method: 'POST',
+        path,
+      });
+      assert.equal(res.status, 404);
+      assert.equal((res.body.value as any).error, 'no such window');
+    }
+  });
+
+  it('should return 404 no such window for document endpoints when no active context', async () => {
+    for (const path of ['/title', '/source']) {
+      const res = await processor.processCommand({
+        id: `test-${path}`,
+        method: 'GET',
+        path,
+      });
+      assert.equal(res.status, 404);
+      assert.equal((res.body.value as any).error, 'no such window');
+    }
+  });
+
+  it('should return status ready on GET /status', async () => {
+    const res = await processor.processCommand({
+      id: 'test-status',
+      method: 'GET',
+      path: '/status',
+    });
+    assert.equal(res.status, 200);
+    assert.isTrue((res.body.value as any).ready);
+  });
+
+  it('should return session result on POST /session and DELETE /session', async () => {
+    const postRes = await processor.processCommand({
+      id: 'test-session-post',
+      method: 'POST',
+      path: '/session',
+    });
+    assert.equal(postRes.status, 200);
+    assert.equal((postRes.body.value as any).sessionId, 'default');
+
+    const delRes = await processor.processCommand({
+      id: 'test-session-del',
+      method: 'DELETE',
+      path: '/session',
+    });
+    assert.equal(delRes.status, 200);
+    assert.isNull(delRes.body.value);
+  });
+
+  it('should return 404 no such window for window rect/state endpoints when no active context', async () => {
+    for (const path of [
+      '/window/rect',
+      '/window/maximize',
+      '/window/minimize',
+      '/window/fullscreen',
+    ]) {
+      const method = path === '/window/rect' ? 'GET' : 'POST';
+      const res = await processor.processCommand({
+        id: `test-${path}`,
+        method,
+        path,
+      });
+      assert.equal(res.status, 404);
+      assert.equal((res.body.value as any).error, 'no such window');
+    }
+  });
+
+  it('should return 400 for POST /alert/text without a string text parameter', async () => {
+    const res = await processor.processCommand({
+      id: 'test-alert-text-invalid',
+      method: 'POST',
+      path: '/alert/text',
+      body: {},
+    });
+    assert.equal(res.status, 400);
+    assert.equal((res.body.value as any).error, 'invalid argument');
+  });
+
+  it('should return 404 no such window for cookie endpoints when no active context', async () => {
+    for (const {method, path} of [
+      {method: 'GET', path: '/cookie'},
+      {method: 'POST', path: '/cookie'},
+      {method: 'DELETE', path: '/cookie'},
+      {method: 'GET', path: '/cookie/testCookie'},
+      {method: 'DELETE', path: '/cookie/testCookie'},
+    ]) {
+      const res = await processor.processCommand({
+        id: `test-cookie-${method}-${path}`,
+        method,
+        path,
+        body: method === 'POST' ? {cookie: {name: 'test', value: 'val'}} : {},
+      });
+      assert.equal(res.status, 404);
+      assert.equal((res.body.value as any).error, 'no such window');
+    }
+  });
+
+  it('should return 404 no such window for element finding endpoints when no active context', async () => {
+    for (const {method, path} of [
+      {method: 'POST', path: '/element'},
+      {method: 'POST', path: '/elements'},
+      {method: 'GET', path: '/element/active'},
+      {method: 'POST', path: '/element/e123/element'},
+      {method: 'POST', path: '/element/e123/elements'},
+      {method: 'GET', path: '/element/e123/shadow'},
+      {method: 'POST', path: '/shadow/s123/element'},
+      {method: 'POST', path: '/shadow/s123/elements'},
+    ]) {
+      const res = await processor.processCommand({
+        id: `test-elem-${method}-${path}`,
+        method,
+        path,
+        body: method === 'POST' ? {using: 'css selector', value: 'div'} : {},
+      });
+      assert.equal(res.status, 404);
+      assert.equal((res.body.value as any).error, 'no such window');
+    }
   });
 });

--- a/src/bidiMapper/ClassicCommandProcessor.test.ts
+++ b/src/bidiMapper/ClassicCommandProcessor.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, beforeEach} from 'node:test';
+import {assert} from 'chai';
+
+import {ClassicCommandProcessor} from './ClassicCommandProcessor.js';
+import type {
+  ClassicRequest,
+  ClassicResponse,
+  ClassicTransport,
+} from './ClassicTransport.js';
+import {ContextConfigStorage} from './modules/browser/ContextConfigStorage.js';
+import {UserContextStorage} from './modules/browser/UserContextStorage.js';
+import {BrowsingContextStorage} from './modules/context/BrowsingContextStorage.js';
+import {PreloadScriptStorage} from './modules/script/PreloadScriptStorage.js';
+import {RealmStorage} from './modules/script/RealmStorage.js';
+import {EventManager} from './modules/session/EventManager.js';
+
+class MockClassicTransport implements ClassicTransport {
+  onMessage: ((request: ClassicRequest) => void) | null = null;
+  lastSentResponse: ClassicResponse | null = null;
+  closed = false;
+
+  setOnMessage(onMessage: (request: ClassicRequest) => void): void {
+    this.onMessage = onMessage;
+  }
+
+  async sendMessage(response: ClassicResponse): Promise<void> {
+    this.lastSentResponse = response;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+describe('ClassicCommandProcessor', () => {
+  let processor: ClassicCommandProcessor;
+  let transport: MockClassicTransport;
+  let browsingContextStorage: BrowsingContextStorage;
+  let realmStorage: RealmStorage;
+
+  beforeEach(() => {
+    browsingContextStorage = new BrowsingContextStorage();
+    realmStorage = new RealmStorage();
+    const preloadScriptStorage = new PreloadScriptStorage();
+    const userContextStorage = new UserContextStorage({} as any);
+    const contextConfigStorage = new ContextConfigStorage();
+    const eventManager = new EventManager(
+      browsingContextStorage,
+      userContextStorage,
+    );
+    transport = new MockClassicTransport();
+    processor = new ClassicCommandProcessor(
+      eventManager,
+      browsingContextStorage,
+      realmStorage,
+      preloadScriptStorage,
+      userContextStorage,
+      contextConfigStorage,
+      {} as any,
+      transport,
+    );
+  });
+
+  it('should return 404 for unknown endpoint paths', async () => {
+    const res = await processor.processCommand({
+      id: 'test-1',
+      method: 'GET',
+      path: '/unknown/endpoint',
+    });
+    assert.equal(res.status, 404);
+    assert.equal((res.body.value as any).error, 'unknown command');
+  });
+
+  it('should return 400 for execute/sync without a script string', async () => {
+    const res = await processor.processCommand({
+      id: 'test-2',
+      method: 'POST',
+      path: '/execute/sync',
+      body: {args: []},
+    });
+    assert.equal(res.status, 400);
+    assert.equal((res.body.value as any).error, 'invalid argument');
+  });
+
+  it('should return 404 no such window if there is no active context', async () => {
+    const res = await processor.processCommand({
+      id: 'test-3',
+      method: 'POST',
+      path: '/execute/sync',
+      body: {script: 'return 1;', args: []},
+    });
+    assert.equal(res.status, 404);
+    assert.equal((res.body.value as any).error, 'no such window');
+  });
+});

--- a/src/bidiMapper/ClassicCommandProcessor.ts
+++ b/src/bidiMapper/ClassicCommandProcessor.ts
@@ -31,20 +31,28 @@ import type {ContextConfigStorage} from './modules/browser/ContextConfigStorage.
 import type {UserContextStorage} from './modules/browser/UserContextStorage.js';
 import {BrowsingContextProcessor} from './modules/context/BrowsingContextProcessor.js';
 import type {BrowsingContextStorage} from './modules/context/BrowsingContextStorage.js';
+import {InputProcessor} from './modules/input/InputProcessor.js';
 import type {PreloadScriptStorage} from './modules/script/PreloadScriptStorage.js';
 import type {RealmStorage} from './modules/script/RealmStorage.js';
 import {ScriptProcessor} from './modules/script/ScriptProcessor.js';
 import type {EventManager} from './modules/session/EventManager.js';
+import {StorageProcessor} from './modules/storage/StorageProcessor.js';
 
 export class ClassicCommandProcessor {
   readonly #mutex = new Mutex();
-  readonly #timeouts: {implicit: number; pageLoad: number; script: number | null} = {
+  readonly #timeouts: {
+    implicit: number;
+    pageLoad: number;
+    script: number | null;
+  } = {
     implicit: 0,
     pageLoad: 300000,
     script: 30000,
   };
   #scriptProcessor: ScriptProcessor;
   #browsingContextProcessor: BrowsingContextProcessor;
+  #storageProcessor: StorageProcessor;
+  #inputProcessor: InputProcessor;
   #transport: ClassicTransport;
   #logger?: LoggerFn;
 
@@ -85,6 +93,14 @@ export class ClassicCommandProcessor {
       userContextStorage,
       contextConfigStorage,
       eventManager,
+    );
+    this.#storageProcessor = new StorageProcessor(
+      browserCdpClient,
+      browsingContextStorage,
+      logger,
+    );
+    this.#inputProcessor = new InputProcessor(browsingContextStorage, () =>
+      this.#browsingContextProcessor.classicGetActiveContext(),
     );
     this.#transport.setOnMessage(
       (request) => void this.#handleMessage(request),
@@ -163,6 +179,42 @@ export class ClassicCommandProcessor {
     body: unknown,
   ): Promise<ClassicResponse> {
     switch (path) {
+      case '/status': {
+        if (method === 'GET') {
+          return {
+            status: 200,
+            body: {
+              value: {
+                ready: true,
+                message: 'ready',
+              },
+            },
+          };
+        }
+        break;
+      }
+      case '/session': {
+        switch (method) {
+          case 'POST':
+            return {
+              status: 200,
+              body: {
+                value: {
+                  sessionId: 'default',
+                  capabilities: {},
+                },
+              },
+            };
+          case 'DELETE':
+            return {
+              status: 200,
+              body: {value: null},
+            };
+          default:
+            break;
+        }
+        break;
+      }
       case '/timeouts': {
         switch (method) {
           case 'GET':
@@ -190,7 +242,7 @@ export class ClassicCommandProcessor {
               if (key in params) {
                 const val = params[key];
                 const isValid =
-                  (key === 'script' && val === null) ||
+                  ((key === 'script' || key === 'pageLoad') && val === null) ||
                   (typeof val === 'number' &&
                     val >= 0 &&
                     Number.isFinite(val) &&
@@ -289,13 +341,58 @@ export class ClassicCommandProcessor {
       case '/url': {
         switch (method) {
           case 'GET':
-            return this.#browsingContextProcessor.classicGetUrl();
+            return await this.#browsingContextProcessor.classicGetUrl();
           case 'POST': {
             const params = body as {url?: unknown} | undefined;
             return await this.#browsingContextProcessor.classicNavigate(
               params?.url,
             );
           }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/back': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicBack();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/forward': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicForward();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/refresh': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicRefresh();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/title': {
+        switch (method) {
+          case 'GET':
+            return await this.#browsingContextProcessor.classicGetTitle();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/source': {
+        switch (method) {
+          case 'GET':
+            return await this.#browsingContextProcessor.classicGetPageSource();
           default:
             break;
         }
@@ -343,11 +440,51 @@ export class ClassicCommandProcessor {
         }
         break;
       }
+      case '/window/rect': {
+        switch (method) {
+          case 'GET':
+            return await this.#browsingContextProcessor.classicGetWindowRect();
+          case 'POST':
+            return await this.#browsingContextProcessor.classicSetWindowRect(
+              body,
+            );
+          default:
+            break;
+        }
+        break;
+      }
+      case '/window/maximize': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicMaximizeWindow();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/window/minimize': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicMinimizeWindow();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/window/fullscreen': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicFullscreenWindow();
+          default:
+            break;
+        }
+        break;
+      }
       case '/frame': {
         switch (method) {
           case 'POST': {
             const params = body as {id?: unknown} | undefined;
-            return this.#browsingContextProcessor.classicSwitchToFrame(
+            return await this.#browsingContextProcessor.classicSwitchToFrame(
               params ? (params.id === undefined ? null : params.id) : null,
             );
           }
@@ -391,6 +528,74 @@ export class ClassicCommandProcessor {
         switch (method) {
           case 'GET':
             return this.#browsingContextProcessor.classicGetAlertText();
+          case 'POST':
+            return await this.#browsingContextProcessor.classicSendAlertText(
+              body,
+            );
+          default:
+            break;
+        }
+        break;
+      }
+      case '/cookie': {
+        switch (method) {
+          case 'GET':
+            return await this.#storageProcessor.classicGetAllCookies();
+          case 'POST':
+            return await this.#storageProcessor.classicAddCookie(body);
+          case 'DELETE':
+            return await this.#storageProcessor.classicDeleteAllCookies();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/element': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicFindElement(
+              body,
+            );
+          default:
+            break;
+        }
+        break;
+      }
+      case '/elements': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicFindElements(
+              body,
+            );
+          default:
+            break;
+        }
+        break;
+      }
+      case '/element/active': {
+        switch (method) {
+          case 'GET':
+            return await this.#browsingContextProcessor.classicGetActiveElement();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/screenshot': {
+        switch (method) {
+          case 'GET':
+            return await this.#browsingContextProcessor.classicTakeScreenshot();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/actions': {
+        switch (method) {
+          case 'POST':
+            return await this.#inputProcessor.classicPerformActions(body);
+          case 'DELETE':
+            return await this.#inputProcessor.classicReleaseActions();
           default:
             break;
         }
@@ -398,6 +603,177 @@ export class ClassicCommandProcessor {
       }
       default:
         break;
+    }
+    if (path.startsWith('/cookie/')) {
+      const cookieName = decodeURIComponent(path.substring('/cookie/'.length));
+      switch (method) {
+        case 'GET':
+          return await this.#storageProcessor.classicGetNamedCookie(cookieName);
+        case 'DELETE':
+          return await this.#storageProcessor.classicDeleteCookie(cookieName);
+        default:
+          break;
+      }
+    }
+
+    const elemMatch = path.match(
+      /^\/element\/([^/]+)\/(element|elements|shadow)$/,
+    );
+    if (elemMatch) {
+      const elementId = decodeURIComponent(elemMatch[1]!);
+      const subAction = elemMatch[2];
+      if (method === 'POST' && subAction === 'element') {
+        return await this.#browsingContextProcessor.classicFindElement(
+          body,
+          elementId,
+        );
+      }
+      if (method === 'POST' && subAction === 'elements') {
+        return await this.#browsingContextProcessor.classicFindElements(
+          body,
+          elementId,
+        );
+      }
+      if (method === 'GET' && subAction === 'shadow') {
+        return await this.#browsingContextProcessor.classicGetElementShadowRoot(
+          elementId,
+        );
+      }
+    }
+
+    const elemSubMatch = path.match(
+      /^\/element\/([^/]+)\/(selected|text|name|rect|enabled|computedlabel|computedrole|screenshot|click|clear|value)$/,
+    );
+    if (elemSubMatch) {
+      const elementId = decodeURIComponent(elemSubMatch[1]!);
+      const subAction = elemSubMatch[2];
+      if (method === 'GET') {
+        switch (subAction) {
+          case 'selected':
+            return await this.#browsingContextProcessor.classicIsElementSelected(
+              elementId,
+            );
+          case 'text':
+            return await this.#browsingContextProcessor.classicGetElementText(
+              elementId,
+            );
+          case 'name':
+            return await this.#browsingContextProcessor.classicGetElementTagName(
+              elementId,
+            );
+          case 'rect':
+            return await this.#browsingContextProcessor.classicGetElementRect(
+              elementId,
+            );
+          case 'enabled':
+            return await this.#browsingContextProcessor.classicIsElementEnabled(
+              elementId,
+            );
+          case 'computedlabel':
+            return await this.#browsingContextProcessor.classicGetComputedLabel(
+              elementId,
+            );
+          case 'computedrole':
+            return await this.#browsingContextProcessor.classicGetComputedRole(
+              elementId,
+            );
+          case 'screenshot':
+            return await this.#browsingContextProcessor.classicTakeElementScreenshot(
+              elementId,
+            );
+          default:
+            break;
+        }
+      } else if (method === 'POST') {
+        switch (subAction) {
+          case 'click':
+            return await this.#browsingContextProcessor.classicElementClick(
+              elementId,
+            );
+          case 'clear':
+            return await this.#browsingContextProcessor.classicElementClear(
+              elementId,
+            );
+          case 'value': {
+            const bodyObj =
+              typeof body === 'object' && body !== null
+                ? (body as Record<string, unknown>)
+                : undefined;
+            const textParam = bodyObj
+              ? (bodyObj['text'] ??
+                (Array.isArray(bodyObj['value'])
+                  ? (bodyObj['value'] as string[]).join('')
+                  : bodyObj['value']))
+              : undefined;
+            if (typeof textParam !== 'string') {
+              return {
+                status: 400,
+                body: {
+                  value: {
+                    error: 'invalid argument',
+                    message: 'text or value must be a string',
+                    stacktrace: '',
+                  },
+                },
+              };
+            }
+            return await this.#browsingContextProcessor.classicElementValue(
+              elementId,
+              textParam,
+            );
+          }
+          default:
+            break;
+        }
+      }
+    }
+
+    const elemParamMatch = path.match(
+      /^\/element\/([^/]+)\/(attribute|property|css)\/([^/]+)$/,
+    );
+    if (elemParamMatch && method === 'GET') {
+      const elementId = decodeURIComponent(elemParamMatch[1]!);
+      const subAction = elemParamMatch[2];
+      const paramName = decodeURIComponent(elemParamMatch[3]!);
+      switch (subAction) {
+        case 'attribute':
+          return await this.#browsingContextProcessor.classicGetElementAttribute(
+            elementId,
+            paramName,
+          );
+        case 'property':
+          return await this.#browsingContextProcessor.classicGetElementProperty(
+            elementId,
+            paramName,
+          );
+        case 'css':
+          return await this.#browsingContextProcessor.classicGetElementCSSValue(
+            elementId,
+            paramName,
+          );
+        default:
+          break;
+      }
+    }
+
+    const shadowMatch = path.match(/^\/shadow\/([^/]+)\/(element|elements)$/);
+    if (shadowMatch) {
+      const shadowId = decodeURIComponent(shadowMatch[1]!);
+      const subAction = shadowMatch[2];
+      if (method === 'POST' && subAction === 'element') {
+        return await this.#browsingContextProcessor.classicFindElement(
+          body,
+          shadowId,
+          true,
+        );
+      }
+      if (method === 'POST' && subAction === 'elements') {
+        return await this.#browsingContextProcessor.classicFindElements(
+          body,
+          shadowId,
+          true,
+        );
+      }
     }
     return {
       status: 404,

--- a/src/bidiMapper/ClassicCommandProcessor.ts
+++ b/src/bidiMapper/ClassicCommandProcessor.ts
@@ -1,0 +1,413 @@
+/**
+ * Copyright 2026 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LogType, type LoggerFn} from '../utils/log.js';
+import {Mutex} from '../utils/Mutex.js';
+
+import type {CdpClient} from '../cdp/CdpClient.js';
+import {Session} from '../protocol/protocol.js';
+
+import {
+  type ClassicRequest,
+  type ClassicResponse,
+  type ClassicTransport,
+  ClassicException,
+} from './ClassicTransport.js';
+import type {ContextConfigStorage} from './modules/browser/ContextConfigStorage.js';
+import type {UserContextStorage} from './modules/browser/UserContextStorage.js';
+import {BrowsingContextProcessor} from './modules/context/BrowsingContextProcessor.js';
+import type {BrowsingContextStorage} from './modules/context/BrowsingContextStorage.js';
+import type {PreloadScriptStorage} from './modules/script/PreloadScriptStorage.js';
+import type {RealmStorage} from './modules/script/RealmStorage.js';
+import {ScriptProcessor} from './modules/script/ScriptProcessor.js';
+import type {EventManager} from './modules/session/EventManager.js';
+
+export class ClassicCommandProcessor {
+  readonly #mutex = new Mutex();
+  readonly #timeouts: {implicit: number; pageLoad: number; script: number | null} = {
+    implicit: 0,
+    pageLoad: 300000,
+    script: 30000,
+  };
+  #scriptProcessor: ScriptProcessor;
+  #browsingContextProcessor: BrowsingContextProcessor;
+  #transport: ClassicTransport;
+  #logger?: LoggerFn;
+
+  constructor(
+    eventManager: EventManager,
+    browsingContextStorage: BrowsingContextStorage,
+    realmStorage: RealmStorage,
+    preloadScriptStorage: PreloadScriptStorage,
+    userContextStorage: UserContextStorage,
+    contextConfigStorage: ContextConfigStorage,
+    browserCdpClient: CdpClient,
+    transport: ClassicTransport,
+    logger?: LoggerFn,
+  ) {
+    this.#transport = transport;
+    this.#logger = logger;
+
+    contextConfigStorage.updateGlobalConfig({
+      userPromptHandler: {
+        default: Session.UserPromptHandlerType.Ignore,
+        alert: Session.UserPromptHandlerType.Ignore,
+        confirm: Session.UserPromptHandlerType.Ignore,
+        prompt: Session.UserPromptHandlerType.Ignore,
+      },
+    });
+
+    this.#scriptProcessor = new ScriptProcessor(
+      eventManager,
+      browsingContextStorage,
+      realmStorage,
+      preloadScriptStorage,
+      userContextStorage,
+      logger,
+    );
+    this.#browsingContextProcessor = new BrowsingContextProcessor(
+      browserCdpClient,
+      browsingContextStorage,
+      userContextStorage,
+      contextConfigStorage,
+      eventManager,
+    );
+    this.#transport.setOnMessage(
+      (request) => void this.#handleMessage(request),
+    );
+  }
+
+  async #handleMessage(request: ClassicRequest): Promise<void> {
+    try {
+      const response = await this.processCommand(request);
+      await this.#transport.sendMessage(response);
+    } catch (error: unknown) {
+      this.#logger?.(LogType.debugError)?.(
+        'Classic command processing failed',
+        error,
+      );
+      const err = error instanceof Error ? error : new Error(String(error));
+      void this.#transport.sendMessage({
+        id: request.id,
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      });
+    }
+  }
+
+  async processCommand(request: ClassicRequest): Promise<ClassicResponse> {
+    return await this.#mutex.run(async () => {
+      try {
+        const {status, body} = await this.#executeCommand(
+          request.method.toUpperCase(),
+          request.path,
+          request.body,
+        );
+        return {
+          id: request.id,
+          status,
+          body,
+        };
+      } catch (e: unknown) {
+        if (e instanceof ClassicException) {
+          let status = 500;
+          if (e.error === 'invalid argument') {
+            status = 400;
+          } else if (
+            e.error === 'no such window' ||
+            e.error === 'unknown command'
+          ) {
+            status = 404;
+          }
+          return e.toErrorResponse(request.id, status);
+        }
+        const err = e instanceof Error ? e : new Error(String(e));
+        return {
+          id: request.id,
+          status: 500,
+          body: {
+            value: {
+              error: 'unknown error',
+              message: err.message,
+              stacktrace: err.stack ?? '',
+            },
+          },
+        };
+      }
+    });
+  }
+
+  async #executeCommand(
+    method: string,
+    path: string,
+    body: unknown,
+  ): Promise<ClassicResponse> {
+    switch (path) {
+      case '/timeouts': {
+        switch (method) {
+          case 'GET':
+            return {
+              status: 200,
+              body: {
+                value: this.#timeouts,
+              },
+            };
+          case 'POST': {
+            const params = body as Record<string, unknown> | undefined;
+            if (!params || typeof params !== 'object') {
+              return {
+                status: 400,
+                body: {
+                  value: {
+                    error: 'invalid argument',
+                    message: 'Timeouts parameters must be an object',
+                    stacktrace: '',
+                  },
+                },
+              };
+            }
+            for (const key of ['implicit', 'pageLoad', 'script'] as const) {
+              if (key in params) {
+                const val = params[key];
+                const isValid =
+                  (key === 'script' && val === null) ||
+                  (typeof val === 'number' &&
+                    val >= 0 &&
+                    Number.isFinite(val) &&
+                    Number.isInteger(val));
+                if (!isValid) {
+                  return {
+                    status: 400,
+                    body: {
+                      value: {
+                        error: 'invalid argument',
+                        message: `Invalid timeout value for ${key}`,
+                        stacktrace: '',
+                      },
+                    },
+                  };
+                }
+              }
+            }
+            for (const key of ['implicit', 'pageLoad', 'script'] as const) {
+              if (key in params) {
+                (this.#timeouts as any)[key] = params[key];
+              }
+            }
+            return {
+              status: 200,
+              body: {
+                value: null,
+              },
+            };
+          }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/execute/sync':
+      case '/execute':
+      case '/execute_script': {
+        switch (method) {
+          case 'POST': {
+            const params = body as
+              | {script?: unknown; args?: unknown}
+              | undefined;
+            if (!params || typeof params.script !== 'string') {
+              return {
+                status: 400,
+                body: {
+                  value: {
+                    error: 'invalid argument',
+                    message: 'Script parameter must be a string',
+                    stacktrace: '',
+                  },
+                },
+              };
+            }
+            return await this.#scriptProcessor.classicExecuteScript(
+              params.script,
+              Array.isArray(params.args) ? params.args : [],
+            );
+          }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/execute/async':
+      case '/execute_async_script': {
+        switch (method) {
+          case 'POST': {
+            const params = body as
+              | {script?: unknown; args?: unknown}
+              | undefined;
+            if (!params || typeof params.script !== 'string') {
+              return {
+                status: 400,
+                body: {
+                  value: {
+                    error: 'invalid argument',
+                    message: 'Script parameter must be a string',
+                    stacktrace: '',
+                  },
+                },
+              };
+            }
+            return await this.#scriptProcessor.classicExecuteAsyncScript(
+              params.script,
+              Array.isArray(params.args) ? params.args : [],
+              this.#timeouts.script,
+            );
+          }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/url': {
+        switch (method) {
+          case 'GET':
+            return this.#browsingContextProcessor.classicGetUrl();
+          case 'POST': {
+            const params = body as {url?: unknown} | undefined;
+            return await this.#browsingContextProcessor.classicNavigate(
+              params?.url,
+            );
+          }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/window':
+      case '/window/handle': {
+        switch (method) {
+          case 'GET':
+            return this.#browsingContextProcessor.classicGetWindowHandle();
+          case 'POST': {
+            const params = body as
+              | {handle?: unknown; name?: unknown}
+              | undefined;
+            return this.#browsingContextProcessor.classicSwitchToWindow(
+              params?.handle ?? params?.name,
+            );
+          }
+          case 'DELETE':
+            return await this.#browsingContextProcessor.classicCloseWindow();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/window/handles': {
+        switch (method) {
+          case 'GET':
+            return this.#browsingContextProcessor.classicGetWindowHandles();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/window/new': {
+        switch (method) {
+          case 'POST': {
+            const params = body as {type?: unknown} | undefined;
+            return await this.#browsingContextProcessor.classicNewWindow(
+              params?.type,
+            );
+          }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/frame': {
+        switch (method) {
+          case 'POST': {
+            const params = body as {id?: unknown} | undefined;
+            return this.#browsingContextProcessor.classicSwitchToFrame(
+              params ? (params.id === undefined ? null : params.id) : null,
+            );
+          }
+          default:
+            break;
+        }
+        break;
+      }
+      case '/frame/parent': {
+        switch (method) {
+          case 'POST':
+            return this.#browsingContextProcessor.classicSwitchToParentFrame();
+          default:
+            break;
+        }
+        break;
+      }
+      case '/alert/accept': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicHandleAlert(
+              true,
+            );
+          default:
+            break;
+        }
+        break;
+      }
+      case '/alert/dismiss': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicHandleAlert(
+              false,
+            );
+          default:
+            break;
+        }
+        break;
+      }
+      case '/alert/text': {
+        switch (method) {
+          case 'GET':
+            return this.#browsingContextProcessor.classicGetAlertText();
+          default:
+            break;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    return {
+      status: 404,
+      body: {
+        value: {
+          error: 'unknown command',
+          message: `Unknown classic command ${method} ${path}`,
+          stacktrace: '',
+        },
+      },
+    };
+  }
+}

--- a/src/bidiMapper/ClassicCommandProcessor.ts
+++ b/src/bidiMapper/ClassicCommandProcessor.ts
@@ -601,6 +601,15 @@ export class ClassicCommandProcessor {
         }
         break;
       }
+      case '/print': {
+        switch (method) {
+          case 'POST':
+            return await this.#browsingContextProcessor.classicPrintPage(body);
+          default:
+            break;
+        }
+        break;
+      }
       default:
         break;
     }
@@ -773,6 +782,17 @@ export class ClassicCommandProcessor {
           shadowId,
           true,
         );
+      }
+    }
+
+    const cookieMatch = path.match(/^\/cookie\/([^/]+)$/);
+    if (cookieMatch) {
+      const cookieName = decodeURIComponent(cookieMatch[1]!);
+      if (method === 'GET') {
+        return await this.#storageProcessor.classicGetNamedCookie(cookieName);
+      }
+      if (method === 'DELETE') {
+        return await this.#storageProcessor.classicDeleteCookie(cookieName);
       }
     }
     return {

--- a/src/bidiMapper/ClassicTransport.ts
+++ b/src/bidiMapper/ClassicTransport.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ClassicRequest {
+  readonly id: string;
+  readonly method: string;
+  readonly path: string;
+  readonly body?: unknown;
+}
+
+export interface ClassicResponse {
+  readonly id?: string;
+  readonly status: number;
+  readonly body: {
+    value: unknown;
+  };
+}
+
+export interface ClassicTransport {
+  setOnMessage(onMessage: (request: ClassicRequest) => void): void;
+  sendMessage(response: ClassicResponse): Promise<void> | void;
+  close(): void;
+}
+
+export class ClassicException extends Error {
+  constructor(
+    public error: string,
+    public override message: string,
+    public stacktrace: string = '',
+  ) {
+    super(message);
+  }
+
+  toErrorResponse(id: string, status = 500): ClassicResponse {
+    return {
+      id,
+      status,
+      body: {
+        value: {
+          error: this.error,
+          message: this.message,
+          stacktrace: this.stacktrace,
+        },
+      },
+    };
+  }
+}

--- a/src/bidiMapper/modules/context/BrowsingContextImpl.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextImpl.ts
@@ -92,6 +92,7 @@ export class BrowsingContextImpl {
 
   // Set when the user prompt is opened. Required to provide the type in closing event.
   #lastUserPromptType?: BrowsingContext.UserPromptType;
+  #activeUserPromptMessage?: string;
 
   private constructor(
     id: BrowsingContext.BrowsingContext,
@@ -328,6 +329,10 @@ export class BrowsingContextImpl {
 
   get url(): string {
     return this.#navigationTracker.url;
+  }
+
+  get activeUserPromptMessage(): string | undefined {
+    return this.#activeUserPromptMessage;
   }
 
   async lifecycleLoaded() {
@@ -739,6 +744,7 @@ export class BrowsingContextImpl {
         this.id,
       );
       this.#lastUserPromptType = undefined;
+      this.#activeUserPromptMessage = undefined;
     });
 
     this.#cdpTarget.cdpClient.on('Page.javascriptDialogOpening', (params) => {
@@ -764,6 +770,7 @@ export class BrowsingContextImpl {
       const promptType = BrowsingContextImpl.#getPromptType(params.type);
       // Set the last prompt type to provide it in closing event.
       this.#lastUserPromptType = promptType;
+      this.#activeUserPromptMessage = params.message;
       const promptHandler = this.#getPromptHandler(promptType);
       this.#eventManager.registerEvent(
         {

--- a/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
@@ -1137,9 +1137,15 @@ export class BrowsingContextProcessor {
       case 'partial link text':
         return {type: 'innerText', value, matchType: 'partial'};
       case 'id':
-        return {type: 'css', value: `[id="${value.replace(/"/g, '\\"')}"]`};
+        return {
+          type: 'css',
+          value: `[id="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`,
+        };
       case 'name':
-        return {type: 'css', value: `[name="${value.replace(/"/g, '\\"')}"]`};
+        return {
+          type: 'css',
+          value: `[name="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`,
+        };
       case 'class name':
         return {type: 'css', value: `.${value.replace(/ /g, '.')}`};
       default:

--- a/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
@@ -32,6 +32,8 @@ import type {ContextConfigStorage} from '../browser/ContextConfigStorage.js';
 import type {UserContextStorage} from '../browser/UserContextStorage.js';
 import type {EventManager} from '../session/EventManager.js';
 
+import type {ClassicResponse} from '../../ClassicTransport.js';
+
 import type {BrowsingContextImpl} from './BrowsingContextImpl.js';
 import type {BrowsingContextStorage} from './BrowsingContextStorage.js';
 
@@ -186,6 +188,7 @@ export class BrowsingContextProcessor {
       );
     }
     await context.activate();
+    this.#browsingContextStorage.setActiveContextId(context.id);
     return {};
   }
 
@@ -410,6 +413,359 @@ export class BrowsingContextProcessor {
   ): Promise<BrowsingContext.LocateNodesResult> {
     const context = this.#browsingContextStorage.getContext(params.context);
     return await context.locateNodes(params);
+  }
+
+  classicGetUrl(): ClassicResponse {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    return {
+      status: 200,
+      body: {
+        value: context.url,
+      },
+    };
+  }
+
+  async classicNavigate(urlInput: unknown): Promise<ClassicResponse> {
+    if (typeof urlInput !== 'string') {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'url parameter must be a string',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await context.navigate(urlInput, 'complete' as BrowsingContext.ReadinessState);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  classicGetWindowHandle(): ClassicResponse {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    return {
+      status: 200,
+      body: {
+        value: context.id,
+      },
+    };
+  }
+
+  classicGetWindowHandles(): ClassicResponse {
+    return {
+      status: 200,
+      body: {
+        value: this.#browsingContextStorage.getTopLevelContexts().map((c) => c.id),
+      },
+    };
+  }
+
+  async classicNewWindow(typeHint: unknown): Promise<ClassicResponse> {
+    try {
+      const type = typeHint === 'window' ? BrowsingContext.CreateType.Window : BrowsingContext.CreateType.Tab;
+      const res = await this.create({type, referenceContext: undefined, userContext: 'default', background: false});
+      return {
+        status: 200,
+        body: {
+          value: {
+            handle: res.context,
+            type: typeHint === 'window' ? 'window' : 'tab',
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicCloseWindow(): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await this.close({context: context.id});
+      const remaining = this.#browsingContextStorage.getTopLevelContexts();
+      if (remaining.length > 0) {
+        this.#browsingContextStorage.setActiveContextId(remaining[0]?.id);
+      } else {
+        this.#browsingContextStorage.setActiveContextId(undefined);
+      }
+      return {
+        status: 200,
+        body: {
+          value: remaining.map((c) => c.id),
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  classicSwitchToWindow(handleInput: unknown): ClassicResponse {
+    if (typeof handleInput !== 'string') {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'handle must be a string',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const target = this.#browsingContextStorage.getTopLevelContexts().find(c => c.id === handleInput);
+    if (!target) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: `Window handle ${handleInput} not found`,
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    this.#browsingContextStorage.setActiveContextId(target.id);
+    return {
+      status: 200,
+      body: {value: null},
+    };
+  }
+
+  classicSwitchToFrame(frameInput: unknown): ClassicResponse {
+    const active =
+      this.#browsingContextStorage.getActiveContext() ??
+      this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!active) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    if (frameInput === null || frameInput === undefined) {
+      this.#browsingContextStorage.setActiveContextId(active.top.id);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    }
+    const children = active.directChildren;
+    if (typeof frameInput === 'number') {
+      if (frameInput < 0 || frameInput >= children.length) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such frame',
+              message: `Frame index ${frameInput} out of bounds`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+      this.#browsingContextStorage.setActiveContextId(children[frameInput]?.id);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    }
+    if (typeof frameInput === 'object' && frameInput !== null && children.length === 1) {
+      this.#browsingContextStorage.setActiveContextId(children[0]?.id);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    }
+    return {
+      status: 404,
+      body: {
+        value: {
+          error: 'no such frame',
+          message: `Frame ${JSON.stringify(frameInput)} not found`,
+          stacktrace: '',
+        },
+      },
+    };
+  }
+
+  classicSwitchToParentFrame(): ClassicResponse {
+    const active =
+      this.#browsingContextStorage.getActiveContext() ??
+      this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!active) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    if (active.parent) {
+      this.#browsingContextStorage.setActiveContextId(active.parent.id);
+    } else {
+      this.#browsingContextStorage.setActiveContextId(active.id);
+    }
+    return {
+      status: 200,
+      body: {value: null},
+    };
+  }
+
+  async classicHandleAlert(accept: boolean): Promise<ClassicResponse> {
+    const active =
+      this.#browsingContextStorage.getActiveContext() ??
+      this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!active) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await active.handleUserPrompt(accept);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such alert',
+            message: 'No user prompt is currently showing',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+  }
+
+  classicGetAlertText(): ClassicResponse {
+    const active =
+      this.#browsingContextStorage.getActiveContext() ??
+      this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!active || active.activeUserPromptMessage === undefined) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such alert',
+            message: 'No user prompt is currently showing',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    return {
+      status: 200,
+      body: {
+        value: active.activeUserPromptMessage,
+      },
+    };
   }
 
   #onContextCreatedSubscribeHook(

--- a/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
@@ -725,7 +725,7 @@ export class BrowsingContextProcessor {
   }
 
   async classicGetWindowRect(): Promise<ClassicResponse> {
-    const context = this.#browsingContextStorage.getActiveContext();
+    const context = await this.classicGetActiveContext();
     if (!context) {
       return {
         status: 404,
@@ -770,7 +770,7 @@ export class BrowsingContextProcessor {
   }
 
   async classicSetWindowRect(rectInput: unknown): Promise<ClassicResponse> {
-    const context = this.#browsingContextStorage.getActiveContext();
+    const context = await this.classicGetActiveContext();
     if (!context) {
       return {
         status: 404,
@@ -1887,6 +1887,48 @@ export class BrowsingContextProcessor {
       const result = await context.top.captureScreenshot({
         context: context.top.id,
         origin: 'viewport',
+      });
+      return {
+        status: 200,
+        body: {
+          value: result.data,
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicPrintPage(params: unknown): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const printParams =
+        (params as BrowsingContext.PrintParameters | undefined) ?? {};
+      const result = await context.top.print({
+        context: context.top.id,
+        ...printParams,
       });
       return {
         status: 200,

--- a/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextProcessor.ts
@@ -23,7 +23,10 @@ import {
   InvalidArgumentException,
   type EmptyResult,
   NoSuchUserContextException,
+  Script,
   NoSuchAlertException,
+  NoSuchHandleException,
+  NoSuchElementException,
   UnsupportedOperationException,
 } from '../../../protocol/protocol.js';
 import {CdpErrorConstants} from '../../../utils/cdpErrorConstants.js';
@@ -415,8 +418,39 @@ export class BrowsingContextProcessor {
     return await context.locateNodes(params);
   }
 
-  classicGetUrl(): ClassicResponse {
-    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+  async classicGetActiveContext(): Promise<BrowsingContextImpl | undefined> {
+    const activeContext = this.#browsingContextStorage.getActiveContext();
+    if (!activeContext) {
+      return undefined;
+    }
+    let current: BrowsingContextImpl | null = activeContext;
+    while (current && !current.isTopLevelContext()) {
+      try {
+        const realm = await current.getOrCreateUserSandbox(undefined);
+        const evalResult = await realm.evaluate(
+          'window.frameElement === null',
+          false,
+          Script.ResultOwnership.None,
+          {},
+          false,
+        );
+        if (
+          evalResult.type !== 'success' ||
+          (evalResult.result.type === 'boolean' &&
+            evalResult.result.value === true)
+        ) {
+          return undefined;
+        }
+      } catch {
+        return undefined;
+      }
+      current = current.parent;
+    }
+    return activeContext;
+  }
+
+  async classicGetUrl(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
     if (!context) {
       return {
         status: 404,
@@ -450,7 +484,7 @@ export class BrowsingContextProcessor {
         },
       };
     }
-    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    const context = this.#browsingContextStorage.getActiveContext();
     if (!context) {
       return {
         status: 404,
@@ -464,7 +498,10 @@ export class BrowsingContextProcessor {
       };
     }
     try {
-      await context.navigate(urlInput, 'complete' as BrowsingContext.ReadinessState);
+      await context.navigate(
+        urlInput,
+        'complete' as BrowsingContext.ReadinessState,
+      );
       return {
         status: 200,
         body: {value: null},
@@ -484,8 +521,764 @@ export class BrowsingContextProcessor {
     }
   }
 
-  classicGetWindowHandle(): ClassicResponse {
+  async classicBack(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await context.traverseHistory(-1);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicForward(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await context.traverseHistory(1);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicRefresh(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await context.reload(false, 'complete' as BrowsingContext.ReadinessState);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicGetTitle(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const realm = await context.getOrCreateUserSandbox(undefined);
+      const evalResult = await realm.evaluate(
+        'document.title',
+        false,
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+      let title = '';
+      if (
+        evalResult.type === 'success' &&
+        evalResult.result.type === 'string'
+      ) {
+        title = evalResult.result.value;
+      }
+      return {
+        status: 200,
+        body: {value: title},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicGetPageSource(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const realm = await context.getOrCreateUserSandbox(undefined);
+      const evalResult = await realm.evaluate(
+        'document.documentElement ? document.documentElement.outerHTML : ""',
+        false,
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+      let source = '';
+      if (
+        evalResult.type === 'success' &&
+        evalResult.result.type === 'string'
+      ) {
+        source = evalResult.result.value;
+      }
+      return {
+        status: 200,
+        body: {value: source},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicGetWindowRect(): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const {bounds} = await this.#browserCdpClient.sendCommand(
+        'Browser.getWindowForTarget',
+        {targetId: context.cdpTarget.id},
+      );
+      return {
+        status: 200,
+        body: {
+          value: {
+            x: bounds.left ?? 0,
+            y: bounds.top ?? 0,
+            width: bounds.width ?? 0,
+            height: bounds.height ?? 0,
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicSetWindowRect(rectInput: unknown): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const params = (rectInput as Record<string, unknown> | undefined) ?? {};
+      const {windowId} = await this.#browserCdpClient.sendCommand(
+        'Browser.getWindowForTarget',
+        {targetId: context.cdpTarget.id},
+      );
+
+      const bounds: Protocol.Browser.Bounds = {
+        windowState: 'normal',
+      };
+      if (typeof params['width'] === 'number') {
+        bounds.width = Math.floor(params['width']);
+      }
+      if (typeof params['height'] === 'number') {
+        bounds.height = Math.floor(params['height']);
+      }
+      if (typeof params['x'] === 'number') {
+        bounds.left = Math.floor(params['x']);
+      }
+      if (typeof params['y'] === 'number') {
+        bounds.top = Math.floor(params['y']);
+      }
+
+      await this.#browserCdpClient.sendCommand('Browser.setWindowBounds', {
+        windowId,
+        bounds,
+      });
+
+      const {bounds: newBounds} = await this.#browserCdpClient.sendCommand(
+        'Browser.getWindowForTarget',
+        {targetId: context.cdpTarget.id},
+      );
+      return {
+        status: 200,
+        body: {
+          value: {
+            x: newBounds.left ?? 0,
+            y: newBounds.top ?? 0,
+            width: newBounds.width ?? 0,
+            height: newBounds.height ?? 0,
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async #classicSetWindowState(
+    state: Protocol.Browser.WindowState,
+  ): Promise<ClassicResponse> {
     const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const {windowId} = await this.#browserCdpClient.sendCommand(
+        'Browser.getWindowForTarget',
+        {targetId: context.cdpTarget.id},
+      );
+      await this.#browserCdpClient.sendCommand('Browser.setWindowBounds', {
+        windowId,
+        bounds: {windowState: state},
+      });
+      const {bounds: newBounds} = await this.#browserCdpClient.sendCommand(
+        'Browser.getWindowForTarget',
+        {targetId: context.cdpTarget.id},
+      );
+      return {
+        status: 200,
+        body: {
+          value: {
+            x: newBounds.left ?? 0,
+            y: newBounds.top ?? 0,
+            width: newBounds.width ?? 0,
+            height: newBounds.height ?? 0,
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicMaximizeWindow(): Promise<ClassicResponse> {
+    return await this.#classicSetWindowState('maximized');
+  }
+
+  async classicMinimizeWindow(): Promise<ClassicResponse> {
+    return await this.#classicSetWindowState('minimized');
+  }
+
+  async classicFullscreenWindow(): Promise<ClassicResponse> {
+    return await this.#classicSetWindowState('fullscreen');
+  }
+
+  async classicFindElement(
+    input: unknown,
+    startElementId?: string,
+    isShadowRoot = false,
+  ): Promise<ClassicResponse> {
+    const params = input as {using?: unknown; value?: unknown} | undefined;
+    if (
+      typeof params?.using !== 'string' ||
+      typeof params?.value !== 'string'
+    ) {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'using and value parameters must be strings',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const context = this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      if (startElementId) {
+        const realm = await context.getOrCreateUserSandbox(undefined);
+        const checkResult = await realm.callFunction(
+          isShadowRoot
+            ? '(node) => node instanceof ShadowRoot'
+            : '(node) => node instanceof Element',
+          false,
+          {type: 'undefined'},
+          [{sharedId: startElementId}],
+          Script.ResultOwnership.None,
+          {},
+          false,
+        );
+        if (
+          checkResult.type !== 'success' ||
+          checkResult.result.type !== 'boolean' ||
+          checkResult.result.value !== true
+        ) {
+          return {
+            status: 404,
+            body: {
+              value: {
+                error: isShadowRoot ? 'no such shadow root' : 'no such element',
+                message: isShadowRoot
+                  ? `Node ${startElementId} is not a ShadowRoot`
+                  : `Node ${startElementId} is not an Element`,
+                stacktrace: '',
+              },
+            },
+          };
+        }
+      }
+
+      const locator = this.#classicToBidiLocator(params.using, params.value);
+      const startNodes:
+        | [Script.SharedReference, ...Script.SharedReference[]]
+        | undefined = startElementId ? [{sharedId: startElementId}] : undefined;
+      const result = await context.locateNodes({
+        context: context.id,
+        locator,
+        startNodes,
+        maxNodeCount: 1,
+      });
+      if (!result.nodes.length || !result.nodes[0]?.sharedId) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such element',
+              message: `Element not found using ${params.using}: ${params.value}`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+      return {
+        status: 200,
+        body: {
+          value: {
+            'element-6066-11e4-a52e-4f735466cecf': result.nodes[0].sharedId,
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicFindElements(
+    input: unknown,
+    startElementId?: string,
+    isShadowRoot = false,
+  ): Promise<ClassicResponse> {
+    const params = input as {using?: unknown; value?: unknown} | undefined;
+    if (
+      typeof params?.using !== 'string' ||
+      typeof params?.value !== 'string'
+    ) {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'using and value parameters must be strings',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const context = this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      if (startElementId) {
+        const realm = await context.getOrCreateUserSandbox(undefined);
+        const checkResult = await realm.callFunction(
+          isShadowRoot
+            ? '(node) => node instanceof ShadowRoot'
+            : '(node) => node instanceof Element',
+          false,
+          {type: 'undefined'},
+          [{sharedId: startElementId}],
+          Script.ResultOwnership.None,
+          {},
+          false,
+        );
+        if (
+          checkResult.type !== 'success' ||
+          checkResult.result.type !== 'boolean' ||
+          checkResult.result.value !== true
+        ) {
+          return {
+            status: 404,
+            body: {
+              value: {
+                error: isShadowRoot ? 'no such shadow root' : 'no such element',
+                message: isShadowRoot
+                  ? `Node ${startElementId} is not a ShadowRoot`
+                  : `Node ${startElementId} is not an Element`,
+                stacktrace: '',
+              },
+            },
+          };
+        }
+      }
+
+      const locator = this.#classicToBidiLocator(params.using, params.value);
+      const startNodes:
+        | [Script.SharedReference, ...Script.SharedReference[]]
+        | undefined = startElementId ? [{sharedId: startElementId}] : undefined;
+      const result = await context.locateNodes({
+        context: context.id,
+        locator,
+        startNodes,
+      });
+      const elements = result.nodes
+        .filter((node) => node.sharedId)
+        .map((node) => ({
+          'element-6066-11e4-a52e-4f735466cecf': node.sharedId!,
+        }));
+      return {
+        status: 200,
+        body: {
+          value: elements,
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  #classicToBidiLocator(using: string, value: string): BrowsingContext.Locator {
+    switch (using) {
+      case 'css selector':
+        return {type: 'css', value};
+      case 'xpath':
+        return {type: 'xpath', value};
+      case 'tag name':
+        return {type: 'css', value};
+      case 'link text':
+        return {type: 'innerText', value, matchType: 'full'};
+      case 'partial link text':
+        return {type: 'innerText', value, matchType: 'partial'};
+      case 'id':
+        return {type: 'css', value: `[id="${value.replace(/"/g, '\\"')}"]`};
+      case 'name':
+        return {type: 'css', value: `[name="${value.replace(/"/g, '\\"')}"]`};
+      case 'class name':
+        return {type: 'css', value: `.${value.replace(/ /g, '.')}`};
+      default:
+        throw new InvalidArgumentException(
+          `Unsupported locator strategy: ${using}`,
+        );
+    }
+  }
+
+  async classicGetActiveElement(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const realm = await context.getOrCreateUserSandbox(undefined);
+      const evalResult = await realm.evaluate(
+        'document.activeElement',
+        false,
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+      if (
+        evalResult.type === 'success' &&
+        evalResult.result.type === 'node' &&
+        evalResult.result.sharedId
+      ) {
+        return {
+          status: 200,
+          body: {
+            value: {
+              'element-6066-11e4-a52e-4f735466cecf': evalResult.result.sharedId,
+            },
+          },
+        };
+      }
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such element',
+            message: 'Active element not found',
+            stacktrace: '',
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicGetElementShadowRoot(
+    elementId: string,
+  ): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const realm = await context.getOrCreateUserSandbox(undefined);
+      const evalResult = await realm.callFunction(
+        '(element) => { const sr = element.shadowRoot; return (sr && sr.mode === "open") ? sr : null; }',
+        false,
+        {type: 'undefined'},
+        [{sharedId: elementId}],
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+      if (
+        evalResult.type === 'success' &&
+        evalResult.result.type === 'node' &&
+        evalResult.result.sharedId
+      ) {
+        return {
+          status: 200,
+          body: {
+            value: {
+              'shadow-6066-11e4-a52e-4f735466cecf': evalResult.result.sharedId,
+            },
+          },
+        };
+      }
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such shadow root',
+            message: `Shadow root not found for element ${elementId}`,
+            stacktrace: '',
+          },
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such element',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  classicGetWindowHandle(): ClassicResponse {
+    const context = this.#browsingContextStorage.getActiveContext();
     if (!context) {
       return {
         status: 404,
@@ -510,15 +1303,25 @@ export class BrowsingContextProcessor {
     return {
       status: 200,
       body: {
-        value: this.#browsingContextStorage.getTopLevelContexts().map((c) => c.id),
+        value: this.#browsingContextStorage
+          .getTopLevelContexts()
+          .map((c) => c.id),
       },
     };
   }
 
   async classicNewWindow(typeHint: unknown): Promise<ClassicResponse> {
     try {
-      const type = typeHint === 'window' ? BrowsingContext.CreateType.Window : BrowsingContext.CreateType.Tab;
-      const res = await this.create({type, referenceContext: undefined, userContext: 'default', background: false});
+      const type =
+        typeHint === 'window'
+          ? BrowsingContext.CreateType.Window
+          : BrowsingContext.CreateType.Tab;
+      const res = await this.create({
+        type,
+        referenceContext: undefined,
+        userContext: 'default',
+        background: false,
+      });
       return {
         status: 200,
         body: {
@@ -599,7 +1402,9 @@ export class BrowsingContextProcessor {
         },
       };
     }
-    const target = this.#browsingContextStorage.getTopLevelContexts().find(c => c.id === handleInput);
+    const target = this.#browsingContextStorage
+      .getTopLevelContexts()
+      .find((c) => c.id === handleInput);
     if (!target) {
       return {
         status: 404,
@@ -619,7 +1424,7 @@ export class BrowsingContextProcessor {
     };
   }
 
-  classicSwitchToFrame(frameInput: unknown): ClassicResponse {
+  async classicSwitchToFrame(frameInput: unknown): Promise<ClassicResponse> {
     const active =
       this.#browsingContextStorage.getActiveContext() ??
       this.#browsingContextStorage.getActiveTopLevelContext();
@@ -662,12 +1467,43 @@ export class BrowsingContextProcessor {
         body: {value: null},
       };
     }
-    if (typeof frameInput === 'object' && frameInput !== null && children.length === 1) {
-      this.#browsingContextStorage.setActiveContextId(children[0]?.id);
-      return {
-        status: 200,
-        body: {value: null},
-      };
+    if (typeof frameInput === 'object' && frameInput !== null) {
+      const elementId =
+        (frameInput as Record<string, string>)[
+          'element-6066-11e4-a52e-4f735466cecf'
+        ] ?? (frameInput as Record<string, string>)['sharedId'];
+      if (elementId) {
+        try {
+          const realm = await active.getOrCreateUserSandbox(undefined);
+          const result = await realm.callFunction(
+            '(element) => Array.from(window.frames).indexOf(element.contentWindow)',
+            false,
+            {type: 'undefined'},
+            [{sharedId: elementId}],
+            Script.ResultOwnership.None,
+            {},
+            false,
+          );
+          if (
+            result.type === 'success' &&
+            result.result.type === 'number' &&
+            typeof result.result.value === 'number' &&
+            result.result.value >= 0 &&
+            result.result.value < children.length
+          ) {
+            const childContext = children[result.result.value];
+            if (childContext) {
+              this.#browsingContextStorage.setActiveContextId(childContext.id);
+              return {
+                status: 200,
+                body: {value: null},
+              };
+            }
+          }
+        } catch {
+          // Fallthrough
+        }
+      }
     }
     return {
       status: 404,
@@ -682,9 +1518,7 @@ export class BrowsingContextProcessor {
   }
 
   classicSwitchToParentFrame(): ClassicResponse {
-    const active =
-      this.#browsingContextStorage.getActiveContext() ??
-      this.#browsingContextStorage.getActiveTopLevelContext();
+    const active = this.#browsingContextStorage.getActiveContext();
     if (!active) {
       return {
         status: 404,
@@ -709,9 +1543,7 @@ export class BrowsingContextProcessor {
   }
 
   async classicHandleAlert(accept: boolean): Promise<ClassicResponse> {
-    const active =
-      this.#browsingContextStorage.getActiveContext() ??
-      this.#browsingContextStorage.getActiveTopLevelContext();
+    const active = this.#browsingContextStorage.getActiveContext();
     if (!active) {
       return {
         status: 404,
@@ -745,9 +1577,7 @@ export class BrowsingContextProcessor {
   }
 
   classicGetAlertText(): ClassicResponse {
-    const active =
-      this.#browsingContextStorage.getActiveContext() ??
-      this.#browsingContextStorage.getActiveTopLevelContext();
+    const active = this.#browsingContextStorage.getActiveContext();
     if (!active || active.activeUserPromptMessage === undefined) {
       return {
         status: 404,
@@ -766,6 +1596,53 @@ export class BrowsingContextProcessor {
         value: active.activeUserPromptMessage,
       },
     };
+  }
+
+  async classicSendAlertText(textInput: unknown): Promise<ClassicResponse> {
+    const params = textInput as {text?: unknown} | undefined;
+    if (typeof params?.text !== 'string') {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'text parameter must be a string',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const active = this.#browsingContextStorage.getActiveContext();
+    if (!active) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await active.handleUserPrompt(undefined, params.text);
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such alert',
+            message: 'No user prompt is currently showing',
+            stacktrace: '',
+          },
+        },
+      };
+    }
   }
 
   #onContextCreatedSubscribeHook(
@@ -787,5 +1664,409 @@ export class BrowsingContextProcessor {
       );
     });
     return Promise.resolve();
+  }
+
+  async #classicEvaluateOnElement(
+    elementId: string,
+    expression: string,
+    args: Script.LocalValue[] = [],
+  ): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const realm = await context.getOrCreateUserSandbox(undefined);
+      const checkNodeResult = await realm.callFunction(
+        '(node) => { if (!node) return 1; if (node.nodeType !== 1) return 2; return 0; }',
+        false,
+        {type: 'undefined'},
+        [{sharedId: elementId}],
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+      if (
+        checkNodeResult.type !== 'success' ||
+        checkNodeResult.result.type !== 'number' ||
+        checkNodeResult.result.value !== 0
+      ) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such element',
+              message: `Element ${elementId} not found`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+
+      const evalResult = await realm.callFunction(
+        expression,
+        false,
+        {type: 'undefined'},
+        [{sharedId: elementId}, ...args],
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+
+      if (evalResult.type === 'success') {
+        if (evalResult.result.type === 'string') {
+          try {
+            const parsed = JSON.parse(evalResult.result.value);
+            return {
+              status: 200,
+              body: {value: parsed},
+            };
+          } catch {
+            return {
+              status: 200,
+              body: {value: evalResult.result.value},
+            };
+          }
+        }
+        let val: unknown = null;
+        if ('value' in evalResult.result) {
+          val = evalResult.result.value;
+        }
+        return {
+          status: 200,
+          body: {value: val},
+        };
+      }
+
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: 'Failed to evaluate script on element',
+            stacktrace: '',
+          },
+        },
+      };
+    } catch (e: unknown) {
+      if (
+        e instanceof NoSuchHandleException ||
+        e instanceof InvalidArgumentException
+      ) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such element',
+              message: `Element ${elementId} not found`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicIsElementSelected(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { if (element.tagName === "OPTION") return element.selected; if (element.tagName === "INPUT" && (element.type === "checkbox" || element.type === "radio")) return element.checked; return false; })())',
+    );
+  }
+
+  async classicGetElementAttribute(
+    elementId: string,
+    name: string,
+  ): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element, attrName) => JSON.stringify((() => { if (!element.hasAttribute(attrName)) return null; return element.getAttribute(attrName); })())',
+      [{type: 'string', value: name}],
+    );
+  }
+
+  async classicGetElementProperty(
+    elementId: string,
+    name: string,
+  ): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element, propName) => JSON.stringify((() => { const val = element[propName]; return val === undefined ? null : val; })())',
+      [{type: 'string', value: name}],
+    );
+  }
+
+  async classicGetElementCSSValue(
+    elementId: string,
+    propertyName: string,
+  ): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element, prop) => JSON.stringify((() => { return window.getComputedStyle(element).getPropertyValue(prop); })())',
+      [{type: 'string', value: propertyName}],
+    );
+  }
+
+  async classicGetElementText(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { if (element.ownerDocument && element.ownerDocument.contentType && element.ownerDocument.contentType.includes("xml")) { return element.textContent ?? ""; } return element.innerText ?? element.textContent ?? ""; })())',
+    );
+  }
+
+  async classicGetElementTagName(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { return element.tagName; })())',
+    );
+  }
+
+  async classicGetElementRect(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { const rect = element.getBoundingClientRect(); return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }; })())',
+    );
+  }
+
+  async classicIsElementEnabled(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { if ("disabled" in element) return !element.disabled; return true; })())',
+    );
+  }
+
+  async classicGetComputedLabel(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { return element.computedName ?? ""; })())',
+    );
+  }
+
+  async classicGetComputedRole(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element) => JSON.stringify((() => { return element.computedRole ?? ""; })())',
+    );
+  }
+
+  async classicTakeScreenshot(): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const result = await context.top.captureScreenshot({
+        context: context.top.id,
+        origin: 'viewport',
+      });
+      return {
+        status: 200,
+        body: {
+          value: result.data,
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicTakeElementScreenshot(
+    elementId: string,
+  ): Promise<ClassicResponse> {
+    const context = await this.classicGetActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const realm = await context.getOrCreateUserSandbox(undefined);
+      const checkNodeResult = await realm.callFunction(
+        `(node) => {
+          if (!node) return 1;
+          if (node.nodeType !== 1) return 2;
+          let curr = node;
+          while (curr) {
+            if (curr.style) {
+              curr.style.scrollBehavior = 'auto';
+            }
+            curr = curr.parentElement;
+          }
+          node.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
+          return 0;
+        }`,
+        false,
+        {type: 'undefined'},
+        [{sharedId: elementId}],
+        Script.ResultOwnership.None,
+        {},
+        false,
+      );
+      if (
+        checkNodeResult.type !== 'success' ||
+        checkNodeResult.result.type !== 'number' ||
+        checkNodeResult.result.value !== 0
+      ) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such element',
+              message: `Element ${elementId} not found`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+
+      const result = await context.top.captureScreenshot({
+        context: context.top.id,
+        clip: {
+          type: 'element',
+          element: {sharedId: elementId},
+        },
+      });
+
+      return {
+        status: 200,
+        body: {
+          value: result.data,
+        },
+      };
+    } catch (e: unknown) {
+      if (
+        e instanceof NoSuchHandleException ||
+        e instanceof InvalidArgumentException ||
+        e instanceof NoSuchElementException
+      ) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such element',
+              message: `Element ${elementId} not found`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicElementClick(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      `(element) => JSON.stringify((() => {
+        let curr = element;
+        while (curr) {
+          if (curr.style) {
+            curr.style.scrollBehavior = 'auto';
+          }
+          curr = curr.parentElement;
+        }
+        element.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
+        element.click();
+        return null;
+      })())`,
+    );
+  }
+
+  async classicElementClear(elementId: string): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      `(element) => JSON.stringify((() => {
+        let curr = element;
+        while (curr) {
+          if (curr.style) {
+            curr.style.scrollBehavior = 'auto';
+          }
+          curr = curr.parentElement;
+        }
+        element.scrollIntoView({block: 'center', inline: 'center', behavior: 'instant'});
+        element.focus();
+        if (element.isContentEditable) {
+          element.innerHTML = '';
+          element.blur();
+          return null;
+        }
+        if ('value' in element) {
+          element.value = '';
+          element.dispatchEvent(new Event('input', {bubbles: true}));
+          element.dispatchEvent(new Event('change', {bubbles: true}));
+          element.blur();
+          return null;
+        }
+        element.blur();
+        return null;
+      })())`,
+    );
+  }
+
+  async classicElementValue(
+    elementId: string,
+    text: string,
+  ): Promise<ClassicResponse> {
+    return await this.#classicEvaluateOnElement(
+      elementId,
+      '(element, valText) => JSON.stringify((() => { element.focus(); if ("value" in element) { element.value += valText; element.dispatchEvent(new Event("input", {bubbles: true})); element.dispatchEvent(new Event("change", {bubbles: true})); return null; } if (element.isContentEditable) { element.innerText += valText; return null; } return null; })())',
+      [{type: 'string', value: text}],
+    );
   }
 }

--- a/src/bidiMapper/modules/context/BrowsingContextStorage.test.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextStorage.test.ts
@@ -30,6 +30,13 @@ describe('BrowsingContextStorage', () => {
   it('initial state', () => {
     assert.isEmpty(browsingContextStorage.getAllContexts());
     assert.isEmpty(browsingContextStorage.getTopLevelContexts());
+    assert.isUndefined(browsingContextStorage.getActiveTopLevelContext());
+  });
+
+  describe('active top-level context', () => {
+    it('returns undefined when no contexts exist', () => {
+      assert.isUndefined(browsingContextStorage.getActiveTopLevelContext());
+    });
   });
 
   describe('find top-level context ID', () => {

--- a/src/bidiMapper/modules/context/BrowsingContextStorage.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextStorage.ts
@@ -77,7 +77,10 @@ export class BrowsingContextStorage {
 
   getActiveContext(): BrowsingContextImpl | undefined {
     if (this.#activeContextId !== undefined) {
-      return this.#contexts.get(this.#activeContextId);
+      const context = this.#contexts.get(this.#activeContextId);
+      if (context) {
+        return context;
+      }
     }
     return this.getActiveTopLevelContext();
   }
@@ -90,6 +93,9 @@ export class BrowsingContextStorage {
   /** Deletes the context with the given ID. */
   deleteContextById(id: BrowsingContext.BrowsingContext) {
     this.#contexts.delete(id);
+    if (this.#activeContextId === id) {
+      this.#activeContextId = undefined;
+    }
   }
 
   /** Deletes the given context. */

--- a/src/bidiMapper/modules/context/BrowsingContextStorage.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextStorage.ts
@@ -56,11 +56,16 @@ export class BrowsingContextStorage {
   }
 
   getActiveTopLevelContext(): BrowsingContextImpl | undefined {
-    if (this.#activeContextId && this.#contexts.has(this.#activeContextId)) {
-      const context = this.#contexts.get(this.#activeContextId)!;
-      if (context.isTopLevelContext()) {
-        return context;
+    if (this.#activeContextId !== undefined) {
+      const context = this.#contexts.get(this.#activeContextId);
+      if (context) {
+        if (context.isTopLevelContext()) {
+          return context;
+        }
+        const topId = this.findTopLevelContextId(context.id);
+        return topId ? this.findContext(topId) : undefined;
       }
+      return undefined;
     }
     const topLevel = this.getTopLevelContexts();
     if (topLevel.length > 0) {
@@ -71,7 +76,7 @@ export class BrowsingContextStorage {
   }
 
   getActiveContext(): BrowsingContextImpl | undefined {
-    if (this.#activeContextId && this.#contexts.has(this.#activeContextId)) {
+    if (this.#activeContextId !== undefined) {
       return this.#contexts.get(this.#activeContextId);
     }
     return this.getActiveTopLevelContext();
@@ -85,10 +90,6 @@ export class BrowsingContextStorage {
   /** Deletes the context with the given ID. */
   deleteContextById(id: BrowsingContext.BrowsingContext) {
     this.#contexts.delete(id);
-    if (this.#activeContextId === id) {
-      const topLevel = this.getTopLevelContexts();
-      this.setActiveContextId(topLevel[0]?.id);
-    }
   }
 
   /** Deletes the given context. */

--- a/src/bidiMapper/modules/context/BrowsingContextStorage.ts
+++ b/src/bidiMapper/modules/context/BrowsingContextStorage.ts
@@ -42,12 +42,39 @@ export class BrowsingContextStorage {
   /** Event emitter for browsing context storage eventsis not expected to be exposed to
    * the outside world. */
   readonly #eventEmitter = new EventEmitter<BrowsingContextStorageEvent>();
+  #activeContextId?: BrowsingContext.BrowsingContext;
 
   /** Gets all top-level contexts, i.e. those with no parent. */
   getTopLevelContexts(): BrowsingContextImpl[] {
     return this.getAllContexts().filter((context) =>
       context.isTopLevelContext(),
     );
+  }
+
+  setActiveContextId(id?: BrowsingContext.BrowsingContext) {
+    this.#activeContextId = id;
+  }
+
+  getActiveTopLevelContext(): BrowsingContextImpl | undefined {
+    if (this.#activeContextId && this.#contexts.has(this.#activeContextId)) {
+      const context = this.#contexts.get(this.#activeContextId)!;
+      if (context.isTopLevelContext()) {
+        return context;
+      }
+    }
+    const topLevel = this.getTopLevelContexts();
+    if (topLevel.length > 0) {
+      this.setActiveContextId(topLevel[0]?.id);
+      return topLevel[0];
+    }
+    return undefined;
+  }
+
+  getActiveContext(): BrowsingContextImpl | undefined {
+    if (this.#activeContextId && this.#contexts.has(this.#activeContextId)) {
+      return this.#contexts.get(this.#activeContextId);
+    }
+    return this.getActiveTopLevelContext();
   }
 
   /** Gets all contexts. */
@@ -58,16 +85,23 @@ export class BrowsingContextStorage {
   /** Deletes the context with the given ID. */
   deleteContextById(id: BrowsingContext.BrowsingContext) {
     this.#contexts.delete(id);
+    if (this.#activeContextId === id) {
+      const topLevel = this.getTopLevelContexts();
+      this.setActiveContextId(topLevel[0]?.id);
+    }
   }
 
   /** Deletes the given context. */
   deleteContext(context: BrowsingContextImpl) {
-    this.#contexts.delete(context.id);
+    this.deleteContextById(context.id);
   }
 
   /** Tracks the given context. */
   addContext(context: BrowsingContextImpl) {
     this.#contexts.set(context.id, context);
+    if (context.isTopLevelContext() && !this.#activeContextId) {
+      this.setActiveContextId(context.id);
+    }
     this.#eventEmitter.emit(BrowsingContextStorageEvents.Added, {
       browsingContext: context,
     });

--- a/src/bidiMapper/modules/input/InputProcessor.ts
+++ b/src/bidiMapper/modules/input/InputProcessor.ts
@@ -24,6 +24,7 @@ import {
   NoSuchNodeException,
 } from '../../../protocol/protocol.js';
 import {assert} from '../../../utils/assert.js';
+import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
 import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
 import {ActionDispatcher} from '../input/ActionDispatcher.js';
 import type {ActionOption} from '../input/ActionOption.js';
@@ -31,13 +32,20 @@ import {SourceType} from '../input/InputSource.js';
 import type {InputState} from '../input/InputState.js';
 import {InputStateManager} from '../input/InputStateManager.js';
 
+import type {ClassicResponse} from '../../ClassicTransport.js';
+
 export class InputProcessor {
   readonly #browsingContextStorage: BrowsingContextStorage;
+  readonly #getActiveContext?: () => Promise<BrowsingContextImpl | undefined>;
 
   readonly #inputStateManager = new InputStateManager();
 
-  constructor(browsingContextStorage: BrowsingContextStorage) {
+  constructor(
+    browsingContextStorage: BrowsingContextStorage,
+    getActiveContext?: () => Promise<BrowsingContextImpl | undefined>,
+  ) {
     this.#browsingContextStorage = browsingContextStorage;
+    this.#getActiveContext = getActiveContext;
   }
 
   async performActions(
@@ -71,6 +79,116 @@ export class InputProcessor {
     await dispatcher.dispatchTickActions(inputState.cancelList.reverse());
     this.#inputStateManager.delete(topContext);
     return {};
+  }
+
+  async classicPerformActions(body: unknown): Promise<ClassicResponse> {
+    const context = this.#getActiveContext
+      ? await this.#getActiveContext()
+      : this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const params = body as {actions?: unknown} | undefined;
+    if (!params || !Array.isArray(params.actions)) {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'actions must be an array',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await this.performActions({
+        context: context.id,
+        actions: params.actions as any,
+      });
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      if (
+        e instanceof InvalidArgumentException ||
+        e instanceof NoSuchElementException ||
+        e instanceof NoSuchNodeException
+      ) {
+        return {
+          status:
+            e instanceof NoSuchElementException ||
+            e instanceof NoSuchNodeException
+              ? 404
+              : 400,
+          body: {
+            value: {
+              error: e.error,
+              message: e.message,
+              stacktrace: e.stack ?? '',
+            },
+          },
+        };
+      }
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicReleaseActions(): Promise<ClassicResponse> {
+    const context = this.#getActiveContext
+      ? await this.#getActiveContext()
+      : this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await this.releaseActions({context: context.id});
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
   }
 
   async setFiles(params: Input.SetFilesParameters): Promise<EmptyResult> {

--- a/src/bidiMapper/modules/network/NetworkStorage.test.ts
+++ b/src/bidiMapper/modules/network/NetworkStorage.test.ts
@@ -78,6 +78,7 @@ describe('NetworkStorage', () => {
     const browsingContext = {
       cdpTarget,
       id: MockCdpNetworkEvents.defaultFrameId,
+      isTopLevelContext: () => true,
     } as unknown as BrowsingContextImpl;
     cdpClient = cdpTarget.cdpClient;
     const userContextStorage = new UserContextStorage(cdpClient);

--- a/src/bidiMapper/modules/script/ScriptProcessor.ts
+++ b/src/bidiMapper/modules/script/ScriptProcessor.ts
@@ -26,7 +26,10 @@ import type {LoggerFn} from '../../../utils/log.js';
 import type {UserContextStorage} from '../browser/UserContextStorage.js';
 import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
 import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
-import {type EventManager, EventManagerEvents} from '../session/EventManager.js';
+import {
+  type EventManager,
+  EventManagerEvents,
+} from '../session/EventManager.js';
 
 import type {ClassicResponse} from '../../ClassicTransport.js';
 import {PreloadScript} from './PreloadScript.js';

--- a/src/bidiMapper/modules/script/ScriptProcessor.ts
+++ b/src/bidiMapper/modules/script/ScriptProcessor.ts
@@ -26,8 +26,9 @@ import type {LoggerFn} from '../../../utils/log.js';
 import type {UserContextStorage} from '../browser/UserContextStorage.js';
 import type {BrowsingContextImpl} from '../context/BrowsingContextImpl.js';
 import type {BrowsingContextStorage} from '../context/BrowsingContextStorage.js';
-import type {EventManager} from '../session/EventManager.js';
+import {type EventManager, EventManagerEvents} from '../session/EventManager.js';
 
+import type {ClassicResponse} from '../../ClassicTransport.js';
 import {PreloadScript} from './PreloadScript.js';
 import type {PreloadScriptStorage} from './PreloadScriptStorage.js';
 import type {Realm} from './Realm.js';
@@ -210,5 +211,344 @@ export class ScriptProcessor {
       realmId: target.realm,
       isHidden: false,
     });
+  }
+
+  async classicExecuteScript(
+    script: string,
+    argsInput?: unknown[],
+  ): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const realm = await context.getOrCreateUserSandbox(undefined);
+    const functionDeclaration = `function() {\n${script}\n}`;
+    const args = Array.isArray(argsInput)
+      ? argsInput.map((a) => this.#serializeLocalValue(a))
+      : [];
+
+    const result = await this.#raceWithUserPrompt(realm, [
+      functionDeclaration,
+      false, // awaitPromise
+      {type: 'undefined'},
+      args,
+      'none' as Script.ResultOwnership,
+      {},
+      true, // userActivation
+    ]);
+
+    if ('type' in result && result.type === 'promptOpened') {
+      return {
+        status: 200,
+        body: {
+          value: null,
+        },
+      };
+    }
+
+    if (result.type === 'exception') {
+      const exceptionDetails = result.exceptionDetails;
+      const exceptionVal = exceptionDetails.exception as any;
+      const message =
+        exceptionDetails.text ??
+        exceptionVal?.description ??
+        (exceptionVal?.value ? String(exceptionVal.value) : undefined) ??
+        'JavaScript Error in executeScript';
+      const stacktrace =
+        exceptionDetails.stackTrace?.callFrames
+          .map(
+            (f) =>
+              `${f.functionName}@${f.url}:${f.lineNumber}:${f.columnNumber}`,
+          )
+          .join('\n') ?? '';
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'javascript error',
+            message,
+            stacktrace,
+          },
+        },
+      };
+    }
+
+    return {
+      status: 200,
+      body: {
+        value: this.#deserializeRemoteValue(result.result),
+      },
+    };
+  }
+
+  async classicExecuteAsyncScript(
+    script: string,
+    argsInput?: unknown[],
+    timeoutMs?: number | null,
+  ): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const realm = await context.getOrCreateUserSandbox(undefined);
+    const functionDeclaration = `function() {
+      return new Promise((resolve, reject) => {
+        let timer;
+        if (typeof ${timeoutMs ?? 'null'} === 'number' && ${timeoutMs ?? 'null'} >= 0) {
+          timer = setTimeout(() => {
+            reject(new Error('script timeout: Script evaluation timed out'));
+          }, ${timeoutMs ?? 0});
+        }
+        const callback = (res) => {
+          if (timer) clearTimeout(timer);
+          resolve(res);
+        };
+        try {
+          const func = function() {\n${script}\n};
+          func.apply(this, [...arguments, callback]);
+        } catch (e) {
+          if (timer) clearTimeout(timer);
+          reject(e);
+        }
+      });
+    }`;
+    const args = Array.isArray(argsInput)
+      ? argsInput.map((a) => this.#serializeLocalValue(a))
+      : [];
+
+    const result = await this.#raceWithUserPrompt(realm, [
+      functionDeclaration,
+      true, // awaitPromise
+      {type: 'undefined'},
+      args,
+      'none' as Script.ResultOwnership,
+      {},
+      true, // userActivation
+    ]);
+
+    if ('type' in result && result.type === 'promptOpened') {
+      return {
+        status: 200,
+        body: {
+          value: null,
+        },
+      };
+    }
+
+    if (result.type === 'exception') {
+      const exceptionDetails = result.exceptionDetails;
+      const exceptionVal = exceptionDetails.exception as any;
+      const message =
+        exceptionDetails.text ??
+        exceptionVal?.description ??
+        (exceptionVal?.value ? String(exceptionVal.value) : undefined) ??
+        'JavaScript Error in executeAsyncScript';
+      const stacktrace =
+        exceptionDetails.stackTrace?.callFrames
+          .map(
+            (f) =>
+              `${f.functionName}@${f.url}:${f.lineNumber}:${f.columnNumber}`,
+          )
+          .join('\n') ?? '';
+      if (String(message).includes('script timeout')) {
+        return {
+          status: 500,
+          body: {
+            value: {
+              error: 'script timeout',
+              message: 'Script evaluation timed out',
+              stacktrace,
+            },
+          },
+        };
+      }
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'javascript error',
+            message,
+            stacktrace,
+          },
+        },
+      };
+    }
+
+    return {
+      status: 200,
+      body: {
+        value: this.#deserializeRemoteValue(result.result),
+      },
+    };
+  }
+
+  async #raceWithUserPrompt(
+    realm: Realm,
+    callFunctionArgs: Parameters<Realm['callFunction']>,
+  ): Promise<Script.EvaluateResult | {type: 'promptOpened'}> {
+    let removeListener: () => void = () => {};
+    const promptPromise = new Promise<{type: 'promptOpened'}>((resolve) => {
+      const listener = (event: any) => {
+        if (
+          event.method ===
+          ChromiumBidi.BrowsingContext.EventNames.UserPromptOpened
+        ) {
+          resolve({type: 'promptOpened'});
+        }
+      };
+      this.#eventManager.on(EventManagerEvents.RegisteredEvent, listener);
+      removeListener = () => {
+        this.#eventManager.off(EventManagerEvents.RegisteredEvent, listener);
+      };
+    });
+
+    try {
+      return await Promise.race([
+        realm.callFunction(...callFunctionArgs),
+        promptPromise,
+      ]);
+    } finally {
+      removeListener();
+    }
+  }
+
+  #serializeLocalValue(val: unknown): Script.LocalValue {
+    if (val === null || val === undefined) {
+      return {type: 'null'};
+    }
+    if (typeof val === 'number') {
+      if (Number.isNaN(val)) {
+        return {type: 'number', value: 'NaN'};
+      }
+      if (!Number.isFinite(val)) {
+        return {type: 'number', value: val < 0 ? '-Infinity' : 'Infinity'};
+      }
+      return {type: 'number', value: val};
+    }
+    if (typeof val === 'string') {
+      return {type: 'string', value: val};
+    }
+    if (typeof val === 'boolean') {
+      return {type: 'boolean', value: val};
+    }
+    if (Array.isArray(val)) {
+      return {
+        type: 'array',
+        value: val.map((item) => this.#serializeLocalValue(item)),
+      };
+    }
+    if (typeof val === 'object') {
+      const rec = val as Record<string, unknown>;
+      const elementId =
+        rec['element-6066-11e4-a52e-4f735466cecf'] ??
+        rec['ELEMENT'] ??
+        rec['shadow-6066-11e4-a52e-4f735466cecf'];
+      if (typeof elementId === 'string') {
+        return {
+          sharedId: elementId,
+        };
+      }
+      const windowId =
+        rec['window-fcc6-11e5-b4f8-330a88ab9d7f'] ??
+        rec['frame-075b-4da1-b6ba-e579c2d3230a'];
+      if (typeof windowId === 'string') {
+        return {
+          handle: windowId,
+          sharedId: windowId,
+        } as unknown as Script.LocalValue;
+      }
+      const objValue: [string, Script.LocalValue][] = [];
+      for (const [k, v] of Object.entries(rec)) {
+        objValue.push([k, this.#serializeLocalValue(v)]);
+      }
+      return {type: 'object', value: objValue};
+    }
+    return {type: 'undefined'};
+  }
+
+  #deserializeRemoteValue(remote: Script.RemoteValue): unknown {
+    switch (remote.type) {
+      case 'number':
+      case 'string':
+      case 'boolean':
+        return remote.value;
+      case 'null':
+      case 'undefined':
+        return null;
+      case 'array':
+      case 'set':
+      case 'nodelist':
+      case 'htmlcollection':
+        return (remote.value ?? []).map((item: Script.RemoteValue) =>
+          this.#deserializeRemoteValue(item),
+        );
+      case 'node':
+        if ('sharedId' in remote && remote.sharedId) {
+          if (remote.value?.nodeType === 11) {
+            return {
+              'shadow-6066-11e4-a52e-4f735466cecf': remote.sharedId,
+            };
+          }
+          return {
+            'element-6066-11e4-a52e-4f735466cecf': remote.sharedId,
+            ELEMENT: remote.sharedId,
+          };
+        }
+        return null;
+      case 'window': {
+        const contextId = remote.value.context;
+        const ctx = this.#browsingContextStorage.findContext(contextId);
+        const id = remote.handle ?? (remote as any).sharedId ?? contextId;
+        if (!ctx || ctx.isTopLevelContext()) {
+          return {
+            'window-fcc6-11e5-b4f8-330a88ab9d7f': id,
+          };
+        }
+        return {
+          'frame-075b-4da1-b6ba-e579c2d3230a': id,
+        };
+      }
+      case 'object':
+      case 'map': {
+        const result: Record<string, unknown> = {};
+        for (const entry of remote.value ?? []) {
+          if (Array.isArray(entry) && entry.length === 2) {
+            const entryKey = entry[0] as any;
+            const key =
+              typeof entryKey === 'string'
+                ? entryKey
+                : 'value' in entryKey
+                  ? entryKey.value
+                  : String(entryKey.type);
+            if (key !== undefined && key !== null) {
+              result[String(key)] = this.#deserializeRemoteValue(
+                entry[1] as Script.RemoteValue,
+              );
+            }
+          }
+        }
+        return result;
+      }
+      default:
+        return ('value' in remote ? (remote as any).value : null) ?? null;
+    }
   }
 }

--- a/src/bidiMapper/modules/session/EventManager.ts
+++ b/src/bidiMapper/modules/session/EventManager.ts
@@ -66,6 +66,7 @@ class EventWrapper {
 
 export const enum EventManagerEvents {
   Event = 'event',
+  RegisteredEvent = 'registeredEvent',
 }
 
 interface EventManagerEventsMap extends Record<string | symbol, unknown> {
@@ -73,6 +74,7 @@ interface EventManagerEventsMap extends Record<string | symbol, unknown> {
     message: Promise<Result<OutgoingMessage>>;
     event: string;
   };
+  [EventManagerEvents.RegisteredEvent]: ChromiumBidi.Event;
 }
 /**
  * Maps event name to a desired buffer length.
@@ -183,6 +185,11 @@ export class EventManager extends EventEmitter<EventManagerEventsMap> {
     contextId: BrowsingContext.BrowsingContext,
     eventName: ChromiumBidi.EventNames,
   ): void {
+    void event.then((res) => {
+      if (res.kind === 'success') {
+        this.emit(EventManagerEvents.RegisteredEvent, res.value);
+      }
+    });
     const eventWrapper = new EventWrapper(event, contextId);
     const sortedGoogChannels =
       this.#subscriptionManager.getGoogChannelsSubscribedToEvent(
@@ -204,6 +211,11 @@ export class EventManager extends EventEmitter<EventManagerEventsMap> {
     event: Promise<Result<ChromiumBidi.Event>>,
     eventName: ChromiumBidi.EventNames,
   ): void {
+    void event.then((res) => {
+      if (res.kind === 'success') {
+        this.emit(EventManagerEvents.RegisteredEvent, res.value);
+      }
+    });
     const eventWrapper = new EventWrapper(event, null);
     const sortedGoogChannels =
       this.#subscriptionManager.getGoogChannelsSubscribedToEventGlobally(

--- a/src/bidiMapper/modules/session/EventManager.ts
+++ b/src/bidiMapper/modules/session/EventManager.ts
@@ -189,6 +189,7 @@ export class EventManager extends EventEmitter<EventManagerEventsMap> {
       if (res.kind === 'success') {
         this.emit(EventManagerEvents.RegisteredEvent, res.value);
       }
+      return undefined;
     });
     const eventWrapper = new EventWrapper(event, contextId);
     const sortedGoogChannels =
@@ -215,6 +216,7 @@ export class EventManager extends EventEmitter<EventManagerEventsMap> {
       if (res.kind === 'success') {
         this.emit(EventManagerEvents.RegisteredEvent, res.value);
       }
+      return undefined;
     });
     const eventWrapper = new EventWrapper(event, null);
     const sortedGoogChannels =

--- a/src/bidiMapper/modules/storage/StorageProcessor.ts
+++ b/src/bidiMapper/modules/storage/StorageProcessor.ts
@@ -443,6 +443,17 @@ export class StorageProcessor {
         const url = new URL(context.url);
         domain = url.hostname;
       }
+      let sameSite: Network.SameSite | undefined;
+      if (typeof cookie['sameSite'] === 'string') {
+        const ss = (cookie['sameSite'] as string).toLowerCase();
+        if (ss === 'lax') {
+          sameSite = Network.SameSite.Lax;
+        } else if (ss === 'strict') {
+          sameSite = Network.SameSite.Strict;
+        } else if (ss === 'none') {
+          sameSite = Network.SameSite.None;
+        }
+      }
       await this.setCookie({
         cookie: {
           name: cookie['name'] as string,
@@ -463,6 +474,7 @@ export class StorageProcessor {
           ...(typeof cookie['expiry'] === 'number'
             ? {expiry: cookie['expiry'] as number}
             : {}),
+          ...(sameSite ? {sameSite} : {}),
         },
         partition: {type: 'context', context: context.id},
       });

--- a/src/bidiMapper/modules/storage/StorageProcessor.ts
+++ b/src/bidiMapper/modules/storage/StorageProcessor.ts
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 import type {CdpClient} from '../../../cdp/CdpClient.js';
+import type {ClassicResponse} from '../../ClassicTransport.js';
+import type {Storage} from '../../../protocol/protocol.js';
 import {
+  Network,
   NoSuchUserContextException,
   UnableToSetCookieException,
 } from '../../../protocol/protocol.js';
-import type {Storage, Network} from '../../../protocol/protocol.js';
 import {assert} from '../../../utils/assert.js';
 import type {LoggerFn} from '../../../utils/log.js';
 import {LogType} from '../../../utils/log.js';
@@ -30,6 +32,41 @@ import {
   cdpToBiDiCookie,
   deserializeByteValue,
 } from '../network/NetworkUtils.js';
+
+export interface ClassicCookie {
+  name: string;
+  value: string;
+  path?: string;
+  domain?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  expiry?: number;
+  sameSite?: 'Lax' | 'Strict' | 'None';
+}
+
+function bidiToClassicCookie(c: Network.Cookie): ClassicCookie {
+  const result: ClassicCookie = {
+    name: c.name,
+    value: c.value.value,
+    domain: c.domain,
+    path: c.path,
+    secure: c.secure,
+    httpOnly: c.httpOnly,
+  };
+  if (c.expiry !== undefined) {
+    result.expiry = c.expiry;
+  }
+  if (c.sameSite !== undefined) {
+    if (c.sameSite === Network.SameSite.Lax) {
+      result.sameSite = 'Lax';
+    } else if (c.sameSite === Network.SameSite.Strict) {
+      result.sameSite = 'Strict';
+    } else if (c.sameSite === Network.SameSite.None) {
+      result.sameSite = 'None';
+    }
+  }
+  return result;
+}
 
 /**
  * Responsible for handling the `storage` module.
@@ -269,5 +306,257 @@ export class StorageProcessor {
       (filter.sameSite === undefined || filter.sameSite === cookie.sameSite) &&
       (filter.expiry === undefined || filter.expiry === cookie.expiry)
     );
+  }
+
+  async classicGetAllCookies(): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const {cookies} = await this.getCookies({
+        partition: {type: 'context', context: context.id},
+      });
+      return {
+        status: 200,
+        body: {
+          value: cookies.map(bidiToClassicCookie),
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicGetNamedCookie(name: string): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      const {cookies} = await this.getCookies({
+        partition: {type: 'context', context: context.id},
+        filter: {name},
+      });
+      const cookie = cookies.find((c) => c.name === name);
+      if (!cookie) {
+        return {
+          status: 404,
+          body: {
+            value: {
+              error: 'no such cookie',
+              message: `Cookie '${name}' not found`,
+              stacktrace: '',
+            },
+          },
+        };
+      }
+      return {
+        status: 200,
+        body: {
+          value: bidiToClassicCookie(cookie),
+        },
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicAddCookie(cookieInput: unknown): Promise<ClassicResponse> {
+    const params = cookieInput as
+      | {cookie?: Record<string, unknown>}
+      | undefined;
+    const cookie = params?.cookie;
+    if (
+      !cookie ||
+      typeof cookie['name'] !== 'string' ||
+      typeof cookie['value'] !== 'string'
+    ) {
+      return {
+        status: 400,
+        body: {
+          value: {
+            error: 'invalid argument',
+            message: 'cookie parameters must specify name and value strings',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      let domain =
+        typeof cookie['domain'] === 'string'
+          ? (cookie['domain'] as string)
+          : undefined;
+      if (!domain) {
+        const url = new URL(context.url);
+        domain = url.hostname;
+      }
+      await this.setCookie({
+        cookie: {
+          name: cookie['name'] as string,
+          value: {type: 'string', value: cookie['value'] as string},
+          domain,
+          path:
+            typeof cookie['path'] === 'string'
+              ? (cookie['path'] as string)
+              : '/',
+          secure:
+            typeof cookie['secure'] === 'boolean'
+              ? (cookie['secure'] as boolean)
+              : false,
+          httpOnly:
+            typeof cookie['httpOnly'] === 'boolean'
+              ? (cookie['httpOnly'] as boolean)
+              : false,
+          ...(typeof cookie['expiry'] === 'number'
+            ? {expiry: cookie['expiry'] as number}
+            : {}),
+        },
+        partition: {type: 'context', context: context.id},
+      });
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unable to set cookie',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicDeleteCookie(name: string): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await this.deleteCookies({
+        partition: {type: 'context', context: context.id},
+        filter: {name},
+      });
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
+  }
+
+  async classicDeleteAllCookies(): Promise<ClassicResponse> {
+    const context = this.#browsingContextStorage.getActiveTopLevelContext();
+    if (!context) {
+      return {
+        status: 404,
+        body: {
+          value: {
+            error: 'no such window',
+            message: 'No active browsing context found',
+            stacktrace: '',
+          },
+        },
+      };
+    }
+    try {
+      await this.deleteCookies({
+        partition: {type: 'context', context: context.id},
+      });
+      return {
+        status: 200,
+        body: {value: null},
+      };
+    } catch (e: unknown) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      return {
+        status: 500,
+        body: {
+          value: {
+            error: 'unknown error',
+            message: err.message,
+            stacktrace: err.stack ?? '',
+          },
+        },
+      };
+    }
   }
 }

--- a/src/bidiServer/BrowserInstance.ts
+++ b/src/bidiServer/BrowserInstance.ts
@@ -137,6 +137,10 @@ export class BrowserInstance {
     return this.#mapperCdpConnection.bidiSession();
   }
 
+  classicSession(): SimpleTransport {
+    return this.#mapperCdpConnection.classicSession();
+  }
+
   static #establishPipeConnection(
     browserProcess: Process,
   ): MapperCdpConnection {

--- a/src/bidiServer/MapperCdpConnection.ts
+++ b/src/bidiServer/MapperCdpConnection.ts
@@ -42,6 +42,7 @@ const getLogger = (type: LogPrefix) => {
 export class MapperServerCdpConnection {
   #cdpConnection: MapperCdpConnection;
   #bidiSession: SimpleTransport;
+  #classicSession: SimpleTransport;
 
   static async create(
     cdpConnection: MapperCdpConnection,
@@ -49,12 +50,16 @@ export class MapperServerCdpConnection {
     verbose: boolean,
   ): Promise<MapperServerCdpConnection> {
     try {
-      const bidiSession = await this.#initMapper(
+      const {bidiSession, classicSession} = await this.#initMapper(
         cdpConnection,
         mapperTabSource,
         verbose,
       );
-      return new MapperServerCdpConnection(cdpConnection, bidiSession);
+      return new MapperServerCdpConnection(
+        cdpConnection,
+        bidiSession,
+        classicSession,
+      );
     } catch (e) {
       cdpConnection.close();
       throw e;
@@ -64,9 +69,11 @@ export class MapperServerCdpConnection {
   private constructor(
     cdpConnection: MapperCdpConnection,
     bidiSession: SimpleTransport,
+    classicSession: SimpleTransport,
   ) {
     this.#cdpConnection = cdpConnection;
     this.#bidiSession = bidiSession;
+    this.#classicSession = classicSession;
   }
 
   static async #sendMessage(
@@ -82,6 +89,19 @@ export class MapperServerCdpConnection {
     }
   }
 
+  static async #sendClassicMessage(
+    mapperCdpClient: MapperCdpClient,
+    message: string,
+  ): Promise<void> {
+    try {
+      await mapperCdpClient.sendCommand('Runtime.evaluate', {
+        expression: `onClassicMessage(${JSON.stringify(message)})`,
+      });
+    } catch (error) {
+      debugInternal('Call to onClassicMessage failed', error);
+    }
+  }
+
   close() {
     this.#cdpConnection.close();
   }
@@ -90,12 +110,19 @@ export class MapperServerCdpConnection {
     return this.#bidiSession;
   }
 
+  classicSession(): SimpleTransport {
+    return this.#classicSession;
+  }
+
   static #onBindingCalled = (
     params: Protocol.Runtime.BindingCalledEvent,
     bidiSession: SimpleTransport,
+    classicSession: SimpleTransport,
   ) => {
     if (params.name === 'sendBidiResponse') {
       bidiSession.emit('message', params.payload);
+    } else if (params.name === 'sendClassicResponse') {
+      classicSession.emit('message', params.payload);
     } else if (params.name === 'sendDebugMessage') {
       this.#onDebugMessage(params.payload);
     }
@@ -138,7 +165,7 @@ export class MapperServerCdpConnection {
     cdpConnection: MapperCdpConnection,
     mapperTabSource: string,
     verbose: boolean,
-  ): Promise<SimpleTransport> {
+  ): Promise<{bidiSession: SimpleTransport; classicSession: SimpleTransport}> {
     debugInternal('Initializing Mapper.');
 
     const browserClient = await cdpConnection.createBrowserSession();
@@ -162,10 +189,14 @@ export class MapperServerCdpConnection {
     const bidiSession = new SimpleTransport(
       async (message) => await this.#sendMessage(mapperCdpClient, message),
     );
+    const classicSession = new SimpleTransport(
+      async (message) =>
+        await this.#sendClassicMessage(mapperCdpClient, message),
+    );
 
     // Process responses from the mapper tab.
     mapperCdpClient.on('Runtime.bindingCalled', (params) =>
-      this.#onBindingCalled(params, bidiSession),
+      this.#onBindingCalled(params, bidiSession, classicSession),
     );
     // Forward console messages from the mapper tab.
     mapperCdpClient.on('Runtime.consoleAPICalled', this.#onConsoleAPICalled);
@@ -185,6 +216,9 @@ export class MapperServerCdpConnection {
 
     await mapperCdpClient.sendCommand('Runtime.addBinding', {
       name: 'sendBidiResponse',
+    });
+    await mapperCdpClient.sendCommand('Runtime.addBinding', {
+      name: 'sendClassicResponse',
     });
 
     if (verbose) {
@@ -206,6 +240,6 @@ export class MapperServerCdpConnection {
     });
 
     debugInternal('Mapper is launched!');
-    return bidiSession;
+    return {bidiSession, classicSession};
   }
 }

--- a/src/bidiServer/WebSocketServer.ts
+++ b/src/bidiServer/WebSocketServer.ts
@@ -19,8 +19,9 @@ import {debuglog} from 'node:util';
 
 import * as websocket from 'websocket';
 
-import {ErrorCode, type Session} from '../protocol/protocol.js';
+import {ErrorCode} from '../protocol/protocol.js';
 import {Deferred} from '../utils/Deferred.js';
+import {Mutex} from '../utils/Mutex.js';
 import {uuidv4} from '../utils/uuid.js';
 
 import {BrowserInstance, type ChromeOptions} from './BrowserInstance.js';
@@ -31,6 +32,7 @@ const debugSend = debuglog('bidi:server:SEND ▸');
 const debugRecv = debuglog('bidi:server:RECV ◂');
 
 interface Session {
+  readonly mutex: Mutex;
   sessionId: string;
   // Promise is used to decrease WebSocket handshake latency. If session is set via
   // WebDriver Classic, we need to launch Browser instance for each new WebSocket
@@ -133,11 +135,12 @@ export class WebSocketServer {
       // https://w3c.github.io/webdriver-bidi/#transport, step 3.
       const jsonBody = JSON.parse(body.toString());
       response.writeHead(200, {
-        'Content-Type': 'application/json;charset=utf-8',
+        'Content-Type': 'application/json; charset=utf-8',
         'Cache-Control': 'no-cache',
       });
       const sessionId = uuidv4();
       const session: Session = {
+        mutex: new Mutex(),
         sessionId,
         // TODO: launch browser instance and set it to the session after WPT
         //  tests clean up is switched to pure BiDi.
@@ -166,27 +169,95 @@ export class WebSocketServer {
         }),
       );
       return response.end();
-    } else if (request.url.startsWith('/session')) {
-      debugInternal(
-        `Unknown session command ${
-          request.method ?? 'UNKNOWN METHOD'
-        } request for ${
-          request.url
-        } with payload ${await this.#getHttpRequestPayload(
-          request,
-        )}. 200 returned.`,
-      );
+    } else if (request.url.startsWith('/session/')) {
+      const urlParts = request.url.split('/');
+      const sessionId = urlParts[2];
+      const commandPath = `/${urlParts.slice(3).join('/')}`;
+      const session = this.#sessions.get(sessionId ?? '');
 
-      response.writeHead(200, {
-        'Content-Type': 'application/json;charset=utf-8',
-        'Cache-Control': 'no-cache',
+      if (!session) {
+        response.writeHead(404, {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Cache-Control': 'no-cache',
+        });
+        response.write(
+          JSON.stringify({
+            value: {
+              error: 'invalid session id',
+              message: `Session ${sessionId} not found`,
+              stacktrace: '',
+            },
+          }),
+        );
+        return response.end();
+      }
+
+      await session.mutex.run(async () => {
+        if (
+          (request.method ?? 'GET').toUpperCase() === 'DELETE' &&
+          (commandPath === '/' || commandPath === '')
+        ) {
+          await this.#closeBrowserInstanceIfLaunched(session);
+          this.#sessions.delete(session.sessionId);
+          response.writeHead(200, {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Cache-Control': 'no-cache',
+          });
+          response.write(JSON.stringify({value: null}));
+          response.end();
+          return;
+        }
+
+        if (session.browserInstancePromise === undefined) {
+          session.browserInstancePromise = this.#launchBrowserInstance(
+            undefined,
+            session.sessionOptions,
+          );
+        }
+        const browserInstance = await session.browserInstancePromise;
+
+        const payloadString = await this.#getHttpRequestPayload(request);
+        let body: unknown = undefined;
+        if (payloadString.trim()) {
+          try {
+            body = JSON.parse(payloadString);
+          } catch {}
+        }
+
+        const id = uuidv4();
+        const classicReq = {
+          id,
+          method: request.method ?? 'GET',
+          path: commandPath,
+          body,
+        };
+
+        const deferred = new Deferred<string>();
+        const listener = (msg: string) => {
+          try {
+            const parsed = JSON.parse(msg);
+            if (parsed.id === id) {
+              deferred.resolve(msg);
+            }
+          } catch {}
+        };
+
+        browserInstance.classicSession().on('message', listener);
+        await browserInstance
+          .classicSession()
+          .sendCommand(JSON.stringify(classicReq));
+        const resString = await deferred;
+        browserInstance.classicSession().off('message', listener);
+
+        const parsedRes = JSON.parse(resString);
+        response.writeHead(parsedRes.status ?? 200, {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Cache-Control': 'no-cache',
+        });
+        response.write(JSON.stringify(parsedRes.body ?? {value: null}));
+        response.end();
       });
-      response.write(
-        JSON.stringify({
-          value: {},
-        }),
-      );
-      return response.end();
+      return;
     }
 
     throw new Error(
@@ -226,24 +297,24 @@ export class WebSocketServer {
 
     session = this.#sessions.get(requestSessionId ?? '');
     if (session !== undefined) {
-      // BrowserInstance is created for each new WS connection, even for the
-      // same SessionId. This is because WPT uses a single session for all the
-      // tests, but cleans up tests using WebDriver Classic commands, which is
-      // not implemented in this Mapper runner.
-      // TODO: connect to an existing BrowserInstance instead.
       const sessionOptions = session.sessionOptions;
-      session.browserInstancePromise = this.#closeBrowserInstanceIfLaunched(
-        session,
-      )
-        .then(
-          async () =>
-            await this.#launchBrowserInstance(connection, sessionOptions),
-        )
-        .catch((e) => {
+      if (session.browserInstancePromise === undefined) {
+        session.browserInstancePromise = this.#launchBrowserInstance(
+          connection,
+          sessionOptions,
+        ).catch((e) => {
           debugInfo('Error while creating session', e);
           connection.close(500, 'cannot create browser instance');
           throw e;
         });
+      } else {
+        void session.browserInstancePromise.then((browserInstance) => {
+          browserInstance.bidiSession().on('message', (message) => {
+            this.#sendClientMessageString(message, connection);
+          });
+          return null;
+        });
+      }
     }
 
     connection.on('message', async (message) => {
@@ -313,6 +384,7 @@ export class WebSocketServer {
 
           const sessionId = uuidv4();
           session = {
+            mutex: new Mutex(),
             sessionId,
             browserInstancePromise: Promise.resolve(browserInstance),
             sessionOptions,
@@ -444,7 +516,7 @@ export class WebSocketServer {
   }
 
   async #launchBrowserInstance(
-    connection: websocket.connection,
+    connection: websocket.connection | undefined,
     sessionOptions: SessionOptions,
     passSessionNewThrough = false,
   ): Promise<BrowserInstance> {
@@ -462,7 +534,7 @@ export class WebSocketServer {
       if (jsonMessage['id'] === id) {
         debugInfo('Receiving session.new response from mapper', message);
         sessionCreated.resolve();
-        if (passSessionNewThrough) {
+        if (passSessionNewThrough && connection) {
           this.#sendClientMessageString(message, connection);
         }
       }
@@ -476,9 +548,11 @@ export class WebSocketServer {
     await sessionCreated;
     browserInstance.bidiSession().off('message', sessionResponseListener);
 
-    // Forward messages from BiDi Mapper to the client unconditionally.
+    // Forward messages from BiDi Mapper to the client unconditionally if connected.
     browserInstance.bidiSession().on('message', (message) => {
-      this.#sendClientMessageString(message, connection);
+      if (connection) {
+        this.#sendClientMessageString(message, connection);
+      }
     });
 
     debugInfo('Browser is launched!');

--- a/src/bidiTab/Transport.test.ts
+++ b/src/bidiTab/Transport.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 Google LLC.
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, beforeEach, afterEach} from 'node:test';
+import {assert} from 'chai';
+
+import type {ClassicRequest} from '../bidiMapper/BidiMapper.js';
+
+import {WindowClassicTransport} from './Transport.js';
+
+describe('WindowClassicTransport', () => {
+  let transport: WindowClassicTransport;
+  let sentResponses: string[];
+
+  beforeEach(() => {
+    sentResponses = [];
+    (globalThis as any).window = {
+      sendClassicResponse: (res: string) => sentResponses.push(res),
+    };
+    transport = new WindowClassicTransport();
+  });
+
+  afterEach(() => {
+    transport.close();
+    delete (globalThis as any).window;
+  });
+
+  it('receives messages from window.onClassicMessage and dispatches them', () => {
+    let received: ClassicRequest | null = null;
+    transport.setOnMessage((req) => {
+      received = req;
+    });
+
+    (globalThis as any).window.onClassicMessage(
+      JSON.stringify({
+        id: '1',
+        method: 'POST',
+        path: '/execute/sync',
+        body: {},
+      }),
+    );
+
+    const req = received as unknown as ClassicRequest | null;
+    assert.isNotNull(req);
+    assert.equal(req?.id, '1');
+    assert.equal(req?.method, 'POST');
+    assert.equal(req?.path, '/execute/sync');
+  });
+
+  it('sends responses to window.sendClassicResponse', () => {
+    transport.sendMessage({
+      id: '1',
+      status: 200,
+      body: {value: 'result'},
+    });
+    assert.equal(sentResponses.length, 1);
+    const parsed = JSON.parse(sentResponses[0]!);
+    assert.equal(parsed.id, '1');
+    assert.equal(parsed.status, 200);
+    assert.equal(parsed.body.value, 'result');
+  });
+});

--- a/src/bidiTab/Transport.ts
+++ b/src/bidiTab/Transport.ts
@@ -14,7 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License. *
  */
-import type {BidiTransport} from '../bidiMapper/BidiMapper.js';
+import type {
+  BidiTransport,
+  ClassicRequest,
+  ClassicResponse,
+  ClassicTransport,
+} from '../bidiMapper/BidiMapper.js';
 import type {GoogChannel} from '../protocol/chromium-bidi.js';
 import {
   type ChromiumBidi,
@@ -198,5 +203,46 @@ export class WindowCdpTransport implements Transport {
   close() {
     this.#onMessage = null;
     window.cdp.onmessage = null;
+  }
+}
+
+export class WindowClassicTransport implements ClassicTransport {
+  #onMessage: ((request: ClassicRequest) => void) | null = null;
+
+  constructor() {
+    (window as any).onClassicMessage = (message: string) => {
+      try {
+        const request = JSON.parse(message) as ClassicRequest;
+        this.#onMessage?.call(null, request);
+      } catch (e: unknown) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        (window as any).sendClassicResponse?.(
+          JSON.stringify({
+            id: '',
+            status: 500,
+            body: {
+              value: {
+                error: 'unknown error',
+                message: err.message,
+                stacktrace: err.stack ?? '',
+              },
+            },
+          }),
+        );
+      }
+    };
+  }
+
+  setOnMessage(onMessage: (request: ClassicRequest) => void) {
+    this.#onMessage = onMessage;
+  }
+
+  sendMessage(response: ClassicResponse) {
+    (window as any).sendClassicResponse?.(JSON.stringify(response));
+  }
+
+  close() {
+    this.#onMessage = null;
+    (window as any).onClassicMessage = null;
   }
 }

--- a/src/bidiTab/bidiTab.ts
+++ b/src/bidiTab/bidiTab.ts
@@ -23,7 +23,11 @@ import {LogType} from '../utils/log.js';
 
 import {BidiParser} from './BidiParser.js';
 import {generatePage, log} from './mapperTabPage.js';
-import {WindowBidiTransport, WindowCdpTransport} from './Transport.js';
+import {
+  WindowBidiTransport,
+  WindowCdpTransport,
+  WindowClassicTransport,
+} from './Transport.js';
 
 declare global {
   interface Window {
@@ -41,9 +45,11 @@ declare global {
 
     // `window.sendBidiResponse` is exposed by `Runtime.addBinding` from the server side.
     sendBidiResponse: (response: string) => void;
+    sendClassicResponse?: (response: string) => void;
 
     // `window.onBidiMessage` is called via `Runtime.evaluate` from the server side.
     onBidiMessage: ((message: string) => void) | null;
+    onClassicMessage?: ((message: string) => void) | null;
 
     // Set from the server side if verbose logging is required.
     sendDebugMessage?: ((message: string) => void) | null;
@@ -57,6 +63,7 @@ declare global {
 
 generatePage();
 const mapperTabToServerTransport = new WindowBidiTransport();
+const classicTransport = new WindowClassicTransport();
 const cdpTransport = new WindowCdpTransport();
 /**
  * A CdpTransport implementation that uses the window.cdp bindings
@@ -83,6 +90,7 @@ async function runMapperInstance(selfTargetId: string) {
     selfTargetId,
     new BidiParser(),
     log,
+    classicTransport,
   );
 
   log(LogType.debugInfo)?.('Mapper instance has been launched');

--- a/tests/classic/__init__.py
+++ b/tests/classic/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/classic/conftest.py
+++ b/tests/classic/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from classic_helpers import end_classic_session, start_classic_session
+
+
+@pytest.fixture
+def classic_session():
+    session_id, ws_url = start_classic_session()
+    yield session_id, ws_url
+    end_classic_session(session_id)

--- a/tests/classic/test_combined_classic_and_bidi.py
+++ b/tests/classic/test_combined_classic_and_bidi.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import websockets
+from classic_helpers import http_post
+from test_helpers import execute_command
+
+
+@pytest.mark.asyncio
+async def test_interleaved_classic_and_bidi(classic_session):
+    session_id, ws_url = classic_session
+    async with websockets.connect(ws_url) as ws:
+        # 1. Get browsing contexts via BiDi
+        tree_res = await execute_command(
+            ws, {"method": "browsingContext.getTree", "params": {}}
+        )
+        contexts = tree_res["contexts"]
+        assert len(contexts) > 0
+        context_id = contexts[0]["context"]
+
+        # 2. Set a JavaScript variable using BiDi script.evaluate
+        eval_res = await execute_command(
+            ws,
+            {
+                "method": "script.evaluate",
+                "params": {
+                    "expression": "window.sharedVar = 'set_by_bidi'",
+                    "target": {"context": context_id},
+                    "awaitPromise": False,
+                },
+            },
+        )
+        assert "result" in eval_res
+        assert eval_res["result"]["value"] == "set_by_bidi"
+
+        # 3. Read the variable via WebDriver Classic HTTP command
+        classic_res = http_post(
+            f"/session/{session_id}/execute/sync",
+            {
+                "script": "return window.sharedVar + ' & read_by_classic';",
+                "args": [],
+            },
+        )
+        assert classic_res["value"] == "set_by_bidi & read_by_classic"
+
+        # 4. Modify a variable via WebDriver Classic HTTP command
+        http_post(
+            f"/session/{session_id}/execute/sync",
+            {"script": "window.classicCounter = 100;", "args": []},
+        )
+
+        # 5. Read back the modification using BiDi script.evaluate over WebSocket
+        eval_res2 = await execute_command(
+            ws,
+            {
+                "method": "script.evaluate",
+                "params": {
+                    "expression": "window.classicCounter + 50",
+                    "target": {"context": context_id},
+                    "awaitPromise": False,
+                },
+            },
+        )
+        assert "result" in eval_res2
+        assert eval_res2["result"]["value"] == 150

--- a/tests/classic/test_execute_script.py
+++ b/tests/classic/test_execute_script.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+from classic_helpers import http_post
+
+
+@pytest.mark.asyncio
+async def test_classic_execute_script_basic(classic_session):
+    session_id, _ = classic_session
+    res = http_post(
+        f"/session/{session_id}/execute/sync",
+        {"script": "return 10 + 25;", "args": []},
+    )
+    assert "value" in res
+    assert res["value"] == 35
+
+
+@pytest.mark.asyncio
+async def test_classic_execute_script_with_args(classic_session):
+    session_id, _ = classic_session
+    res = http_post(
+        f"/session/{session_id}/execute/sync",
+        {
+            "script": "return arguments[0] + ' ' + arguments[1].name;",
+            "args": ["Hello", {"name": "WebDriver"}],
+        },
+    )
+    assert "value" in res
+    assert res["value"] == "Hello WebDriver"
+
+
+@pytest.mark.asyncio
+async def test_classic_execute_script_exception(classic_session):
+    session_id, _ = classic_session
+    res = http_post(
+        f"/session/{session_id}/execute/sync",
+        {"script": "throw new Error('Test Classic Error');", "args": []},
+    )
+    assert "value" in res
+    assert isinstance(res["value"], dict)
+    assert res["value"].get("error") == "javascript error"
+    assert "Test Classic Error" in res["value"].get("message", "")
+
+
+@pytest.mark.asyncio
+async def test_classic_execute_script_sequential(classic_session):
+    session_id, _ = classic_session
+    http_post(
+        f"/session/{session_id}/execute/sync",
+        {"script": "window.order = []; return true;", "args": []},
+    )
+
+    def run_first_script():
+        return http_post(
+            f"/session/{session_id}/execute/sync",
+            {
+                "script": "const start = Date.now(); while(Date.now() - start < 100) {}; window.order.push(1); return window.order;",
+                "args": [],
+            },
+        )
+
+    def run_second_script():
+        return http_post(
+            f"/session/{session_id}/execute/sync",
+            {"script": "window.order.push(2); return window.order;", "args": []},
+        )
+
+    t1 = asyncio.to_thread(run_first_script)
+    t2 = asyncio.to_thread(run_second_script)
+    await asyncio.gather(t1, t2)
+
+    res = http_post(
+        f"/session/{session_id}/execute/sync",
+        {"script": "return window.order;", "args": []},
+    )
+    assert res["value"] == [1, 2]

--- a/tests/classic_helpers.py
+++ b/tests/classic_helpers.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC.
+# Copyright (c) Microsoft Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+
+def get_server_port() -> int:
+    return int(os.getenv("PORT", 8080))
+
+
+def http_post(path: str, data: dict | None = None) -> dict:
+    url = f"http://localhost:{get_server_port()}{path}"
+    payload = json.dumps(data or {}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json;charset=utf-8"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8")
+        try:
+            return json.loads(body)
+        except Exception:
+            return {"error": str(e), "status": e.code, "body": body}
+
+
+def http_delete(path: str) -> dict:
+    url = f"http://localhost:{get_server_port()}{path}"
+    req = urllib.request.Request(
+        url,
+        headers={"Content-Type": "application/json;charset=utf-8"},
+        method="DELETE",
+    )
+    with urllib.request.urlopen(req) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def start_classic_session() -> tuple[str, str]:
+    default_capabilities: dict[str, any] = {
+        "goog:chromeOptions": {
+            "args": [
+                "--disable-background-networking",
+                "--disable-background-timer-throttling",
+                "--disable-backgrounding-occluded-windows",
+            ]
+        }
+    }
+    maybe_browser_bin = os.getenv("BROWSER_BIN")
+    if maybe_browser_bin:
+        default_capabilities["goog:chromeOptions"]["binary"] = maybe_browser_bin
+
+    headless = os.getenv("HEADLESS", "true")
+    if headless != "false":
+        if headless == "old":
+            default_capabilities["goog:chromeOptions"]["args"].extend(
+                ["--hide-scrollbars", "--mute-audio"]
+            )
+        else:
+            default_capabilities["goog:chromeOptions"]["args"].append("--headless=new")
+
+    res = http_post("/session", {"capabilities": {"alwaysMatch": default_capabilities}})
+    val = res["value"]
+    return val["sessionId"], val["capabilities"]["webSocketUrl"]
+
+
+def end_classic_session(session_id: str):
+    try:
+        http_delete(f"/session/{session_id}")
+    except Exception:
+        pass


### PR DESCRIPTION
Experiment on implementing WebDriver Classic in Mapper. 

This can allow for consolidating all the logic in 1 place instead of spreading it between ChromeDriver and Mapper.