### PR TITLE
fix: validate manual proxy endpoints

### DIFF
--- a/src/bidiMapper/modules/browser/BrowserProcessor.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessor.ts
@@ -336,6 +336,34 @@ export class BrowserProcessor {
   }
 }
 
+function validateProxyEndpoint(
+  endpoint: unknown,
+  property: 'httpProxy' | 'sslProxy' | 'socksProxy',
+): string {
+  if (
+    typeof endpoint !== 'string' ||
+    endpoint.length === 0 ||
+    endpoint.endsWith(':') ||
+    /[\s/?#\\]/u.test(endpoint)
+  ) {
+    throw new InvalidArgumentException(
+      `'${property}' must be a valid host and optional port`,
+    );
+  }
+
+  try {
+    // The synthetic scheme provides URL Standard host and port parsing. Keep
+    // the caller's endpoint unchanged when constructing the CDP proxy string.
+    new URL(`http://${endpoint}`);
+  } catch {
+    throw new InvalidArgumentException(
+      `'${property}' must be a valid host and optional port`,
+    );
+  }
+
+  return endpoint;
+}
+
 /**
  * Proxy config parse implementation:
  * https://source.chromium.org/chromium/chromium/src/+/main:net/proxy_resolution/proxy_config.h;drc=743a82d08e59d803c94ee1b8564b8b11dd7b462f;l=107
@@ -370,14 +398,16 @@ export function getProxyStr(
 
     // HTTP Proxy
     if (proxyConfig.httpProxy !== undefined) {
-      // servers.push(proxyConfig.httpProxy);
-      servers.push(`http=${proxyConfig.httpProxy}`);
+      servers.push(
+        `http=${validateProxyEndpoint(proxyConfig.httpProxy, 'httpProxy')}`,
+      );
     }
 
     // SSL Proxy (uses 'https' scheme)
     if (proxyConfig.sslProxy !== undefined) {
-      // servers.push(proxyConfig.sslProxy);
-      servers.push(`https=${proxyConfig.sslProxy}`);
+      servers.push(
+        `https=${validateProxyEndpoint(proxyConfig.sslProxy, 'sslProxy')}`,
+      );
     }
 
     // SOCKS Proxy
@@ -404,7 +434,7 @@ export function getProxyStr(
         );
       }
       servers.push(
-        `socks=socks${proxyConfig.socksVersion}://${proxyConfig.socksProxy}`,
+        `socks=socks${proxyConfig.socksVersion}://${validateProxyEndpoint(proxyConfig.socksProxy, 'socksProxy')}`,
       );
     }
 

--- a/src/bidiMapper/modules/browser/BrowserProcessot.test.ts
+++ b/src/bidiMapper/modules/browser/BrowserProcessot.test.ts
@@ -27,6 +27,32 @@ import {
 
 import {getProxyStr} from './BrowserProcessor.js';
 
+const invalidProxyEndpoints = [
+  'http://foo',
+  'foo:-1',
+  'foo:bar',
+  'foo:65536',
+  'foo/test',
+  'foo#42',
+  'foo?foo=bar',
+  '2001:db8::1',
+  '',
+  'foo:',
+];
+
+type ProxyEndpointKey = 'httpProxy' | 'sslProxy' | 'socksProxy';
+
+function manualProxyConfig(
+  key: ProxyEndpointKey,
+  value: unknown,
+): Session.ProxyConfiguration {
+  return {
+    proxyType: 'manual',
+    [key]: value,
+    ...(key === 'socksProxy' ? {socksVersion: 5} : {}),
+  } as Session.ProxyConfiguration;
+}
+
 describe('BrowserProcessor:getProxyStr', () => {
   it('should return undefined for "direct" proxyType', () => {
     const proxyConfig: Session.ProxyConfiguration = {proxyType: 'direct'};
@@ -77,6 +103,49 @@ describe('BrowserProcessor:getProxyStr', () => {
         sslProxy: 'secure.proxy:443',
       };
       assert.equal(getProxyStr(proxyConfig), 'https=secure.proxy:443');
+    });
+
+    describe('proxy endpoint validation', () => {
+      for (const [endpoint, expected] of [
+        ['proxy.example', 'http=proxy.example'],
+        ['proxy.example:0', 'http=proxy.example:0'],
+        ['proxy.example:65535', 'http=proxy.example:65535'],
+        ['127.0.0.1:8080', 'http=127.0.0.1:8080'],
+        [
+          'user:password@proxy.example:8080',
+          'http=user:password@proxy.example:8080',
+        ],
+        ['[2001:db8::1]:8080', 'http=[2001:db8::1]:8080'],
+      ]) {
+        it(`should preserve valid endpoint ${JSON.stringify(endpoint)}`, () => {
+          assert.equal(
+            getProxyStr(manualProxyConfig('httpProxy', endpoint)),
+            expected,
+          );
+        });
+      }
+
+      for (const key of ['httpProxy', 'sslProxy', 'socksProxy'] as const) {
+        describe(key, () => {
+          for (const endpoint of invalidProxyEndpoints) {
+            it(`should reject ${JSON.stringify(endpoint)}`, () => {
+              assert.throws(
+                () => getProxyStr(manualProxyConfig(key, endpoint)),
+                InvalidArgumentException,
+              );
+            });
+          }
+        });
+      }
+
+      for (const value of [42, true, [], {}]) {
+        it(`should reject non-string socksProxy ${JSON.stringify(value)}`, () => {
+          assert.throws(
+            () => getProxyStr(manualProxyConfig('socksProxy', value)),
+            InvalidArgumentException,
+          );
+        });
+      }
     });
 
     describe('socksProxy', () => {


### PR DESCRIPTION
## Motivation

Chromium needs WebDriver BiDi `browser.createUserContext` to reject malformed
manual proxy endpoints with `invalid argument`. Today those values pass the
generated string schema and fail later during Chromium context creation as an
`unknown error`.

## Changes

- validate HTTP, SSL, and SOCKS endpoints as a host with an optional valid port;
- reject schemes, paths, queries, fragments, whitespace, malformed IPv6, and
  out-of-range ports;
- preserve accepted endpoint strings without URL normalization; and
- add positive and negative unit coverage for all three proxy fields.

Generated protocol files are unchanged. The Chromium mapper roll and WPT
expectation cleanup remain separate.

## Validation

- 578 chromium-bidi unit tests passed.
- Full build and static checks passed with only pre-existing lint warnings.
- The invalid-proxy WPT produced 134 passing assertions on both host and
  Android; Chromium currently records those as unexpected passes because its
  metadata is stale.
- The valid manual-proxy matrix passed, with existing unsupported
  `autodetect` behavior unchanged.

Chromium issue: https://issues.chromium.org/issues/422822346