### PR TITLE
fix: align continued-request cookie metadata

### DIFF
--- a/src/bidiMapper/modules/network/NetworkModuleMocks.test.ts
+++ b/src/bidiMapper/modules/network/NetworkModuleMocks.test.ts
@@ -193,10 +193,12 @@ export class MockCdpNetworkEvents {
     });
   }
 
-  requestWillBeSentExtraInfo() {
+  requestWillBeSentExtraInfo(
+    associatedCookies: Protocol.Network.AssociatedCookie[] = [],
+  ) {
     this.cdpClient.emit('Network.requestWillBeSentExtraInfo', {
       requestId: this.requestId,
-      associatedCookies: [],
+      associatedCookies,
       headers: {
         Accept: '*/*',
         'Accept-Encoding': 'gzip, deflate, br, zstd',

--- a/src/bidiMapper/modules/network/NetworkRequest.ts
+++ b/src/bidiMapper/modules/network/NetworkRequest.ts
@@ -43,6 +43,7 @@ import {
   cdpFetchHeadersFromBidiNetworkHeaders,
   cdpToBiDiCookie,
   computeHeadersSize,
+  deserializeByteValue,
   getTiming,
   networkHeaderFromCookieHeaders,
   stringToBase64,
@@ -92,7 +93,6 @@ export class NetworkRequest {
     url?: string;
     method?: string;
     headers?: Network.Header[];
-    cookies?: Network.CookieHeader[];
     bodySize?: number;
   };
 
@@ -241,15 +241,35 @@ export class NetworkRequest {
   }
 
   get #cookies() {
-    let cookies: Network.Cookie[] = [];
-    if (this.#request.extraInfo) {
-      cookies = this.#request.extraInfo.associatedCookies
-        .filter(({blockedReasons}) => {
-          return !Array.isArray(blockedReasons) || blockedReasons.length === 0;
-        })
-        .map(({cookie}) => cdpToBiDiCookie(cookie));
+    const associatedCookies =
+      this.#request.extraInfo?.associatedCookies.filter(({blockedReasons}) => {
+        return !Array.isArray(blockedReasons) || blockedReasons.length === 0;
+      }) ?? [];
+    const overrideHeaders = this.#requestOverrides?.headers;
+    if (overrideHeaders === undefined) {
+      return associatedCookies.map(({cookie}) => cdpToBiDiCookie(cookie));
     }
-    return cookies;
+
+    const cookieNames = new Set<string>();
+    for (const header of overrideHeaders) {
+      if (
+        header.name.localeCompare('cookie', undefined, {
+          sensitivity: 'base',
+        }) !== 0
+      ) {
+        continue;
+      }
+      for (const cookie of deserializeByteValue(header.value).split(';')) {
+        const separatorIndex = cookie.indexOf('=');
+        if (separatorIndex !== -1) {
+          cookieNames.add(cookie.slice(0, separatorIndex).trim());
+        }
+      }
+    }
+
+    return associatedCookies
+      .filter(({cookie}) => cookieNames.has(cookie.name))
+      .map(({cookie}) => cdpToBiDiCookie(cookie));
   }
 
   #getBodySizeFromHeaders(
@@ -739,8 +759,7 @@ export class NetworkRequest {
     this.#requestOverrides = {
       url: overrides.url,
       method: overrides.method,
-      headers: overrides.headers,
-      cookies: overrides.cookies,
+      headers: overrideHeaders,
       bodySize: getSizeFromBiDiBytesValue(overrides.body),
     };
   }
@@ -1187,13 +1206,13 @@ export class NetworkRequest {
     if (!headers && !cookies) {
       return undefined;
     }
-    let overrideHeaders: Network.Header[] | undefined = headers;
+    let overrideHeaders = headers === undefined ? undefined : [...headers];
     const cookieHeader = networkHeaderFromCookieHeaders(cookies);
     if (cookieHeader && !overrideHeaders) {
-      overrideHeaders = this.#requestHeaders;
+      overrideHeaders = [...this.#requestHeaders];
     }
     if (cookieHeader && overrideHeaders) {
-      overrideHeaders.filter(
+      overrideHeaders = overrideHeaders.filter(
         (header) =>
           header.name.localeCompare('cookie', undefined, {
             sensitivity: 'base',

--- a/src/bidiMapper/modules/network/NetworkStorage.test.ts
+++ b/src/bidiMapper/modules/network/NetworkStorage.test.ts
@@ -17,6 +17,7 @@
  */
 import {describe, it, beforeEach} from 'node:test';
 import {assert} from 'chai';
+import type {Protocol} from 'devtools-protocol';
 
 import type {CdpClient} from '../../../cdp/CdpClient.js';
 import {ChromiumBidi, Network} from '../../../protocol/protocol.js';
@@ -44,6 +45,29 @@ function logger(...args: any[]) {
     };
   }
   return;
+}
+
+function createAssociatedCookie(
+  name: string,
+  value: string,
+): Protocol.Network.AssociatedCookie {
+  return {
+    cookie: {
+      name,
+      value,
+      domain: '.google.com',
+      path: '/',
+      expires: -1,
+      size: name.length + value.length + 1,
+      httpOnly: false,
+      secure: false,
+      session: true,
+      priority: 'Medium',
+      sourceScheme: 'NonSecure',
+      sourcePort: 80,
+    },
+    blockedReasons: [],
+  };
 }
 
 describe('NetworkStorage', () => {
@@ -484,6 +508,144 @@ describe('NetworkStorage', () => {
   });
 
   describe('overrides', () => {
+    async function continueRequestAndGetResponse(
+      overrides: Omit<Network.ContinueRequestParameters, 'request'>,
+      associatedCookies: Protocol.Network.AssociatedCookie[] = [],
+    ) {
+      const request = new MockCdpNetworkEvents(cdpClient);
+      networkStorage.addIntercept({
+        urlPatterns: NetworkProcessor.parseUrlPatterns([
+          {type: 'string', pattern: request.url},
+        ]),
+        phases: [Network.InterceptPhase.BeforeRequestSent],
+      });
+
+      request.requestWillBeSent();
+      request.requestWillBeSentExtraInfo(associatedCookies);
+      request.requestPaused();
+
+      const networkRequest = networkStorage.getRequestById(request.requestId)!;
+      await networkRequest.continueRequest(overrides);
+
+      request.responseReceived();
+      request.responseReceivedExtraInfo();
+      request.loadingFinished();
+
+      const event = await getEvent('network.responseCompleted');
+      assert.exists(event);
+      return event as Network.ResponseCompletedParameters;
+    }
+
+    const storedCookies = [
+      createAssociatedCookie('a', 'from-store-a'),
+      createAssociatedCookie('b', 'from-store-b'),
+    ];
+
+    const cookieOverrideCases: {
+      name: string;
+      overrides: Omit<Network.ContinueRequestParameters, 'request'>;
+      expectedCookies: {name: string; value: string}[];
+    }[] = [
+      {
+        name: 'keeps associated cookies without header overrides',
+        overrides: {method: 'POST'},
+        expectedCookies: [
+          {name: 'a', value: 'from-store-a'},
+          {name: 'b', value: 'from-store-b'},
+        ],
+      },
+      {
+        name: 'removes associated cookies for an empty cookie override',
+        overrides: {cookies: []},
+        expectedCookies: [],
+      },
+      {
+        name: 'keeps metadata only for associated cookie names that remain',
+        overrides: {
+          cookies: [
+            {name: 'b', value: {type: 'string', value: 'from-command-b'}},
+            {name: 'c', value: {type: 'string', value: 'from-command-c'}},
+          ],
+        },
+        expectedCookies: [{name: 'b', value: 'from-store-b'}],
+      },
+      {
+        name: 'does not invent metadata for override-only cookies',
+        overrides: {
+          cookies: [
+            {name: 'c', value: {type: 'string', value: 'from-command-c'}},
+          ],
+        },
+        expectedCookies: [],
+      },
+      {
+        name: 'uses explicit Cookie headers to select associated cookies',
+        overrides: {
+          headers: [
+            {
+              name: 'Cookie',
+              value: {type: 'string', value: 'b=from-header;c=from-header'},
+            },
+          ],
+        },
+        expectedCookies: [{name: 'b', value: 'from-store-b'}],
+      },
+      {
+        name: 'removes associated cookies with an empty header override',
+        overrides: {headers: []},
+        expectedCookies: [],
+      },
+    ];
+
+    for (const {name, overrides, expectedCookies} of cookieOverrideCases) {
+      it(name, async () => {
+        const event = await continueRequestAndGetResponse(
+          overrides,
+          storedCookies,
+        );
+
+        assert.deepEqual(
+          event.request.cookies.map((cookie) => ({
+            name: cookie.name,
+            value: cookie.value.value,
+          })),
+          expectedCookies,
+        );
+      });
+    }
+
+    it('does not mutate caller-owned headers when overriding cookies', async () => {
+      const headers: Network.Header[] = [
+        {
+          name: 'Cookie',
+          value: {type: 'string', value: 'a=from-header'},
+        },
+        {
+          name: 'X-Test',
+          value: {type: 'string', value: 'original'},
+        },
+      ];
+      const originalHeaders = structuredClone(headers);
+
+      const event = await continueRequestAndGetResponse({
+        headers,
+        cookies: [{name: 'b', value: {type: 'string', value: 'from-command'}}],
+      });
+
+      assert.deepEqual(headers, originalHeaders);
+      assert.deepEqual(
+        event.request.headers.filter(
+          (header) => header.name.toLowerCase() === 'cookie',
+        ),
+        [
+          {
+            name: 'Cookie',
+            value: {type: 'string', value: 'b=from-command'},
+          },
+        ],
+      );
+    });
+
     it('should show correct URL for response', async () => {
       const request = new MockCdpNetworkEvents(cdpClient);
       const overrideUrl = `${request.url}/override`;


### PR DESCRIPTION
## Motivation

After `network.continueRequest` removes or replaces request cookies, BiDi
network events can still report Chromium's original associated-cookie list.
The request is overridden correctly, but the event metadata does not describe
the effective request.

## Changes

- keep a copied effective header list for continued requests;
- retain associated-cookie metadata only for stored cookies still present in
  the effective `Cookie` header;
- avoid inventing store metadata for override-only cookie values; and
- stop mutating caller-owned header arrays.

This is contained in chromium-bidi. Chromium network-stack changes and the
subsequent mapper roll remain separate.

## Validation

- 545 chromium-bidi unit tests passed.
- All 16 focused cookie/header WPT assertions passed.
- All 194 adjacent `continue_request` WPT assertions passed.
- Full build, static checks, changed-file formatting, and diff checks passed;
  lint reported only pre-existing warnings.

Chromium issue: https://issues.chromium.org/issues/510502571